### PR TITLE
[OYPD-105] Changes for color module support

### DIFF
--- a/openy.info.yml
+++ b/openy.info.yml
@@ -11,6 +11,7 @@ dependencies:
   - block_content
   - breakpoint
   - ckeditor
+  - color
   - config
   - contextual
   - contact

--- a/themes/openy_themes/openy_rose/color/color.inc
+++ b/themes/openy_themes/openy_rose/color/color.inc
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @file
+ * Lists available colors and color schemes for the OpenY Rose theme.
+ */
+
+$info = array(
+  // Available colors and color labels used in theme.
+  'fields' => array(
+    'header_bg' => t('Header background'),
+    'header_hover' => t('Header menu hover'),
+    'main_bg' => t('Main background'),
+    'footer' => t('Footer background'),
+    'text' => t('Text color'),
+    'link' => t('Link color'),
+    'button' => t('Button color'),
+  ),
+  // Pre-defined color schemes.
+  'schemes' => array(
+    'default' => array(
+      'title' => t('Lochmara (default)'),
+      'colors' => array(
+        'header_bg' => '#0089d0',
+        'header_hover' => '#0060af',
+        'main_bg' => '#ffffff',
+        'footer' => '#4f4f4f',
+        'text' => '#636466',
+        'link' => '#337ab7',
+        'button' => '#00aeef',
+      ),
+    ),
+  ),
+
+  // CSS files (excluding @import) to rewrite with new color scheme.
+  'css' => array(
+    'css/colors.css',
+  ),
+
+);

--- a/themes/openy_themes/openy_rose/color/color.inc
+++ b/themes/openy_themes/openy_rose/color/color.inc
@@ -37,4 +37,12 @@ $info = array(
     'css/colors.css',
   ),
 
+  /**
+   * This copies the logo file from the theme. It is needed because the logo
+   * gets overridden by the Color module automatically.
+   * */
+  'copy' => array(
+    'logo.svg',
+  ),
+
 );

--- a/themes/openy_themes/openy_rose/color/color.inc
+++ b/themes/openy_themes/openy_rose/color/color.inc
@@ -8,9 +8,9 @@
 $info = array(
   // Available colors and color labels used in theme.
   'fields' => array(
-    'header_bg' => t('Header background'),
-    'header_hover' => t('Header menu hover'),
-    'main_bg' => t('Main background'),
+    'headerbg' => t('Header background'),
+    'headerhover' => t('Header menu hover'),
+    'bg' => t('Main background'),
     'footer' => t('Footer background'),
     'text' => t('Text color'),
     'link' => t('Link color'),
@@ -21,13 +21,37 @@ $info = array(
     'default' => array(
       'title' => t('Lochmara (default)'),
       'colors' => array(
-        'header_bg' => '#0089d0',
-        'header_hover' => '#0060af',
-        'main_bg' => '#ffffff',
+        'headerbg' => '#0089d0',
+        'headerhover' => '#0060af',
+        'bg' => '#ffffff',
         'footer' => '#4f4f4f',
         'text' => '#636466',
         'link' => '#337ab7',
         'button' => '#00aeef',
+      ),
+    ),
+    'endeavour' => array(
+      'title' => t('Endeavour'),
+      'colors' => array(
+        'headerbg' => '#0060af',
+        'headerhover' => '#3983c1',
+        'bg' => '#ffffff',
+        'footer' => '#434343',
+        'text' => '#636466',
+        'link' => '#428bca',
+        'button' => '#00aeef',
+      ),
+    ),
+    'vividviolet' => array(
+      'title' => t('Vivid Violet'),
+      'colors' => array(
+        'headerbg' => '#822a92',
+        'headerhover' => '#9950a6',
+        'bg' => '#ffffff',
+        'footer' => '#434343',
+        'text' => '#636466',
+        'link' => '#822a92',
+        'button' => '#991f76',
       ),
     ),
   ),

--- a/themes/openy_themes/openy_rose/color/color.inc
+++ b/themes/openy_themes/openy_rose/color/color.inc
@@ -61,10 +61,7 @@ $info = array(
     'css/colors.css',
   ),
 
-  /**
-   * This copies the logo file from the theme. It is needed because the logo
-   * gets overridden by the Color module automatically.
-   * */
+  // Copy the logo file from the theme. Color module forces this behavior.
   'copy' => array(
     'logo.svg',
   ),

--- a/themes/openy_themes/openy_rose/css/colors.css
+++ b/themes/openy_themes/openy_rose/css/colors.css
@@ -14,9 +14,7 @@ a,
 .top-navs {
   background-color: #0089d0;
 }
-.nav.dropdown-menu,
-.viewport .nav-level-2.open > a, .viewport .nav-level-2.open > a:focus,
-.nav > li > a:hover, .nav > li > a:focus {
+.nav.dropdown-menu {
   background-color: #0060af;
 }
 .footer {

--- a/themes/openy_themes/openy_rose/css/colors.css
+++ b/themes/openy_themes/openy_rose/css/colors.css
@@ -14,7 +14,9 @@ a,
 .top-navs {
   background-color: #0089d0;
 }
-.nav.dropdown-menu {
+.nav.dropdown-menu,
+.viewport .nav-level-2.open > a,
+.viewport .nav-level-2.open > a:focus {
   background-color: #0060af;
 }
 .footer {

--- a/themes/openy_themes/openy_rose/css/colors.css
+++ b/themes/openy_themes/openy_rose/css/colors.css
@@ -1,0 +1,24 @@
+/* ---------- Color Module Styles ----------- */
+body {
+  background-color: #ffffff;
+  color: #636466;
+}
+a,
+.link {
+  color: #337ab7;
+}
+.button,
+.btn {
+  background-color: #00aeef;
+}
+.top-navs {
+  background-color: #0089d0;
+}
+.nav.dropdown-menu,
+.viewport .nav-level-2.open > a, .viewport .nav-level-2.open > a:focus,
+.nav > li > a:hover, .nav > li > a:focus {
+  background-color: #0060af;
+}
+.footer {
+  background-color: #4f4f4f;
+}

--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -846,10 +846,6 @@ body {
     padding: 10px 24px 24px 24px;
   }
 }
-.viewport .nav-level-2.open > a:hover,
-.viewport .nav-level-2.open > a:focus:hover {
-  color: #00aeef;
-}
 .viewport .row-level-3,
 .viewport .nav-level-4 {
   list-style: none;

--- a/themes/openy_themes/openy_rose/openy_rose.libraries.yml
+++ b/themes/openy_themes/openy_rose/openy_rose.libraries.yml
@@ -7,6 +7,7 @@ global-styling:
       css/vendor/bootstrap/bootstrap-theme.min.css: {}
     theme:
       css/styles.css: {}
+      css/colors.css: {}
   js:
     //fast.fonts.net/jsapi/3ab9b18f-e8c9-4cf2-9541-2476051b3754.js: {}
     //use.fontawesome.com/95fd5fcc01.js: {}

--- a/themes/openy_themes/openy_rose/scss/modules/_menu.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_menu.scss
@@ -278,10 +278,6 @@
         @include breakpoint($screen-lg-desktop) {
           padding: 10px 24px 24px 24px;
         }
-
-        &:hover {
-          color: $light-blue;
-        }
       }
     }
   }


### PR DESCRIPTION
This should function. It replaces most of the colors.

![screen shot 2017-02-01 at 8 28 18 pm](https://cloud.githubusercontent.com/assets/1504038/22533601/ff44863e-e8bc-11e6-94ad-4cc808a629c6.png)

There are two big issue. One, the buttons. This is an issue with the theme. The buttons are all in various states all over. As soon as the colors.css file is added some will turn blue which shouldn't. That is because buttons do not have a defined background color. So some, like on the banner paragraphs are normally transparent. This will make them blue. We would have to add CSS for the banner paragraph to override it.

The second problem is that this seems very difficult to work with multiple settings using the same color. It seems to default to using the hex code as the key. So if the colors.css file has body background color #ffffff and footer link color as #ffffff they both get changed.

There is an alternate color scheme in Bartik that has multiple settings using one color. I'll need to see if that actual works correctly. I might be wrong and it is an issue of getting the naming just right, but I haven't gotten it to work just yet.