### PR TITLE
[OYPD-209] Adding nav menu hover to color module override file

### DIFF
--- a/themes/openy_themes/openy_rose/css/colors.css
+++ b/themes/openy_themes/openy_rose/css/colors.css
@@ -26,6 +26,10 @@ a,
 .nav > li > a:focus {
   background-color: #0060af;
 }
+.viewport .nav-level-2.open {
+  background-color: #0060af;
+  border-bottom: #0060af;
+}
 .footer {
   background-color: #4f4f4f;
 }

--- a/themes/openy_themes/openy_rose/css/colors.css
+++ b/themes/openy_themes/openy_rose/css/colors.css
@@ -16,7 +16,9 @@ a,
 }
 .nav.dropdown-menu,
 .viewport .nav-level-2.open > a,
-.viewport .nav-level-2.open > a:focus {
+.viewport .nav-level-2.open > a:focus,
+.nav > li > a:hover,
+.nav > li > a:focus {
   background-color: #0060af;
 }
 .footer {


### PR DESCRIPTION
![screen shot 2017-02-08 at 6 21 52 pm](https://cloud.githubusercontent.com/assets/1504038/22762153/e9ea6276-ee2b-11e6-841a-f593efbfdd63.png)

Bug fix. The top nav didnt not get its hover color overridden when color module override was change to a different color.

- [x] On "Appearance" where theme settings are changed, change the colors for header menu hover.
- [x] Make sure the color appears when hovering over the "My Account" menu link in the color and the main nav drop down.