### PR TITLE
[OYPD-155] Adjustments for the featured blog paragraph type, adds templates, js,…

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_featured_blogs/config/install/core.entity_view_display.paragraph.featured_blogs.default.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_featured_blogs/config/install/core.entity_view_display.paragraph.featured_blogs.default.yml
@@ -12,14 +12,15 @@ mode: default
 content:
   field_fblog_posts:
     weight: 1
-    label: above
+    label: hidden
     settings:
-      link: true
+      view_mode: teaser
+      link: false
     third_party_settings: {  }
-    type: entity_reference_label
+    type: entity_reference_entity_view
   field_prgf_headline:
     weight: 0
-    label: above
+    label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }

--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -4115,29 +4115,29 @@ html.js .branch__updates_queue__button {
   content: none;
 }
 
-.paragraph--type--featured-blog-posts .slick-prev {
+.paragraph--type--featured-blogs .slick-prev {
   left: 15px;
 }
-.paragraph--type--featured-blog-posts .slick-next {
+.paragraph--type--featured-blogs .slick-next {
   right: 15px;
 }
-.paragraph--type--featured-blog-posts .slick-arrow {
+.paragraph--type--featured-blogs .slick-arrow {
   top: 55%;
 }
 
 @media (min-width: 0) and (max-width: 30em) {
-  .container .paragraph--type--featured-blog-posts {
+  .container .paragraph--type--featured-blogs {
     padding-left: 15px;
     padding-right: 15px;
   }
 }
 @media (min-width: 0) and (max-width: 30em) {
-  .container .paragraph--type--featured-blog-posts .slick-prev {
+  .container .paragraph--type--featured-blogs .slick-prev {
     left: -17px;
   }
 }
 @media (min-width: 0) and (max-width: 30em) {
-  .container .paragraph--type--featured-blog-posts .slick-next {
+  .container .paragraph--type--featured-blogs .slick-next {
     right: -17px;
   }
 }

--- a/themes/openy_themes/openy_rose/openy_rose.libraries.yml
+++ b/themes/openy_themes/openy_rose/openy_rose.libraries.yml
@@ -44,3 +44,16 @@ featured_slider:
     - slick/slick.theme
     - slick/slick.arrow.down
     - core/drupalSettings
+
+blog_slider:
+  version: VERSION
+  js:
+    scripts/openy_rose_blog_slider.js: {}
+  dependencies:
+    - core/jquery
+    - core/jquery.once
+    - core/drupal
+    - core/drupalSettings
+    - slick/slick
+    - slick/slick.theme
+    - slick/slick.arrow.down

--- a/themes/openy_themes/openy_rose/scripts/openy_rose_blog_slider.js
+++ b/themes/openy_themes/openy_rose/scripts/openy_rose_blog_slider.js
@@ -1,0 +1,32 @@
+(function ($) {
+  "use strict";
+  Drupal.behaviors.openy_rose_blog_slider = {
+    attach: function (context, settings) {
+      function blogResponsive() {
+        if ($(window).width() < 768) {
+          if (!$('.slick-mobile').hasClass('slick-slider')) {
+            $('.slick-mobile').slick({
+              infinite: false,
+              slidesToShow: 1,
+              slidesToScroll: 1,
+              variableWidth: false,
+              centerMode: false,
+              dots: true,
+              adaptiveHeight: false,
+              nextArrow: '<i class="slick-next slick-arrow fa fa-chevron-right"></i>',
+              prevArrow: '<i class="slick-prev slick-arrow fa fa-chevron-left"></i>',
+            });
+          }
+        }
+        else {
+          if ($('.slick-mobile').hasClass('slick-initialized')) {
+            $('.slick-mobile', context).slick('unslick');
+            $('.slick-mobile').css('width', '');
+          }
+        }
+      }
+
+      $(window).on('resize.blogResponsive', blogResponsive).trigger('resize.blogResponsive');
+    }
+  };
+})(jQuery);

--- a/themes/openy_themes/openy_rose/scss/modules/_blog_post.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_blog_post.scss
@@ -324,7 +324,7 @@
   }
 }
 
-.paragraph--type--featured-blog-posts {
+.paragraph--type--featured-blogs {
   .slick-prev {
     left: 15px;
   }
@@ -339,7 +339,7 @@
 }
 
 .container {
-  .paragraph--type--featured-blog-posts {
+  .paragraph--type--featured-blogs {
     @include breakpoint(0 $screen-xs) {
       padding-left: 15px;
       padding-right: 15px;

--- a/themes/openy_themes/openy_rose/templates/field/field--paragraph--field-fblog-posts.html.twig
+++ b/themes/openy_themes/openy_rose/templates/field/field--paragraph--field-fblog-posts.html.twig
@@ -1,0 +1,67 @@
+{#
+/**
+ * @file
+ * Default theme implementation for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ *
+ * @ingroup themeable
+ */
+#}
+
+{% if label_hidden %}
+  {% if multiple %}
+    <div{{ attributes.addClass('wrapper-' ~ field_name|clean_class, 'description', 'slick-mobile') }}>
+      {% for item in items %}
+        <div{{ attributes.addClass(field_name|clean_class).removeClass('wrapper-' ~ field_name|clean_class, 'description', 'slick-mobile') }}>{{ item.content }}</div>
+      {% endfor %}
+    </div>
+  {% else %}
+    {% for item in items %}
+      <div{{ attributes.addClass(field_name|clean_class) }}>{{ item.content }}</div>
+    {% endfor %}
+  {% endif %}
+{% else %}
+  <div{{ attributes.addClass('wrapper-' ~ field_name|clean_class) }}>
+    <div{{ title_attributes.addClass('label-for-' ~ field_name|clean_class) }}>{{ label }}</div>
+    {% if multiple %}
+    <div class="description slick-mobile">
+      {% endif %}
+      {% for item in items %}
+        <div{{ attributes.addClass(field_name|clean_class).removeClass('wrapper-' ~ field_name|clean_class, 'description', 'slick-mobile') }}>{{ item.content }}</div>
+      {% endfor %}
+      {% if multiple %}
+    </div>
+    {% endif %}
+  </div>
+{% endif %}

--- a/themes/openy_themes/openy_rose/templates/paragraph/paragraph--featured-blogs--default.html.twig
+++ b/themes/openy_themes/openy_rose/templates/paragraph/paragraph--featured-blogs--default.html.twig
@@ -1,0 +1,53 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a paragraph.
+ *
+ * Available variables:
+ * - paragraph: Full paragraph entity.
+ *   - id: The paragraph ID.
+ *   - bundle: The type of the paragraph, for example, "image" or "text".
+ *   - authorid: The user ID of the paragraph author.
+ *   - createdtime: Formatted creation date. Preprocess functions can
+ *     reformat it by calling format_date() with the desired parameters on
+ *     $variables['paragraph']->getCreatedTime().
+ * - content: All paragraph items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - paragraphs: The current template type (also known as a "theming hook").
+ *   - paragraphs--type-[type]: The current paragraphs type. For example, if the paragraph is an
+ *     "Image" it would result in "paragraphs--type--image". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - paragraphs--view-mode--[view_mode]: The View Mode of the paragraph; for example, a
+ *     preview would result in: "paragraphs--view-mode--preview", and
+ *     default: "paragraphs--view-mode--default".
+ * - view_mode: View mode; for example, "preview" or "full".
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_paragraph()
+ *
+ * @ingroup themeable
+ */
+#}
+{%
+set classes = [
+  'paragraph',
+  'blog-card',
+  'paragraph--type--' ~ paragraph.bundle|clean_class,
+  view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
+]
+%}
+{{ attach_library('openy_rose/blog_slider') }}
+<div{{ attributes.addClass(classes) }}>
+  <h3 class="h1">
+    {{ content.field_prgf_headline }}
+  </h3>
+  {{ content.field_fblog_posts }}
+</div>


### PR DESCRIPTION
This is for the featured blog post paragraph. I'm not sure how far we can go to test this. The blog post teasers will not look right because that styling comes from the blog content type and that styling is I think out of scope for this issue.

I did verify that the slider works when on mobile.

This is what it will look like without the blog post styling.

![screen shot 2017-01-26 at 3 27 38 pm](https://cloud.githubusercontent.com/assets/1504038/22353297/d073ca96-e3ed-11e6-9676-5f801f529eac.png)


- [ ] Add a page that uses paragraphs, like landing page.
- [ ] Add "featured blog post" paragraph type.
- [ ] Link multiple blog posts (they need to already exist)
- [ ] Verify it looks correct.