### PR TITLE
Update zindexes on the mobile navigation

### DIFF
--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -511,7 +511,7 @@ body {
 
   .viewport {
     position: relative;
-    z-index: 41;
+    z-index: 39;
     width: 100%;
   }
   .viewport.collapsing-in, .viewport.collapsing-out {

--- a/themes/openy_themes/openy_rose/scss/modules/_header.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_header.scss
@@ -303,7 +303,7 @@
 
   .viewport {
     position: relative;
-    z-index: 41;
+    z-index: 39;
     width: 100%;
 
     &.collapsing-in,


### PR DESCRIPTION
On Mobile size breakpoints the `.sidebar` `z-index` property is set to `40`. This overlays the the `.viewport` class which needs to be set to `39` so the navigation is visible above other content.

<img width="448" alt="screen shot 2017-02-14 at 10 56 03 am" src="https://cloud.githubusercontent.com/assets/1957330/22936877/c9dcd824-f2a4-11e6-84e6-6d110dfff7e6.png">

<img width="448" alt="screen shot 2017-02-14 at 10 56 36 am" src="https://cloud.githubusercontent.com/assets/1957330/22936893/d2fce2b4-f2a4-11e6-8ea5-839e9c838c81.png">

Drupal.org issue https://www.drupal.org/node/2852572


