### PR TITLE
[OYPD-151] Updating small banner paragraph type, add template, preprocess functi…

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_small_ banner/config/install/core.entity_view_display.media.image.prgf_small_banner.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_small_ banner/config/install/core.entity_view_display.media.image.prgf_small_banner.yml
@@ -1,0 +1,34 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.media.prgf_small_banner
+    - field.field.media.image.field_media_caption
+    - field.field.media.image.field_media_image
+    - field.field.media.image.field_media_in_library
+    - field.field.media.image.field_media_tags
+    - image.style.prgf_small_banner
+    - media_entity.bundle.image
+  module:
+    - image
+id: media.image.prgf_small_banner
+targetEntityType: media
+bundle: image
+mode: prgf_small_banner
+content:
+  field_media_image:
+    weight: 0
+    label: hidden
+    settings:
+      image_style: prgf_small_banner
+      image_link: ''
+    third_party_settings: {  }
+    type: image
+hidden:
+  created: true
+  field_media_caption: true
+  field_media_in_library: true
+  field_media_tags: true
+  name: true
+  thumbnail: true
+  uid: true

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_small_ banner/config/install/core.entity_view_display.paragraph.small_banner.default.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_small_ banner/config/install/core.entity_view_display.paragraph.small_banner.default.yml
@@ -15,7 +15,7 @@ content:
     weight: 2
     label: hidden
     settings:
-      view_mode: default
+      view_mode: color
       link: false
     third_party_settings: {  }
     type: entity_reference_entity_view

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_small_ banner/config/install/core.entity_view_display.paragraph.small_banner.default.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_small_ banner/config/install/core.entity_view_display.paragraph.small_banner.default.yml
@@ -13,25 +13,27 @@ mode: default
 content:
   field_prgf_color:
     weight: 2
-    label: above
+    label: hidden
     settings:
-      link: true
+      view_mode: default
+      link: false
     third_party_settings: {  }
-    type: entity_reference_label
+    type: entity_reference_entity_view
   field_prgf_headline:
     weight: 0
-    label: above
+    label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
     type: string
   field_prgf_image:
     weight: 1
-    label: above
+    label: hidden
     settings:
-      link: true
+      view_mode: prgf_small_banner
+      link: false
     third_party_settings: {  }
-    type: entity_reference_label
+    type: entity_reference_entity_view
 hidden:
   created: true
   uid: true

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_small_ banner/config/install/core.entity_view_display.taxonomy_term.color.color.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_small_ banner/config/install/core.entity_view_display.taxonomy_term.color.color.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.taxonomy_term.color
+    - field.field.taxonomy_term.color.field_color
+    - taxonomy.vocabulary.color
+  module:
+    - jquery_colorpicker
+id: taxonomy_term.color.color
+targetEntityType: taxonomy_term
+bundle: color
+mode: color
+content:
+  field_color:
+    weight: 0
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: jquery_colorpicker_raw_hex_display
+hidden:
+  description: true

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_small_ banner/config/install/core.entity_view_mode.media.prgf_small_banner.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_small_ banner/config/install/core.entity_view_mode.media.prgf_small_banner.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media_entity
+id: media.prgf_small_banner
+label: 'Paragraph small banner'
+targetEntityType: media
+cache: true

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_small_ banner/config/install/core.entity_view_mode.taxonomy_term.color.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_small_ banner/config/install/core.entity_view_mode.taxonomy_term.color.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.color
+label: Color
+targetEntityType: taxonomy_term
+cache: true

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_small_ banner/config/install/image.style.prgf_small_banner.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_small_ banner/config/install/image.style.prgf_small_banner.yml
@@ -1,0 +1,13 @@
+langcode: en
+status: true
+dependencies: {  }
+name: prgf_small_banner
+label: 'Paragraph small banner'
+effects:
+  df827bff-9135-41a3-ba9e-2559ceadd523:
+    uuid: df827bff-9135-41a3-ba9e-2559ceadd523
+    id: image_scale_and_crop
+    weight: 1
+    data:
+      width: 960
+      height: 854

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_small_ banner/openy_prgf_small_banner.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_small_ banner/openy_prgf_small_banner.info.yml
@@ -6,9 +6,11 @@ dependencies:
   - entity_browser
   - field
   - image
+  - jquery_colorpicker
   - media_entity
   - openy_media_image
   - openy_node
   - openy_prgf
   - paragraphs
+  - taxonomy
 version: 8.x-1.0

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_small_ banner/openy_prgf_small_banner.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_small_ banner/openy_prgf_small_banner.info.yml
@@ -5,6 +5,8 @@ core: 8.x
 dependencies:
   - entity_browser
   - field
+  - image
+  - media_entity
   - openy_media_image
   - openy_node
   - openy_prgf

--- a/themes/openy_themes/openy_rose/openy_rose.theme
+++ b/themes/openy_themes/openy_rose/openy_rose.theme
@@ -7,6 +7,7 @@
 
 use Drupal\Core\Render\Element;
 use Drupal\Core\Render\Element\RenderElement;
+use Drupal\taxonomy\Entity\Term;
 
 /**
  * Implements hook_preprocess_node().
@@ -26,6 +27,19 @@ function openy_rose_preprocess_paragraph(&$variables) {
     $function = __FUNCTION__ . '_' . $variables['paragraph']->bundle();
     $function($variables);
   }
+}
+
+/**
+ * Implements a custom paragraph preprocess function, defined by
+ * openy_rose_preprocess_paragraph().
+ */
+function openy_rose_preprocess_paragraph_small_banner(array &$variables) {
+  // Get the referenced term id.
+  $term_id = $variables['paragraph']->get('field_prgf_color')->getValue()[0]['target_id'];
+  // Get the actual color value from the taxonomy term.
+  $color_value = \Drupal\taxonomy\Entity\Term::load($term_id)->get('field_color')->getValue()[0]['value'];
+  // Pass the color value to the template for use as a background color.
+  $variables['color'] = $color_value;
 }
 
 /**

--- a/themes/openy_themes/openy_rose/openy_rose.theme
+++ b/themes/openy_themes/openy_rose/openy_rose.theme
@@ -7,7 +7,6 @@
 
 use Drupal\Core\Render\Element;
 use Drupal\Core\Render\Element\RenderElement;
-use Drupal\taxonomy\Entity\Term;
 
 /**
  * Implements hook_preprocess_node().
@@ -27,19 +26,6 @@ function openy_rose_preprocess_paragraph(&$variables) {
     $function = __FUNCTION__ . '_' . $variables['paragraph']->bundle();
     $function($variables);
   }
-}
-
-/**
- * Implements a custom paragraph preprocess function, defined by
- * openy_rose_preprocess_paragraph().
- */
-function openy_rose_preprocess_paragraph_small_banner(array &$variables) {
-  // Get the referenced term id.
-  $term_id = $variables['paragraph']->get('field_prgf_color')->getValue()[0]['target_id'];
-  // Get the actual color value from the taxonomy term.
-  $color_value = \Drupal\taxonomy\Entity\Term::load($term_id)->get('field_color')->getValue()[0]['value'];
-  // Pass the color value to the template for use as a background color.
-  $variables['color'] = $color_value;
 }
 
 /**

--- a/themes/openy_themes/openy_rose/templates/field/field--paragraph--field-prgf-color--small-banner.html.twig
+++ b/themes/openy_themes/openy_rose/templates/field/field--paragraph--field-prgf-color--small-banner.html.twig
@@ -1,0 +1,43 @@
+{#
+/**
+ * @file
+ * Default theme implementation for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ *
+ * @ingroup themeable
+ */
+#}
+{% for item in items %}
+  {{- item.content -}}
+{% endfor %}

--- a/themes/openy_themes/openy_rose/templates/paragraph/paragraph--small-banner.html.twig
+++ b/themes/openy_themes/openy_rose/templates/paragraph/paragraph--small-banner.html.twig
@@ -45,8 +45,7 @@
     'banner--small',
   ]
 %}
-
-<div{{ attributes.addClass(classes).setAttribute('style', 'background-color:#' ~ color) }}>
+<div{{ attributes.addClass(classes) }} style="background-color:# {{- content.field_prgf_color -}}">
   <div class="banner-image">
     <div class="banner-image-wrapper">
       {{ content.field_prgf_image }}

--- a/themes/openy_themes/openy_rose/templates/paragraph/paragraph--small-banner.html.twig
+++ b/themes/openy_themes/openy_rose/templates/paragraph/paragraph--small-banner.html.twig
@@ -1,0 +1,66 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a paragraph.
+ *
+ * Available variables:
+ * - paragraph: Full paragraph entity.
+ *   - id: The paragraph ID.
+ *   - bundle: The type of the paragraph, for example, "image" or "text".
+ *   - authorid: The user ID of the paragraph author.
+ *   - createdtime: Formatted creation date. Preprocess functions can
+ *     reformat it by calling format_date() with the desired parameters on
+ *     $variables['paragraph']->getCreatedTime().
+ * - content: All paragraph items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - paragraphs: The current template type (also known as a "theming hook").
+ *   - paragraphs--type-[type]: The current paragraphs type. For example, if the paragraph is an
+ *     "Image" it would result in "paragraphs--type--image". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - paragraphs--view-mode--[view_mode]: The View Mode of the paragraph; for example, a
+ *     preview would result in: "paragraphs--view-mode--preview", and
+ *     default: "paragraphs--view-mode--default".
+ * - view_mode: View mode; for example, "preview" or "full".
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_paragraph()
+ *
+ * @ingroup themeable
+ */
+#}
+{%
+  set classes = [
+    'paragraph',
+    'paragraph--type--' ~ paragraph.bundle|clean_class,
+    view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
+    'banner',
+    'banner--small',
+  ]
+%}
+
+<div{{ attributes.addClass(classes).setAttribute('style', 'background-color:#' ~ color) }}>
+  <div class="banner-image">
+    <div class="banner-image-wrapper">
+      {{ content.field_prgf_image }}
+    </div>
+  </div>
+  <div class="container">
+    <div class="row">
+      <div class="col-sm-12 col-md-8">
+        <div class="banner-cta-section">
+          <h3 class="banner-title">
+            {{ content.field_prgf_headline }}
+          </h3>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/themes/openy_themes/openy_rose/templates/taxonomy/taxonomy-term--color.html.twig
+++ b/themes/openy_themes/openy_rose/templates/taxonomy/taxonomy-term--color.html.twig
@@ -1,0 +1,45 @@
+{#
+/**
+ * @file
+ * Theme override to display a taxonomy term.
+ *
+ * Available variables:
+ * - url: URL of the current term.
+ * - name: Name of the current term.
+ * - content: Items for the content of the term (fields and description).
+ *   Use 'content' to print them all, or print a subset such as
+ *   'content.description'. Use the following code to exclude the
+ *   printing of a given child element:
+ *   @code
+ *   {{ content|without('description') }}
+ *   @endcode
+ * - attributes: HTML attributes for the wrapper.
+ * - page: Flag for the full page state.
+ * - term: The taxonomy term entity, including:
+ *   - id: The ID of the taxonomy term.
+ *   - bundle: Machine name of the current vocabulary.
+ * - view_mode: View mode, e.g. 'full', 'teaser', etc.
+ *
+ * @see template_preprocess_taxonomy_term()
+ */
+#}
+{% if view_mode == 'color' %}
+  {{- content.field_color.0['#markup'] -}}
+{% else %}
+  {%
+    set classes = [
+    'taxonomy-term',
+    'vocabulary-' ~ term.bundle|clean_class,
+    ]
+  %}
+  <div{{ attributes.setAttribute('id', 'taxonomy-term-' ~ term.id).addClass(classes) }}>
+    {{ title_prefix }}
+    {% if not page %}
+      <h2><a href="{{ url }}">{{ name }}</a></h2>
+    {% endif %}
+    {{ title_suffix }}
+    <div class="content">
+      {{ content }}
+    </div>
+  </div>
+{% endif %}


### PR DESCRIPTION
This updates the small banner paragraph.

![screen shot 2017-01-26 at 6 12 25 pm](https://cloud.githubusercontent.com/assets/1504038/22356803/fcbb4fde-e401-11e6-890c-a898efceb82d.png)

- [x] Add a taxonomy term in the "color" vocabulary and choose a color value.
- [x] Add a page that uses paragraphs, like landing page.
- [x] Add a paragraph of type "small banner".
- [x] Add headline, choose color, ad image.
- [x] Verify it looks correct. The left column will be green by default, but have the color chosen from the form.