### PR TITLE
I18n

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .sass-cache/
+.idea
 contrib
 libraries
 vendor

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/modules/openy_features/openy_block/modules/openy_block_basic/config/install/field.field.block_content.basic_block.field_block_content.yml
+++ b/modules/openy_features/openy_block/modules/openy_block_basic/config/install/field.field.block_content.basic_block.field_block_content.yml
@@ -13,7 +13,7 @@ bundle: basic_block
 label: Content
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/openy_features/openy_location/modules/openy_loc_branch/config/install/field.field.node.branch.field_branch_hours.yml
+++ b/modules/openy_features/openy_location/modules/openy_loc_branch/config/install/field.field.node.branch.field_branch_hours.yml
@@ -14,7 +14,7 @@ bundle: branch
 label: 'Branch Hours'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_location/modules/openy_loc_branch/config/install/field.field.node.branch.field_content.yml
+++ b/modules/openy_features/openy_location/modules/openy_loc_branch/config/install/field.field.node.branch.field_content.yml
@@ -13,7 +13,7 @@ bundle: branch
 label: Content
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_location/modules/openy_loc_branch/config/install/field.field.node.branch.field_header_content.yml
+++ b/modules/openy_features/openy_location/modules/openy_loc_branch/config/install/field.field.node.branch.field_header_content.yml
@@ -13,7 +13,7 @@ bundle: branch
 label: 'Header content'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_location/modules/openy_loc_branch/config/install/field.field.node.branch.field_location_address.yml
+++ b/modules/openy_features/openy_location/modules/openy_loc_branch/config/install/field.field.node.branch.field_location_address.yml
@@ -13,7 +13,7 @@ bundle: branch
 label: Address
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_location/modules/openy_loc_branch/config/install/field.field.node.branch.field_location_area.yml
+++ b/modules/openy_features/openy_location/modules/openy_loc_branch/config/install/field.field.node.branch.field_location_area.yml
@@ -12,7 +12,7 @@ bundle: branch
 label: Neighborhood
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_location/modules/openy_loc_branch/config/install/field.field.node.branch.field_location_coordinates.yml
+++ b/modules/openy_features/openy_location/modules/openy_loc_branch/config/install/field.field.node.branch.field_location_coordinates.yml
@@ -13,7 +13,7 @@ bundle: branch
 label: 'Branch Coordinates'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/openy_features/openy_location/modules/openy_loc_branch/config/install/field.field.node.branch.field_location_directions.yml
+++ b/modules/openy_features/openy_location/modules/openy_loc_branch/config/install/field.field.node.branch.field_location_directions.yml
@@ -13,7 +13,7 @@ bundle: branch
 label: Directions
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_location/modules/openy_loc_branch/config/install/field.field.node.branch.field_location_email.yml
+++ b/modules/openy_features/openy_location/modules/openy_loc_branch/config/install/field.field.node.branch.field_location_email.yml
@@ -11,7 +11,7 @@ bundle: branch
 label: Email
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/openy_features/openy_location/modules/openy_loc_branch/config/install/field.field.node.branch.field_location_fax.yml
+++ b/modules/openy_features/openy_location/modules/openy_loc_branch/config/install/field.field.node.branch.field_location_fax.yml
@@ -13,7 +13,7 @@ bundle: branch
 label: Fax
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/openy_features/openy_location/modules/openy_loc_branch/config/install/field.field.node.branch.field_location_phone.yml
+++ b/modules/openy_features/openy_location/modules/openy_loc_branch/config/install/field.field.node.branch.field_location_phone.yml
@@ -13,7 +13,7 @@ bundle: branch
 label: Phone
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/openy_features/openy_location/modules/openy_loc_branch/config/install/field.field.node.branch.field_location_state.yml
+++ b/modules/openy_features/openy_location/modules/openy_loc_branch/config/install/field.field.node.branch.field_location_state.yml
@@ -11,7 +11,7 @@ bundle: branch
 label: 'Coming Soon'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value:
   -
     value: 0

--- a/modules/openy_features/openy_location/modules/openy_loc_branch/config/install/field.field.node.branch.field_location_temp_url.yml
+++ b/modules/openy_features/openy_location/modules/openy_loc_branch/config/install/field.field.node.branch.field_location_temp_url.yml
@@ -13,7 +13,7 @@ bundle: branch
 label: 'Temporary URL'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_location/modules/openy_loc_branch/config/install/field.field.paragraph.branch_hours.field_branch_hours_day.yml
+++ b/modules/openy_features/openy_location/modules/openy_loc_branch/config/install/field.field.paragraph.branch_hours.field_branch_hours_day.yml
@@ -13,7 +13,7 @@ bundle: branch_hours
 label: 'Day of the week'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/openy_features/openy_location/modules/openy_loc_branch/config/install/field.field.paragraph.branch_hours.field_branch_hours_time.yml
+++ b/modules/openy_features/openy_location/modules/openy_loc_branch/config/install/field.field.paragraph.branch_hours.field_branch_hours_time.yml
@@ -11,7 +11,7 @@ bundle: branch_hours
 label: 'Start/End Time'
 description: 'e.g. 9am - 5pm, closed.'
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/openy_features/openy_location/modules/openy_loc_camp/config/install/field.field.node.camp.field_camp_menu_links.yml
+++ b/modules/openy_features/openy_location/modules/openy_loc_camp/config/install/field.field.node.camp.field_camp_menu_links.yml
@@ -13,7 +13,7 @@ bundle: camp
 label: 'Menu links'
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_location/modules/openy_loc_facility/config/install/field.field.node.facility.field_facility_loc.yml
+++ b/modules/openy_features/openy_location/modules/openy_loc_facility/config/install/field.field.node.facility.field_facility_loc.yml
@@ -12,7 +12,7 @@ bundle: facility
 label: 'Facility Branch'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_location/modules/openy_loc_facility/config/install/field.field.node.facility.field_facility_type.yml
+++ b/modules/openy_features/openy_location/modules/openy_loc_facility/config/install/field.field.node.facility.field_facility_type.yml
@@ -12,7 +12,7 @@ bundle: facility
 label: Type
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_location/modules/openy_loc_facility/config/install/field.field.node.facility.field_sidebar_content.yml
+++ b/modules/openy_features/openy_location/modules/openy_loc_facility/config/install/field.field.node.facility.field_sidebar_content.yml
@@ -13,7 +13,7 @@ bundle: facility
 label: 'Sidebar content'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_media/modules/openy_media_document/config/install/field.field.media.document.field_media_document.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_document/config/install/field.field.media.document.field_media_document.yml
@@ -13,7 +13,7 @@ bundle: document
 label: Document
 description: 'This field stores the document file.'
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_media/modules/openy_media_document/config/install/field.field.media.document.field_media_mime.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_document/config/install/field.field.media.document.field_media_mime.yml
@@ -11,7 +11,7 @@ bundle: document
 label: 'Mime Type'
 description: 'This field stores the mime type of the document.'
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/openy_features/openy_media/modules/openy_media_document/config/install/field.field.media.document.field_media_size.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_document/config/install/field.field.media.document.field_media_size.yml
@@ -11,7 +11,7 @@ bundle: document
 label: Size
 description: 'This field stores the size of the document file.'
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_media/modules/openy_media_image/config/install/field.field.media.image.field_media_caption.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_image/config/install/field.field.media.image.field_media_caption.yml
@@ -11,7 +11,7 @@ bundle: image
 label: Caption
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/openy_features/openy_media/modules/openy_media_image/config/install/field.field.media.image.field_media_image.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_image/config/install/field.field.media.image.field_media_image.yml
@@ -13,7 +13,7 @@ bundle: image
 label: Image
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_media/modules/openy_media_image/config/install/field.field.media.image.field_media_in_library.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_image/config/install/field.field.media.image.field_media_in_library.yml
@@ -11,7 +11,7 @@ bundle: image
 label: 'Save to my media library'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value:
   -
     value: 1

--- a/modules/openy_features/openy_media/modules/openy_media_image/config/install/field.field.media.image.field_media_tags.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_image/config/install/field.field.media.image.field_media_tags.yml
@@ -12,7 +12,7 @@ bundle: image
 label: 'Media Tags'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_media/modules/openy_media_video/config/install/field.field.media.video.field_media_source.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_video/config/install/field.field.media.video.field_media_source.yml
@@ -11,7 +11,7 @@ bundle: video
 label: 'Video source name'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/openy_features/openy_media/modules/openy_media_video/config/install/field.field.media.video.field_media_video_id.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_video/config/install/field.field.media.video.field_media_video_id.yml
@@ -11,7 +11,7 @@ bundle: video
 label: 'Video ID'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/openy_features/openy_node/modules/openy_node_activity/config/install/field.field.node.activity.field_activity_category.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_activity/config/install/field.field.node.activity.field_activity_category.yml
@@ -12,7 +12,7 @@ bundle: activity
 label: 'Program Subcategory'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_node/modules/openy_node_activity/config/install/field.field.node.activity.field_activity_description.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_activity/config/install/field.field.node.activity.field_activity_description.yml
@@ -13,7 +13,7 @@ bundle: activity
 label: Description
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/openy_features/openy_node/modules/openy_node_blog/config/install/field.field.node.blog.field_blog_category.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_blog/config/install/field.field.node.blog.field_blog_category.yml
@@ -12,7 +12,7 @@ bundle: blog
 label: Category
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_node/modules/openy_node_blog/config/install/field.field.node.blog.field_blog_description.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_blog/config/install/field.field.node.blog.field_blog_description.yml
@@ -13,7 +13,7 @@ bundle: blog
 label: Description
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/openy_features/openy_node/modules/openy_node_blog/config/install/field.field.node.blog.field_blog_image.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_blog/config/install/field.field.node.blog.field_blog_image.yml
@@ -12,7 +12,7 @@ bundle: blog
 label: Image
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_node/modules/openy_node_blog/config/install/field.field.node.blog.field_blog_location.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_blog/config/install/field.field.node.blog.field_blog_location.yml
@@ -13,7 +13,7 @@ bundle: blog
 label: Locations
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_node/modules/openy_node_blog/config/install/field.field.node.blog.field_blog_related.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_blog/config/install/field.field.node.blog.field_blog_related.yml
@@ -11,7 +11,7 @@ bundle: blog
 label: 'Related content'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_node/modules/openy_node_blog/config/install/field.field.node.blog.field_blog_style.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_blog/config/install/field.field.node.blog.field_blog_style.yml
@@ -13,7 +13,7 @@ bundle: blog
 label: Style
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value:
   -
     value: fuchsia

--- a/modules/openy_features/openy_node/modules/openy_node_category/config/install/field.field.node.program_subcategory.field_category_color.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_category/config/install/field.field.node.program_subcategory.field_category_color.yml
@@ -12,7 +12,7 @@ bundle: program_subcategory
 label: Color
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_node/modules/openy_node_category/config/install/field.field.node.program_subcategory.field_category_description.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_category/config/install/field.field.node.program_subcategory.field_category_description.yml
@@ -13,7 +13,7 @@ bundle: program_subcategory
 label: Description
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/openy_features/openy_node/modules/openy_node_category/config/install/field.field.node.program_subcategory.field_category_image.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_category/config/install/field.field.node.program_subcategory.field_category_image.yml
@@ -12,7 +12,7 @@ bundle: program_subcategory
 label: Image
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_node/modules/openy_node_category/config/install/field.field.node.program_subcategory.field_category_program.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_category/config/install/field.field.node.program_subcategory.field_category_program.yml
@@ -12,7 +12,7 @@ bundle: program_subcategory
 label: Program
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_node/modules/openy_node_class/config/install/field.field.node.class.field_class_activity.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_class/config/install/field.field.node.class.field_class_activity.yml
@@ -12,7 +12,7 @@ bundle: class
 label: Activity
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_node/modules/openy_node_class/config/install/field.field.node.class.field_class_description.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_class/config/install/field.field.node.class.field_class_description.yml
@@ -13,7 +13,7 @@ bundle: class
 label: Description
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/openy_features/openy_node/modules/openy_node_landing/config/install/field.field.node.landing_page.field_lp_layout.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_landing/config/install/field.field.node.landing_page.field_lp_layout.yml
@@ -13,7 +13,7 @@ bundle: landing_page
 label: Layout
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/openy_features/openy_node/modules/openy_node_mbrshp/config/install/field.field.node.membership.field_mbrshp_description.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_mbrshp/config/install/field.field.node.membership.field_mbrshp_description.yml
@@ -13,7 +13,7 @@ bundle: membership
 label: Description
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/openy_features/openy_node/modules/openy_node_mbrshp/config/install/field.field.node.membership.field_mbrshp_image.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_mbrshp/config/install/field.field.node.membership.field_mbrshp_image.yml
@@ -12,7 +12,7 @@ bundle: membership
 label: Image
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_node/modules/openy_node_mbrshp/config/install/field.field.node.membership.field_mbrshp_info.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_mbrshp/config/install/field.field.node.membership.field_mbrshp_info.yml
@@ -14,7 +14,7 @@ bundle: membership
 label: 'Membership info'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_node/modules/openy_node_mbrshp/config/install/field.field.paragraph.membership_info.field_mbrshp_join_fee.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_mbrshp/config/install/field.field.paragraph.membership_info.field_mbrshp_join_fee.yml
@@ -11,7 +11,7 @@ bundle: membership_info
 label: 'Join Fee'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_node/modules/openy_node_mbrshp/config/install/field.field.paragraph.membership_info.field_mbrshp_link.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_mbrshp/config/install/field.field.paragraph.membership_info.field_mbrshp_link.yml
@@ -13,7 +13,7 @@ bundle: membership_info
 label: Link
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_node/modules/openy_node_mbrshp/config/install/field.field.paragraph.membership_info.field_mbrshp_location.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_mbrshp/config/install/field.field.paragraph.membership_info.field_mbrshp_location.yml
@@ -12,7 +12,7 @@ bundle: membership_info
 label: Location
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_node/modules/openy_node_mbrshp/config/install/field.field.paragraph.membership_info.field_mbrshp_monthly_rate.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_mbrshp/config/install/field.field.paragraph.membership_info.field_mbrshp_monthly_rate.yml
@@ -11,7 +11,7 @@ bundle: membership_info
 label: 'Monthly Rate'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_node/modules/openy_node_program/config/install/field.field.node.program.field_program_color.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_program/config/install/field.field.node.program.field_program_color.yml
@@ -12,7 +12,7 @@ bundle: program
 label: Color
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_node/modules/openy_node_program/config/install/field.field.node.program.field_program_description.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_program/config/install/field.field.node.program.field_program_description.yml
@@ -13,7 +13,7 @@ bundle: program
 label: Description
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/openy_features/openy_node/modules/openy_node_program/config/install/field.field.node.program.field_program_icon.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_program/config/install/field.field.node.program.field_program_icon.yml
@@ -12,7 +12,7 @@ bundle: program
 label: Icon
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_node/modules/openy_node_program/config/install/field.field.node.program.field_program_image.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_program/config/install/field.field.node.program.field_program_image.yml
@@ -12,7 +12,7 @@ bundle: program
 label: Image
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_node/modules/openy_node_session/config/install/field.field.node.session.field_session_class.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_session/config/install/field.field.node.session.field_session_class.yml
@@ -12,7 +12,7 @@ bundle: session
 label: Class
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_node/modules/openy_node_session/config/install/field.field.node.session.field_session_description.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_session/config/install/field.field.node.session.field_session_description.yml
@@ -13,7 +13,7 @@ bundle: session
 label: Description
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/openy_features/openy_node/modules/openy_node_session/config/install/field.field.node.session.field_session_exclusions.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_session/config/install/field.field.node.session.field_session_exclusions.yml
@@ -13,7 +13,7 @@ bundle: session
 label: Exclusions
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/openy_features/openy_node/modules/openy_node_session/config/install/field.field.node.session.field_session_gender.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_session/config/install/field.field.node.session.field_session_gender.yml
@@ -13,7 +13,7 @@ bundle: session
 label: Gender
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/openy_features/openy_node/modules/openy_node_session/config/install/field.field.node.session.field_session_in_mbrsh.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_session/config/install/field.field.node.session.field_session_in_mbrsh.yml
@@ -11,7 +11,7 @@ bundle: session
 label: 'In membership'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value:
   -
     value: 0

--- a/modules/openy_features/openy_node/modules/openy_node_session/config/install/field.field.node.session.field_session_location.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_session/config/install/field.field.node.session.field_session_location.yml
@@ -13,7 +13,7 @@ bundle: session
 label: Location
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_node/modules/openy_node_session/config/install/field.field.node.session.field_session_max_age.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_session/config/install/field.field.node.session.field_session_max_age.yml
@@ -11,7 +11,7 @@ bundle: session
 label: 'Max Age'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_node/modules/openy_node_session/config/install/field.field.node.session.field_session_mbr_price.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_session/config/install/field.field.node.session.field_session_mbr_price.yml
@@ -11,7 +11,7 @@ bundle: session
 label: 'Member price'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_node/modules/openy_node_session/config/install/field.field.node.session.field_session_min_age.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_session/config/install/field.field.node.session.field_session_min_age.yml
@@ -11,7 +11,7 @@ bundle: session
 label: 'Min Age'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_node/modules/openy_node_session/config/install/field.field.node.session.field_session_nmbr_price.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_session/config/install/field.field.node.session.field_session_nmbr_price.yml
@@ -11,7 +11,7 @@ bundle: session
 label: 'Non Member Price'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_node/modules/openy_node_session/config/install/field.field.node.session.field_session_online.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_session/config/install/field.field.node.session.field_session_online.yml
@@ -11,7 +11,7 @@ bundle: session
 label: 'Online registration'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value:
   -
     value: 0

--- a/modules/openy_features/openy_node/modules/openy_node_session/config/install/field.field.node.session.field_session_plocation.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_session/config/install/field.field.node.session.field_session_plocation.yml
@@ -12,7 +12,7 @@ bundle: session
 label: 'Physical Location'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_node/modules/openy_node_session/config/install/field.field.node.session.field_session_reg_link.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_session/config/install/field.field.node.session.field_session_reg_link.yml
@@ -13,7 +13,7 @@ bundle: session
 label: 'Registration link'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_node/modules/openy_node_session/config/install/field.field.node.session.field_session_ticket.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_session/config/install/field.field.node.session.field_session_ticket.yml
@@ -11,7 +11,7 @@ bundle: session
 label: 'Ticket required'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value:
   -
     value: 0

--- a/modules/openy_features/openy_node/modules/openy_node_session/config/install/field.field.node.session.field_session_time.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_session/config/install/field.field.node.session.field_session_time.yml
@@ -14,7 +14,7 @@ bundle: session
 label: Time
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_node/modules/openy_node_session/config/install/field.field.paragraph.session_time.field_session_time_date.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_session/config/install/field.field.paragraph.session_time.field_session_time_date.yml
@@ -13,7 +13,7 @@ bundle: session_time
 label: 'Date & Time'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/openy_features/openy_node/modules/openy_node_session/config/install/field.field.paragraph.session_time.field_session_time_days.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_session/config/install/field.field.paragraph.session_time.field_session_time_days.yml
@@ -13,7 +13,7 @@ bundle: session_time
 label: Days
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_banner/config/install/field.field.paragraph.banner.field_prgf_headline.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_banner/config/install/field.field.paragraph.banner.field_prgf_headline.yml
@@ -11,7 +11,7 @@ bundle: banner
 label: Headline
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_banner/config/install/field.field.paragraph.banner.field_prgf_image.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_banner/config/install/field.field.paragraph.banner.field_prgf_image.yml
@@ -12,7 +12,7 @@ bundle: banner
 label: Image
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_banner/config/install/field.field.paragraph.banner.field_prgf_link.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_banner/config/install/field.field.paragraph.banner.field_prgf_link.yml
@@ -13,7 +13,7 @@ bundle: banner
 label: Link
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_classes_listing/config/install/field.field.paragraph.classes_listing.field_prgf_block.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_classes_listing/config/install/field.field.paragraph.classes_listing.field_prgf_block.yml
@@ -13,7 +13,7 @@ bundle: classes_listing
 label: Block
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value:
   -
     plugin_id: 'views_block:classes_listing-search_form'

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_featured_blogs/config/install/field.field.paragraph.featured_blogs.field_fblog_posts.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_featured_blogs/config/install/field.field.paragraph.featured_blogs.field_fblog_posts.yml
@@ -12,7 +12,7 @@ bundle: featured_blogs
 label: 'Blog Posts'
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_featured_content/config/install/field.field.paragraph.featured_content.field_prgf_fc_clm_description.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_featured_content/config/install/field.field.paragraph.featured_content.field_prgf_fc_clm_description.yml
@@ -13,7 +13,7 @@ bundle: featured_content
 label: 'Column description'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_gallery/config/install/field.field.paragraph.gallery.field_prgf_images.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_gallery/config/install/field.field.paragraph.gallery.field_prgf_images.yml
@@ -12,7 +12,7 @@ bundle: gallery
 label: Images
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_grid_content/config/install/field.field.paragraph.grid_columns.field_prgf_clm_class.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_grid_content/config/install/field.field.paragraph.grid_columns.field_prgf_clm_class.yml
@@ -11,7 +11,7 @@ bundle: grid_columns
 label: 'Icon Class'
 description: 'Provide a "Font Awesome" icon name, e.g. flag, car, info. Overrides image Icon.'
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_grid_content/config/install/field.field.paragraph.grid_columns.field_prgf_clm_headline.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_grid_content/config/install/field.field.paragraph.grid_columns.field_prgf_clm_headline.yml
@@ -11,7 +11,7 @@ bundle: grid_columns
 label: Headline
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_grid_content/config/install/field.field.paragraph.grid_columns.field_prgf_clm_icon.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_grid_content/config/install/field.field.paragraph.grid_columns.field_prgf_clm_icon.yml
@@ -12,7 +12,7 @@ bundle: grid_columns
 label: Icon
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_grid_content/config/install/field.field.paragraph.grid_columns.field_prgf_clm_link.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_grid_content/config/install/field.field.paragraph.grid_columns.field_prgf_clm_link.yml
@@ -13,7 +13,7 @@ bundle: grid_columns
 label: Link
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_grid_content/config/install/field.field.paragraph.grid_columns.field_prgf_grid_clm_description.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_grid_content/config/install/field.field.paragraph.grid_columns.field_prgf_grid_clm_description.yml
@@ -13,7 +13,7 @@ bundle: grid_columns
 label: Description
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_grid_content/config/install/field.field.paragraph.grid_content.field_grid_columns.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_grid_content/config/install/field.field.paragraph.grid_content.field_grid_columns.yml
@@ -14,7 +14,7 @@ bundle: grid_content
 label: Content
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_grid_content/config/install/field.field.paragraph.grid_content.field_prgf_grid_style.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_grid_content/config/install/field.field.paragraph.grid_content.field_prgf_grid_style.yml
@@ -13,7 +13,7 @@ bundle: grid_content
 label: Style
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_loc_finder/config/install/field.field.paragraph.prgf_location_finder.field_prgf_location_finder.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_loc_finder/config/install/field.field.paragraph.prgf_location_finder.field_prgf_location_finder.yml
@@ -13,7 +13,7 @@ bundle: prgf_location_finder
 label: 'Location finder'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value:
   -
     plugin_id: location_finder

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_promo_card/config/install/field.field.paragraph.promo_card.field_prgf_title.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_promo_card/config/install/field.field.paragraph.promo_card.field_prgf_title.yml
@@ -11,7 +11,7 @@ bundle: promo_card
 label: Title
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_simple_content/config/install/field.field.paragraph.simple_content.field_prgf_description.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_simple_content/config/install/field.field.paragraph.simple_content.field_prgf_description.yml
@@ -13,7 +13,7 @@ bundle: simple_content
 label: Content
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_small_banner/config/install/field.field.paragraph.small_banner.field_prgf_color.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_small_banner/config/install/field.field.paragraph.small_banner.field_prgf_color.yml
@@ -12,7 +12,7 @@ bundle: small_banner
 label: Color
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings:

--- a/modules/openy_features/openy_taxonomy/modules/openy_txnm_color/config/install/field.field.taxonomy_term.color.field_color.yml
+++ b/modules/openy_features/openy_taxonomy/modules/openy_txnm_color/config/install/field.field.taxonomy_term.color.field_color.yml
@@ -13,7 +13,7 @@ bundle: color
 label: Color
 description: 'The hex value for the color.'
 required: true
-translatable: false
+translatable: true
 default_value:
   -
     value: {  }


### PR DESCRIPTION
Enable all configs to be translatable by default

This came from YGH
Changes are visible only after translation and localization modules are enabled