### PR TITLE
[OYPD-182] Full width image for subcategory list below 480px

### DIFF
--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -2476,6 +2476,7 @@ body {
 }
 .subprogram-listing-item .image {
   margin-bottom: 20px;
+  text-align: center;
 }
 @media (min-width: 0) and (max-width: 30em) {
   .subprogram-listing-item .image img {

--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -2477,6 +2477,12 @@ body {
 .subprogram-listing-item .image {
   margin-bottom: 20px;
 }
+@media (min-width: 0) and (max-width: 30em) {
+  .subprogram-listing-item .image img {
+    height: auto;
+    width: 100%;
+  }
+}
 @media (min-width: 48em) {
   .subprogram-listing-item .image {
     text-align: right;

--- a/themes/openy_themes/openy_rose/scss/modules/_program.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_program.scss
@@ -141,6 +141,7 @@
   }
   .image {
     margin-bottom: 20px;
+    text-align: center;
     @include breakpoint(0 $screen-xs) {
       img {
         height: auto;

--- a/themes/openy_themes/openy_rose/scss/modules/_program.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_program.scss
@@ -141,6 +141,12 @@
   }
   .image {
     margin-bottom: 20px;
+    @include breakpoint(0 $screen-xs) {
+      img {
+        height: auto;
+        width: 100%;
+      }
+    }
     @include breakpoint($screen-sm) {
       text-align: right;
     }


### PR DESCRIPTION
- [x] Create a program page that can list subprograms using the program list paragraph type.
- [x] Look at the program list on smaller screen sizes.
- [x] See the image is full width on screens below 480px.

We may want to center the image between 480 and 760, but I wouldnt make the image max width. It will expand a 270px image to fit 700+ width which will look bad.

![screen shot 2017-02-10 at 12 34 17 pm](https://cloud.githubusercontent.com/assets/1504038/22837280/e259877c-ef8d-11e6-9bd0-9118a674ef22.png)
