### PR TITLE
[OYPD-145] Changing font to Ubuntu Condensed

### DIFF
--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -1,11 +1,11 @@
 @charset "UTF-8";
 body {
   color: #636466;
-  font-family: "Helvetica Neue LT W01_55 Roman", Verdana, sans-serif;
+  font-family: "Helvetica Neue LT W01_55 Roman", 'Ubuntu Condensed', sans-serif;
 }
 
 h1, .h1, h2, .h2, h3, h4, h5, h6 {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
 }
 
 h1,
@@ -134,7 +134,7 @@ body {
 }
 .footer .footer__nav nav ul li a {
   color: #fff;
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   font-size: 20px;
   text-transform: uppercase;
   line-height: 22px;
@@ -207,7 +207,7 @@ body {
   max-width: 400px;
 }
 .footer .footer__social form label {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   color: #fff;
   font-size: 20px;
   line-height: 25px;
@@ -311,7 +311,7 @@ body {
   }
 }
 .page-head__top-menu a {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   color: #fff;
   font-size: 16px;
   font-style: normal;
@@ -330,7 +330,7 @@ body {
   }
 }
 .page-head__main-menu a {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   color: #fff;
   font-size: 18px;
   font-weight: 500;
@@ -919,7 +919,7 @@ body {
 }
 
 .btn, .button {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   background-image: none;
   border-radius: 0;
   border: none;
@@ -1037,7 +1037,7 @@ body {
   padding: 15px 0;
 }
 .yamlform-submission-guest-pass-form-form label {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   font-size: 18px;
   line-height: 23px;
 }
@@ -1454,7 +1454,7 @@ body {
   }
 }
 .paragraph-gallery .cta-group-wrapper .cta-group .text {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   font-size: 18px;
   line-height: 22px;
   margin-bottom: 15px;
@@ -1550,7 +1550,7 @@ body {
 }
 .story-card .quote {
   color: #5c2e91;
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   font-size: 30px;
   line-height: 38px;
   letter-spacing: -1px;
@@ -1658,7 +1658,7 @@ body {
   }
 }
 .banner-title {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   color: #fff;
   font-size: 32px;
   line-height: 36px;
@@ -1678,7 +1678,7 @@ body {
   }
 }
 .banner-description {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   color: #fff;
   font-size: 18px;
   font-style: normal;
@@ -1767,7 +1767,7 @@ body {
 }
 
 .description.purple, .paragraph.featured-content .description {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   padding-bottom: 1em;
   font-size: 20px;
   max-width: 840px;
@@ -1801,7 +1801,7 @@ body {
 }
 .paragraph.featured-content .wrapper-field-prgf-clm-description h3 {
   font-size: 20px;
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
 }
 .paragraph.featured-content center {
   margin-top: 1em;
@@ -1943,7 +1943,7 @@ body {
 }
 
 .site-alert {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   background-color: #00aeef;
   width: 100%;
 }
@@ -2354,7 +2354,7 @@ body {
 .program-header .description {
   font-size: 18px;
   line-height: 27px;
-  font-family: "Cachet W01 Medium", Verdana, sans-serif;
+  font-family: "Cachet W01 Medium", 'Ubuntu Condensed', sans-serif;
 }
 @media (min-width: 48em) {
   .program-header .description {
@@ -2573,7 +2573,7 @@ body {
 .sub-category-classes-view .js-form-type-select label {
   font-size: 14px;
   line-height: 1.6;
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   color: #4f4f4f;
   margin-bottom: 0;
 }
@@ -2585,7 +2585,7 @@ body {
 .sub-category-classes-view .js-form-type-select select {
   text-transform: uppercase;
   color: #4f4f4f;
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
 }
 .sub-category-classes-view .selects-container hr {
   border-color: #636466;
@@ -2640,7 +2640,7 @@ body {
   }
 }
 .sub-category-classes-view .filters-container .reset-wrapper .clear {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   background: none;
   border: none;
   color: #0089d0;
@@ -2668,7 +2668,7 @@ body {
   }
 }
 .sub-category-classes-view .filters-wrapper .label {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   color: #4f4f4f;
   display: block;
   font-size: 14px;
@@ -2686,7 +2686,7 @@ body {
   display: inline-block;
 }
 .sub-category-classes-view .filters-wrapper .filters .filter {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   background: #fff;
   border-radius: 4px;
   color: #00aeef;
@@ -2727,7 +2727,7 @@ body {
   padding: 0;
 }
 .sub-category-classes-view .activity-group h3 {
-  font-family: "Cachet W01 Medium", Verdana, sans-serif;
+  font-family: "Cachet W01 Medium", 'Ubuntu Condensed', sans-serif;
   font-size: 30px;
   line-height: 1.6;
   letter-spacing: -0.8px;
@@ -2750,7 +2750,7 @@ body {
   color: #333333;
 }
 .sub-category-classes-view .activity-group .views-field-title {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   font-size: 22px;
   line-height: 1;
   color: #0089d0;
@@ -2854,13 +2854,13 @@ body {
   }
 }
 .branch-header .desktop .column .field-phone a {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
 }
 .branch-header .desktop .column .ygs-branch-selector {
   margin-top: 22px;
 }
 .branch-header .desktop .column .ygs-branch-selector a {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
 }
 .branch-header .desktop h4 {
   font-size: 16px;
@@ -2872,7 +2872,7 @@ body {
   font-size: 16px;
   line-height: 1.1;
   margin: 0;
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
 }
 @media (min-width: 48em) and (max-width: 62em) {
   .branch-header .desktop p {
@@ -2887,7 +2887,7 @@ body {
 }
 .branch-header .desktop .today-hours .show-link,
 .branch-header .desktop .today-hours .hide-link {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
 }
 .branch-header .desktop .today-hours .branch-hours {
   position: absolute;
@@ -2953,7 +2953,7 @@ body {
 .branch-header .mobile p {
   font-size: 16px;
   line-height: 1.1;
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   margin: 0 0 5px;
 }
 .branch-header .mobile .ui-tabs {
@@ -3005,13 +3005,13 @@ body {
   font-size: 16px;
   line-height: 1.1;
   margin: 0;
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
 }
 .branch-header .mobile .ui-tabs .ui-tabs-panel a {
   color: #fff;
 }
 .branch-header .mobile .ui-tabs .today-hours {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
 }
 .branch-header .mobile .ui-tabs .today-hours .today {
   margin-right: 10px;
@@ -3036,7 +3036,7 @@ body {
 }
 .branch-header .mobile #save-location a {
   color: #fff;
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
 }
 
 .branch__updates_queue {
@@ -3170,7 +3170,7 @@ html.js .branch__updates_queue__button {
 .ygs-branch-sessions-form label {
   font-size: 14px;
   line-height: 1.6;
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   color: #4f4f4f;
   margin-bottom: 0;
 }
@@ -3210,7 +3210,7 @@ html.js .branch__updates_queue__button {
 .ygs-branch-sessions-form .js-form-type-select select {
   text-transform: uppercase;
   color: #4f4f4f;
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
 }
 .ygs-branch-sessions-form .form-item-when-day {
   display: inline-block;
@@ -3335,7 +3335,7 @@ html.js .branch__updates_queue__button {
   }
 }
 .ygs-branch-sessions-form .filters-main-wrapper .reset-wrapper .clear {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   background: none;
   border: none;
   color: #0089d0;
@@ -3363,7 +3363,7 @@ html.js .branch__updates_queue__button {
   }
 }
 .ygs-branch-sessions-form .filters-wrapper .label {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   color: #4f4f4f;
   display: block;
   font-size: 14px;
@@ -3381,7 +3381,7 @@ html.js .branch__updates_queue__button {
   display: inline-block;
 }
 .ygs-branch-sessions-form .filters-wrapper .filters .filter {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   background: #fff;
   border-radius: 4px;
   color: #00aeef;
@@ -3423,7 +3423,7 @@ html.js .branch__updates_queue__button {
   padding: 0;
 }
 .branch-sessions-group h3 {
-  font-family: "Cachet W01 Medium", Verdana, sans-serif;
+  font-family: "Cachet W01 Medium", 'Ubuntu Condensed', sans-serif;
   font-size: 30px;
   line-height: 1.6;
   letter-spacing: -0.8px;
@@ -3485,7 +3485,7 @@ html.js .branch__updates_queue__button {
   color: #333333;
 }
 .branch-sessions-group .group_time {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   background: #fff;
   border-bottom: 1px solid #c6168d;
   color: #5c2e91;
@@ -3712,7 +3712,7 @@ html.js .branch__updates_queue__button {
 .node--type-branch.node--view-mode-teaser h2,
 .node--type-camp.node--view-mode-teaser h2 {
   font-size: 22px;
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   margin: 20px 0 33px;
   font-weight: bold;
 }
@@ -4111,13 +4111,13 @@ html.js .branch__updates_queue__button {
 }
 .blog-more-teaser label {
   display: block;
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
 }
 .blog-more-teaser label[for="edit-combine"] {
   opacity: 0;
 }
 .blog-more-teaser select {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
 }
 .blog-more-teaser .form-text {
   width: 100%;
@@ -4138,7 +4138,7 @@ html.js .branch__updates_queue__button {
   font-size: 16px;
   font-weight: 600;
   color: #ffffff;
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   text-transform: uppercase;
 }
 
@@ -4199,7 +4199,7 @@ html.js .branch__updates_queue__button {
   white-space: normal;
 }
 .class-page-schedule .starting-from {
-  font-family: "Cachet W01 Bold", Verdana, sans-serif;
+  font-family: "Cachet W01 Bold", 'Ubuntu Condensed', sans-serif;
   margin-bottom: 15px;
   font-size: 16px;
 }
@@ -4213,14 +4213,14 @@ html.js .branch__updates_queue__button {
   margin-bottom: 15px;
 }
 .class-page-schedule .tier-prices .tier-price {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   font-size: 18px;
   font-weight: bold;
 }
 .class-page-schedule .ticket {
   color: #5c2e91;
   margin-top: 10px;
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   font-size: 18px;
   font-weight: bold;
 }
@@ -4228,7 +4228,7 @@ html.js .branch__updates_queue__button {
 .class_price,
 .class_time,
 .class_days {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   font-size: 18px;
   font-weight: bold;
 }
@@ -4238,7 +4238,7 @@ html.js .branch__updates_queue__button {
 }
 
 .node--type-class.node--view-mode-teaser h2, .node--type-class.node--view-mode-teaser h3 {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   font-size: 22px;
   line-height: 1;
   color: #0089d0;
@@ -4251,7 +4251,7 @@ html.js .branch__updates_queue__button {
 }
 
 .class-page-other-sessions .session .name {
-  font-family: "Cachet W01 Bold", Verdana, sans-serif;
+  font-family: "Cachet W01 Bold", 'Ubuntu Condensed', sans-serif;
 }
 
 .active-net__teasers .active-net__teasers-list,
@@ -4264,7 +4264,7 @@ html.js .branch__updates_queue__button {
 .active-net__teaser,
 .flexreg__teaser {
   border-bottom: 1px solid #eeeeee;
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
 }
 .active-net__teaser td,
 .flexreg__teaser td {
@@ -4272,7 +4272,7 @@ html.js .branch__updates_queue__button {
 }
 .active-net__teaser .name,
 .flexreg__teaser .name {
-  font-family: "Cachet W01 Bold", Verdana, sans-serif;
+  font-family: "Cachet W01 Bold", 'Ubuntu Condensed', sans-serif;
 }
 .active-net__teaser .description,
 .flexreg__teaser .description {
@@ -4299,7 +4299,7 @@ html.js .branch__updates_queue__button {
 .flexreg__teaser .register a {
   color: #4f4f4f;
   text-decoration: underline;
-  font-family: "Cachet W01 Bold", Verdana, sans-serif;
+  font-family: "Cachet W01 Bold", 'Ubuntu Condensed', sans-serif;
 }
 
 .table-sessions {
@@ -4345,7 +4345,7 @@ html.js .branch__updates_queue__button {
 #schedules-search-form-wrapper .js-form-type-select label {
   font-size: 14px;
   line-height: 1.6;
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   color: #4f4f4f;
   margin-bottom: 0;
 }
@@ -4357,7 +4357,7 @@ html.js .branch__updates_queue__button {
 #schedules-search-form-wrapper .js-form-type-select select {
   text-transform: uppercase;
   color: #4f4f4f;
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
 }
 #schedules-search-form-wrapper .js-form-type-select.form-item-location {
   padding: 15px 0 25px;
@@ -4396,7 +4396,7 @@ html.js .branch__updates_queue__button {
 #schedules-search-form-wrapper .js-form-type-textfield label {
   font-size: 14px;
   line-height: 1.6;
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   color: #4f4f4f;
   margin-bottom: 0;
 }
@@ -4408,7 +4408,7 @@ html.js .branch__updates_queue__button {
 #schedules-search-form-wrapper .js-form-type-textfield input {
   text-transform: uppercase;
   color: #4f4f4f;
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   width: 100%;
 }
 #schedules-search-form-wrapper .js-form-type-textfield .hasDatepicker {
@@ -4469,7 +4469,7 @@ html.js .branch__updates_queue__button {
   }
 }
 #schedules-search-form-wrapper .filters-container .reset-wrapper .clear {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   background: none;
   border: none;
   color: #0089d0;
@@ -4497,7 +4497,7 @@ html.js .branch__updates_queue__button {
   }
 }
 #schedules-search-form-wrapper .filters-wrapper .label {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   color: #4f4f4f;
   display: block;
   font-size: 14px;
@@ -4515,7 +4515,7 @@ html.js .branch__updates_queue__button {
   display: inline-block;
 }
 #schedules-search-form-wrapper .filters-wrapper .filters .filter {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   background: #fff;
   border-radius: 4px;
   color: #00aeef;
@@ -4568,7 +4568,7 @@ html.js .branch__updates_queue__button {
   font-style: normal;
 }
 #schedules-search-form-wrapper .results .group_time {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   color: #5c2e91;
   font-size: 18px;
   margin-bottom: 10px;
@@ -4684,7 +4684,7 @@ html.js .branch__updates_queue__button {
   display: block;
 }
 #schedules-search-form-wrapper .results .views-row h3 {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   font-size: 22px;
   line-height: 1;
   color: #0089d0;
@@ -4766,7 +4766,7 @@ html.js .branch__updates_queue__button {
 #schedules-search-form-wrapper .branch-hours-wrapper .card p {
   font-size: 30px;
   line-height: 1.15;
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
 }
 #schedules-search-form-wrapper .branch-hours-wrapper .col-sm-2 h4 {
   font-size: 14px;
@@ -4869,7 +4869,7 @@ body .branch-popup + .ui-widget-overlay {
   margin-top: -10px;
 }
 .modal-body .fieldset-legend {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
 }
 @media (min-width: 48em) {
   .modal-body .fieldset-legend {
@@ -4877,7 +4877,7 @@ body .branch-popup + .ui-widget-overlay {
   }
 }
 .modal-body .button {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   height: 40px;
   float: right;
   padding: 10px 20px;
@@ -4959,7 +4959,7 @@ a[href="#step2"] {
 .views-element-container .nav-pills {
   display: table;
   width: 100%;
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   overflow: hidden;
   margin-bottom: 20px;
   font-size: 13px;
@@ -5187,7 +5187,7 @@ a[href="#step2"] {
   list-style: none;
 }
 .camp-menu__item a {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   line-height: 50px;
   line-height: 5rem;
   padding: 0 15px;
@@ -5264,7 +5264,7 @@ a[href="#step2"] {
   padding-left: 0;
 }
 .user-login label {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   display: inline-block;
   max-width: 100%;
   margin-bottom: 10px;
@@ -5313,7 +5313,7 @@ a[href="#step2"] {
   list-style: none;
 }
 .openy-page-tabs > ul li {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   display: inline-block;
   font-size: 16px;
   line-height: 17px;
@@ -5331,7 +5331,7 @@ a[href="#step2"] {
   border-right: solid 1px #00aeef;
 }
 .openy-page-tabs > ul li a {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   display: block;
   padding: 9px;
   text-decoration: none;
@@ -5463,7 +5463,7 @@ html.js .flag-waiting .flag-throbber {
 }
 
 .status-message ul, .status-message p {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
   margin: 0 auto;
   padding: 20px;
   color: #fff;

--- a/themes/openy_themes/openy_rose/openy_rose.libraries.yml
+++ b/themes/openy_themes/openy_rose/openy_rose.libraries.yml
@@ -2,14 +2,13 @@ global-styling:
   version: VERSION
   css:
     base:
-      //fast.fonts.net/cssapi/3ab9b18f-e8c9-4cf2-9541-2476051b3754.css: {}
+      //fonts.googleapis.com/css?family=Ubuntu+Condensed:400,700: {}
       css/vendor/bootstrap/bootstrap.css: {}
       css/vendor/bootstrap/bootstrap-theme.min.css: {}
     theme:
       css/styles.css: {}
       css/colors.css: {}
   js:
-    //fast.fonts.net/jsapi/3ab9b18f-e8c9-4cf2-9541-2476051b3754.js: {}
     //use.fontawesome.com/95fd5fcc01.js: {}
     scripts/vendor/bootstrap.min.js: {}
     scripts/openy_rose.js: {}

--- a/themes/openy_themes/openy_rose/scss/base/_mixins.scss
+++ b/themes/openy_themes/openy_rose/scss/base/_mixins.scss
@@ -1,15 +1,15 @@
 @mixin cachet() {
-  font-family: "Cachet W01 Book", Verdana, sans-serif;
+  font-family: "Cachet W01 Book", 'Ubuntu Condensed', sans-serif;
 }
 
 @mixin cachet-medium() {
-  font-family: "Cachet W01 Medium", Verdana, sans-serif;
+  font-family: "Cachet W01 Medium", 'Ubuntu Condensed', sans-serif;
 }
 
 @mixin cachet-bold() {
-  font-family: "Cachet W01 Bold", Verdana, sans-serif;
+  font-family: "Cachet W01 Bold", 'Ubuntu Condensed', sans-serif;
 }
 
 @mixin helvetica-neue() {
-  font-family: "Helvetica Neue LT W01_55 Roman", Verdana, sans-serif;
+  font-family: "Helvetica Neue LT W01_55 Roman", 'Ubuntu Condensed', sans-serif;
 }


### PR DESCRIPTION
- [x] Load site
- [x] Compare font in places where Cachet would have been loaded. Most titles, special text boxes.

After trying many different fonts I'm trying Ubuntu Condensed which is a web font. It is very difficult to match the Cachet styles because of its rounded edges. So I sacrificed style for size. I try to make sure the font was similar width or more narrow so it would not break layouts. Ubuntu is also a web font.

To make the change I added Ubuntu Condensed after Cachet so that if Cached gets added by anyone it should still work. I also removed the fast font link to the Cachet font so it won't be in the distribution any more.

A good place to check is the drop down menu. On my test site the menu column headers look ok. The first one wraps, which it does not on the Seattle site, but the others look ok.

![screen shot 2017-02-15 at 7 06 37 pm](https://cloud.githubusercontent.com/assets/1504038/23001188/f8433fa6-f3b1-11e6-95da-c61ebe81da9b.png)

