### PR TITLE
[OYPD-172] Fix namespace for custom libraries

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         {
             "type": "package",
             "package": {
-                "name": "library:kenwheeler/slick",
+                "name": "library/kenwheeler/slick",
                 "version": "1.6.0",
                 "type": "drupal-library",
                 "source": {
@@ -37,7 +37,7 @@
         {
             "type": "package",
             "package": {
-                "name": "library:dinbror/blazy",
+                "name": "library/dinbror/blazy",
                 "version": "1.8.2",
                 "type": "drupal-library",
                 "source": {
@@ -50,7 +50,7 @@
         {
             "type": "package",
             "package": {
-                "name": "library:gdsmith/jquery.easing",
+                "name": "library/gdsmith/jquery.easing",
                 "version": "1.4.1",
                 "type": "drupal-library",
                 "source": {
@@ -63,7 +63,7 @@
         {
             "type": "package",
             "package": {
-                "name": "library:enyo/dropzone",
+                "name": "library/enyo/dropzone",
                 "version": "4.3.0",
                 "type": "drupal-library",
                 "source": {
@@ -76,7 +76,7 @@
         {
             "type": "package",
             "package": {
-                "name": "library:jaypan/jquery_colorpicker",
+                "name": "library/jaypan/jquery_colorpicker",
                 "version": "1.0.1",
                 "type": "drupal-library",
                 "source": {
@@ -145,10 +145,10 @@
         "drupal/views_infinite_scroll": "1.3",
         "drupal/slick": "1.0-rc1",
         "drupal/blazy": "1.0-rc1",
-        "library:jaypan/jquery_colorpicker": "^1.0.1",
-        "library:enyo/dropzone": "4.3.0",
-        "library:kenwheeler/slick": "1.6.0",
-        "library:dinbror/blazy": "1.8.2",
-        "library:gdsmith/jquery.easing": "1.4.1"
+        "library/jaypan/jquery_colorpicker": "^1.0.1",
+        "library/enyo/dropzone": "4.3.0",
+        "library/kenwheeler/slick": "1.6.0",
+        "library/dinbror/blazy": "1.8.2",
+        "library/gdsmith/jquery.easing": "1.4.1"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "85f6ce9d8e69439f34919d9fd9c187c4",
-    "content-hash": "f1a2157cdffdfacbc1f73064688477f9",
+    "hash": "38184382cfc4db6c246cadf3bb8f5e37",
+    "content-hash": "d2076480df8fb1a0889f74c2f0bebe14",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -3150,7 +3150,7 @@
             "time": "2014-11-20 16:49:30"
         },
         {
-            "name": "library:dinbror/blazy",
+            "name": "library/dinbror/blazy",
             "version": "1.8.2",
             "source": {
                 "type": "git",
@@ -3160,7 +3160,7 @@
             "type": "drupal-library"
         },
         {
-            "name": "library:enyo/dropzone",
+            "name": "library/enyo/dropzone",
             "version": "4.3.0",
             "source": {
                 "type": "git",
@@ -3170,7 +3170,7 @@
             "type": "drupal-library"
         },
         {
-            "name": "library:gdsmith/jquery.easing",
+            "name": "library/gdsmith/jquery.easing",
             "version": "1.4.1",
             "source": {
                 "type": "git",
@@ -3180,7 +3180,7 @@
             "type": "drupal-library"
         },
         {
-            "name": "library:jaypan/jquery_colorpicker",
+            "name": "library/jaypan/jquery_colorpicker",
             "version": "1.0.1",
             "source": {
                 "type": "git",
@@ -3193,7 +3193,7 @@
             "type": "drupal-library"
         },
         {
-            "name": "library:kenwheeler/slick",
+            "name": "library/kenwheeler/slick",
             "version": "1.6.0",
             "source": {
                 "type": "git",


### PR DESCRIPTION
Packagist https://packagist.org/packages/ymcatwincities/openy is complaining about prohibited characters in custom packages. Replaced ":" with "/".

> [Composer\Repository\InvalidRepositoryException]: No valid composer.json was found in any branch or tag of https://github.com/ymcatwincities/openy, could not load a package from it.
Reading composer.json of ymcatwincities/openy (8.x-1.x)
Importing branch 8.x-1.x (dev-8.x-1.x)
Skipped branch 8.x-1.x, Invalid package information: 
require.library:jaypan/jquery_colorpicker : invalid key, package names must be strings containing only [A-Za-z0-9_./-]
require.library:enyo/dropzone : invalid key, package names must be strings containing only [A-Za-z0-9_./-]
require.library:kenwheeler/slick : invalid key, package names must be strings containing only [A-Za-z0-9_./-]
require.library:dinbror/blazy : invalid key, package names must be strings containing only [A-Za-z0-9_./-]
require.library:gdsmith/jquery.easing : invalid key, package names must be strings containing only [A-Za-z0-9_./-]
