### PR TITLE
[OYPD-210] Fixing mobile menu background color when theme settings change the he…

### DIFF
--- a/themes/openy_themes/openy_rose/css/colors.css
+++ b/themes/openy_themes/openy_rose/css/colors.css
@@ -11,7 +11,12 @@ a,
 .btn {
   background-color: #00aeef;
 }
-.top-navs {
+.top-navs,
+.sidebar,
+.navbar-default .navbar-toggle,
+.navbar-default .navbar-toggle:focus,
+.navbar-default .navbar-toggle:hover,
+.navbar-default .navbar-toggle:active {
   background-color: #0089d0;
 }
 .nav.dropdown-menu,


### PR DESCRIPTION
![screen shot 2017-02-08 at 6 53 52 pm](https://cloud.githubusercontent.com/assets/1504038/22762985/3894ba76-ee30-11e6-9fa0-9a8a4bd9dc9c.png)

- [x] Change the header color in theme settings.
- [x] Check that when the mobile menu is open the hamburger and sidebar menu match the header color.