### PR TITLE
[OYPD-152] Updating grid paragraph type, adds templates, update paragraph displa…

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_grid_content/config/install/core.entity_view_display.field_collection_item.field_grid_columns.default.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_grid_content/config/install/core.entity_view_display.field_collection_item.field_grid_columns.default.yml
@@ -18,27 +18,28 @@ mode: default
 content:
   field_prgf_clm_description:
     weight: 3
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
     type: text_default
   field_prgf_clm_headline:
     weight: 0
-    label: above
+    label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }
     type: string
   field_prgf_clm_icon:
     weight: 1
-    label: above
+    label: hidden
     settings:
-      link: true
+      view_mode: icon
+      link: false
     third_party_settings: {  }
-    type: entity_reference_label
+    type: entity_reference_entity_view
   field_prgf_clm_link:
     weight: 4
-    label: above
+    label: hidden
     settings:
       trim_length: 80
       url_only: false
@@ -49,7 +50,7 @@ content:
     type: link
   field_prgf_column_class:
     weight: 2
-    label: above
+    label: hidden
     settings:
       link_to_entity: false
     third_party_settings: {  }

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_grid_content/config/install/core.entity_view_display.paragraph.grid_content.default.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_grid_content/config/install/core.entity_view_display.paragraph.grid_content.default.yml
@@ -15,16 +15,16 @@ mode: default
 content:
   field_grid_columns:
     weight: 1
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
-    type: field_collection_list
+    type: field_collection_items
   field_prgf_grid_style:
     weight: 0
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
-    type: list_default
+    type: list_key
 hidden:
   created: true
   uid: true

--- a/themes/openy_themes/openy_rose/templates/field/field--field-collection-item--field-grid-columns.html.twig
+++ b/themes/openy_themes/openy_rose/templates/field/field--field-collection-item--field-grid-columns.html.twig
@@ -1,0 +1,43 @@
+{#
+/**
+ * @file
+ * Default theme implementation for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ *
+ * @ingroup themeable
+ */
+#}
+{% for item in items %}
+  {{ item.content }}
+{% endfor %}

--- a/themes/openy_themes/openy_rose/templates/field_collection_item/field-collection-item--field-grid-columns--full.html.twig
+++ b/themes/openy_themes/openy_rose/templates/field_collection_item/field-collection-item--field-grid-columns--full.html.twig
@@ -1,0 +1,46 @@
+{#
+/**
+ * @file
+ * Default theme implementation for field collection items.
+ *
+ * Available variables:
+ * - content: An array of comment items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {% hide(content.field_example) %} to temporarily suppress the printing
+ *   of a given element.
+ * - title: The (sanitized) field collection item label.
+ * - url: Direct url of the current entity if specified.
+ * - page: Flag for the full page state.
+ * - attributes: HTML attributes for the surrounding element.
+ *    Attributes include the 'class' information.
+ * - content_attributes: HTML attributes for the content element.
+ *
+ * @see template_preprocess()
+ * @see template_preprocess_entity()
+ *
+ * @ingroup themeable
+ */
+#}
+{%
+set classes = [
+  'grid-item',
+  'field-collection-item',
+  'field-collection-item--name-' ~ field_collection_item.name|clean_class,
+  'field-collection-item--view-mode-' ~ field_collection_item.view_mode|clean_class,
+]
+%}
+<div{{ attributes.addClass(classes) }}>
+  <div class="content"{{ content_attributes }}>
+    <div class="inner">
+      {% if content.field_prgf_column_class.0 %}
+        <i class="fa fa-{{ content.field_prgf_column_class.0 }}"></i>
+        <h2 {% if content.field_prgf_column_class.0 %}class="with-icon"{% endif %}>{{ content.field_prgf_clm_headline }}</h2>
+      {% else %}
+        {{ content.field_prgf_clm_icon }}
+        <h2 {% if content.field_prgf_clm_icon.0 %}class="with-icon"{% endif %}>{{ content.field_prgf_clm_headline }}</h2>
+      {% endif %}
+      <div class="text">{{ content.field_prgf_clm_description }}</div>
+      <div class="more-link">{{ content.field_prgf_clm_link }}</div>
+    </div>
+  </div>
+</div>

--- a/themes/openy_themes/openy_rose/templates/media/media--image--icon.html.twig
+++ b/themes/openy_themes/openy_rose/templates/media/media--image--icon.html.twig
@@ -1,0 +1,17 @@
+{#
+/**
+ * @file
+ * Default theme implementation to present a media entity.
+ *
+ * Available variables:
+ * - name: Name of the media.
+ * - content: Media content.
+ *
+ * @see template_preprocess_media()
+ *
+ * @ingroup themeable
+ */
+#}
+{% if content %}
+  {{ content }}
+{% endif %}

--- a/themes/openy_themes/openy_rose/templates/paragraph/paragraph--grid-content--default.html.twig
+++ b/themes/openy_themes/openy_rose/templates/paragraph/paragraph--grid-content--default.html.twig
@@ -1,0 +1,62 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a paragraph.
+ *
+ * Available variables:
+ * - paragraph: Full paragraph entity.
+ *   - id: The paragraph ID.
+ *   - bundle: The type of the paragraph, for example, "image" or "text".
+ *   - authorid: The user ID of the paragraph author.
+ *   - createdtime: Formatted creation date. Preprocess functions can
+ *     reformat it by calling format_date() with the desired parameters on
+ *     $variables['paragraph']->getCreatedTime().
+ * - content: All paragraph items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - paragraphs: The current template type (also known as a "theming hook").
+ *   - paragraphs--type-[type]: The current paragraphs type. For example, if the paragraph is an
+ *     "Image" it would result in "paragraphs--type--image". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - paragraphs--view-mode--[view_mode]: The View Mode of the paragraph; for example, a
+ *     preview would result in: "paragraphs--view-mode--preview", and
+ *     default: "paragraphs--view-mode--default".
+ * - view_mode: View mode; for example, "preview" or "full".
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_paragraph()
+ *
+ * @ingroup themeable
+ */
+#}
+{%
+set classes = [
+  'paragraph',
+  'row-eq-height',
+  'paragraph--column-in-a-grid',
+  'paragraph--type--' ~ paragraph.bundle|clean_class,
+  view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
+]
+%}
+{% if content.field_prgf_grid_style.0['#markup'] == '2' %}
+  {% set item_class = 'col-xs-12 col-sm-6 row-eq-height' %}
+{% elseif content.field_prgf_grid_style.0['#markup'] == '3' %}
+  {% set item_class = 'col-xs-12 col-sm-4 row-eq-height' %}
+{% endif %}
+
+<div{{ attributes.addClass(classes) }}>
+  {% for key, item in content.field_grid_columns %}
+    {% if key matches '/^\\d+$/' %}
+    <div class="{{ item_class }}">
+      {{ item }}
+    </div>
+    {% endif %}
+  {% endfor %}
+</div>


### PR DESCRIPTION
Updating grid paragraph type, adds templates, update paragraph display, update field collection display, used existing icon image style

![screen shot 2017-01-27 at 5 25 57 pm](https://cloud.githubusercontent.com/assets/1504038/22390275/10f2d376-e4b8-11e6-8ba1-eb45537b2b7b.png)

![screen shot 2017-01-27 at 5 26 11 pm](https://cloud.githubusercontent.com/assets/1504038/22390276/12ca99ae-e4b8-11e6-8f84-4f8b039fad57.png)

- [x] Add a landing page.
- [x] Add a paragraph of type "grid content" with multiple columns and icons.
- [x] Make sure it displays correctly.