### PR TITLE
[OYPD-279] Updating membership calculator styling

### DIFF
--- a/modules/custom/openy_calc/src/Form/CalcBlockForm.php
+++ b/modules/custom/openy_calc/src/Form/CalcBlockForm.php
@@ -208,7 +208,6 @@ class CalcBlockForm extends FormBase {
           'class' => [
             'btn',
             'btn-default',
-            'blue',
             'complete-registration',
             'pull-right',
           ],

--- a/modules/custom/openy_calc/templates/openy-calc-form-header.html.twig
+++ b/modules/custom/openy_calc/templates/openy-calc-form-header.html.twig
@@ -1,5 +1,5 @@
 <h2>{{ 'Find the Membership That’s Best For You'|t }}</h2>
-<p>{{ 'Your membership gives you access to all 13 YMCA branch locations!'|t }}</p>
+<p>{{ 'Your membership gives you access to all YMCA branch locations!'|t }}</p>
 <ul>
   {% for step in steps %}
   <li{% if step.active %} class="active"{% endif %}>

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_mbrshp_calc/config/install/image.style.node_mbrshp_calc_summary.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_mbrshp_calc/config/install/image.style.node_mbrshp_calc_summary.yml
@@ -10,4 +10,4 @@ effects:
     weight: 1
     data:
       width: 555
-      height: 200
+      height: 300

--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -5131,10 +5131,21 @@ a[href="#step2"] {
   display: table-cell;
   float: none;
   vertical-align: middle;
-  width: 34%;
 }
-#membership-calc-wrapper .nav-pills > li:last-child div {
-  padding-left: 25px;
+@media (min-width: 0) and (max-width: 30em) {
+  #membership-calc-wrapper .nav-pills > li {
+    margin-bottom: 5px;
+    display: block;
+    overflow: hidden;
+  }
+}
+@media (min-width: 30em) {
+  #membership-calc-wrapper .nav-pills > li {
+    width: 34%;
+  }
+  #membership-calc-wrapper .nav-pills > li:last-child div {
+    padding-left: 25px;
+  }
 }
 #membership-calc-wrapper .nav-pills > li div {
   text-decoration: none;
@@ -5143,13 +5154,14 @@ a[href="#step2"] {
   border-radius: 0;
   color: white;
   background-color: #92278f;
-  width: calc(100% - 30px);
   text-align: center;
   padding: 9px;
+  width: 90%;
 }
 @media (min-width: 30em) {
   #membership-calc-wrapper .nav-pills > li div {
     display: block;
+    width: calc(100% - 30px);
   }
 }
 #membership-calc-wrapper .nav-pills > li div:before {
@@ -5186,9 +5198,11 @@ a[href="#step2"] {
   position: relative;
   z-index: 3;
 }
-#membership-calc-wrapper .nav-pills > li .step-1,
-#membership-calc-wrapper .nav-pills > li .step-2 {
-  width: calc(100% - 15px);
+@media (min-width: 30em) {
+  #membership-calc-wrapper .nav-pills > li .step-1,
+  #membership-calc-wrapper .nav-pills > li .step-2 {
+    width: calc(100% - 15px);
+  }
 }
 #membership-calc-wrapper .nav-pills > li .step-2 .nav-pills__text {
   margin-left: 5px;
@@ -5198,6 +5212,9 @@ a[href="#step2"] {
 }
 #membership-calc-wrapper .nav-pills > li:first-child div:after, #membership-calc-wrapper .nav-pills > li.active div:after {
   border-left: 30px solid #5c2e91;
+}
+#membership-calc-wrapper .nav-pills li + li {
+  margin-left: 0;
 }
 
 .openy-map-wrapper {

--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -5029,6 +5029,10 @@ a[href="#step2"] {
   pointer-events: none;
 }
 
+#membership-calc-wrapper img {
+  height: auto;
+  max-width: 100%;
+}
 #membership-calc-wrapper .h1 {
   margin-bottom: 30px;
   padding-bottom: 4px;
@@ -5051,10 +5055,12 @@ a[href="#step2"] {
   content: ":";
 }
 #membership-calc-wrapper .membership-type label {
-  bottom: 30px;
+  border-bottom: 1px solid #333;
+  bottom: 0;
   display: block;
+  padding-bottom: 30px;
   position: absolute;
-  width: calc(100% - 30px);
+  width: 100%;
 }
 #membership-calc-wrapper .btn, #membership-calc-wrapper .button {
   line-height: 40px;
@@ -5065,18 +5071,12 @@ a[href="#step2"] {
 #membership-calc-wrapper .text-center {
   margin-top: 40px;
 }
+#membership-calc-wrapper .form-element-wrapper {
+  height: 100%;
+  position: relative;
+}
 #membership-calc-wrapper .form-element-wrapper .btn, #membership-calc-wrapper .form-element-wrapper .button {
   display: block;
-}
-#membership-calc-wrapper .form-element-wrapper .btn:after, #membership-calc-wrapper .form-element-wrapper .button:after {
-  content: "";
-  display: block;
-  width: 100%;
-  background-color: #333;
-  height: 1px;
-  position: absolute;
-  bottom: -30px;
-  left: 0;
 }
 #membership-calc-wrapper input[name="type"] {
   display: none;
@@ -5092,12 +5092,25 @@ a[href="#step2"] {
 #membership-calc-wrapper .col-sm-6 .contextual-region {
   position: static;
 }
-#membership-calc-wrapper .col-sm-6 .node--view-mode-calc-preview {
-  margin-bottom: 110px;
-}
 #membership-calc-wrapper .col-sm-6 .node--view-mode-calc-preview img {
   height: auto;
+  margin-bottom: 10px;
   width: 100%;
+}
+#membership-calc-wrapper input[type="radio"]:checked + .form-element-wrapper label .btn, #membership-calc-wrapper input[type="radio"]:checked + .form-element-wrapper label .button {
+  background-color: #5c2e91;
+  box-shadow: 0 0 5px #5c2e91;
+}
+#membership-calc-wrapper .pull-left,
+#membership-calc-wrapper .pull-right {
+  margin: 20px 0 10px 0;
+}
+#membership-calc-wrapper .node--type-membership.node--view-mode-calc-preview {
+  margin-bottom: 90px;
+}
+#membership-calc-wrapper .pull-right,
+#membership-calc-wrapper .complete-registration {
+  background-color: #5c2e91;
 }
 
 #membership-calc-wrapper .nav-pills {
@@ -5120,10 +5133,10 @@ a[href="#step2"] {
   vertical-align: middle;
   width: 34%;
 }
-#membership-calc-wrapper .nav-pills > li:last-child a {
+#membership-calc-wrapper .nav-pills > li:last-child div {
   padding-left: 25px;
 }
-#membership-calc-wrapper .nav-pills > li a {
+#membership-calc-wrapper .nav-pills > li div {
   text-decoration: none;
   position: relative;
   white-space: nowrap;
@@ -5132,13 +5145,14 @@ a[href="#step2"] {
   background-color: #92278f;
   width: calc(100% - 30px);
   text-align: center;
+  padding: 9px;
 }
 @media (min-width: 30em) {
-  #membership-calc-wrapper .nav-pills > li a {
+  #membership-calc-wrapper .nav-pills > li div {
     display: block;
   }
 }
-#membership-calc-wrapper .nav-pills > li a:before {
+#membership-calc-wrapper .nav-pills > li div:before {
   content: " ";
   display: block;
   width: 0;
@@ -5153,7 +5167,7 @@ a[href="#step2"] {
   left: 100%;
   z-index: 1;
 }
-#membership-calc-wrapper .nav-pills > li a:after {
+#membership-calc-wrapper .nav-pills > li div:after {
   content: " ";
   display: block;
   width: 0;
@@ -5168,21 +5182,21 @@ a[href="#step2"] {
   left: 100%;
   z-index: 2;
 }
-#membership-calc-wrapper .nav-pills > li a .nav-pills__text {
+#membership-calc-wrapper .nav-pills > li div .nav-pills__text {
   position: relative;
   z-index: 3;
 }
-#membership-calc-wrapper .nav-pills > li a[href="#step1"],
-#membership-calc-wrapper .nav-pills > li a[href="#step2"] {
+#membership-calc-wrapper .nav-pills > li .step-1,
+#membership-calc-wrapper .nav-pills > li .step-2 {
   width: calc(100% - 15px);
 }
-#membership-calc-wrapper .nav-pills > li a[href="#step2"] .nav-pills__text {
+#membership-calc-wrapper .nav-pills > li .step-2 .nav-pills__text {
   margin-left: 5px;
 }
-#membership-calc-wrapper .nav-pills > li.active a, #membership-calc-wrapper .nav-pills > li:first-child a {
+#membership-calc-wrapper .nav-pills > li.active div, #membership-calc-wrapper .nav-pills > li:first-child div {
   background-color: #5c2e91;
 }
-#membership-calc-wrapper .nav-pills > li:first-child a:after, #membership-calc-wrapper .nav-pills > li.active a:after {
+#membership-calc-wrapper .nav-pills > li:first-child div:after, #membership-calc-wrapper .nav-pills > li.active div:after {
   border-left: 30px solid #5c2e91;
 }
 

--- a/themes/openy_themes/openy_rose/openy_rose.theme
+++ b/themes/openy_themes/openy_rose/openy_rose.theme
@@ -145,12 +145,8 @@ function openy_rose_form_system_theme_settings_alter(array &$form, FormStateInte
 }
 
 /**
- * Implements template_preprocess_page().
+ * Implements hook_theme_suggestions_HOOK_alter().
  */
-function openy_rose_preprocess_page(array &$variables) {
-  $fid = theme_get_setting('openy_rose_footer_logo');
-  if (!empty($fid) && is_array($fid) && is_numeric(reset($fid))) {
-    $file = File::load(reset($fid));
-    $variables['footer_logo'] = $file->getFileUri();
-  }
+function openy_rose_theme_suggestions_radios_alter(array &$suggestions, array $variables, $hook) {
+  $suggestions[] = 'radios__' . $variables['element']['#name'];
 }

--- a/themes/openy_themes/openy_rose/openy_rose.theme
+++ b/themes/openy_themes/openy_rose/openy_rose.theme
@@ -145,6 +145,17 @@ function openy_rose_form_system_theme_settings_alter(array &$form, FormStateInte
 }
 
 /**
+ * Implements template_preprocess_page().
+ */
+function openy_rose_preprocess_page(array &$variables) {
+  $fid = theme_get_setting('openy_rose_footer_logo');
+  if (!empty($fid) && is_array($fid) && is_numeric(reset($fid))) {
+    $file = File::load(reset($fid));
+    $variables['footer_logo'] = $file->getFileUri();
+  }
+}
+
+/**
  * Implements hook_theme_suggestions_HOOK_alter().
  */
 function openy_rose_theme_suggestions_radios_alter(array &$suggestions, array $variables, $hook) {

--- a/themes/openy_themes/openy_rose/scss/modules/_membership.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_membership.scss
@@ -4,6 +4,10 @@ a[href="#step2"] {
 }
 
 #membership-calc-wrapper {
+  img {
+    height: auto;
+    max-width: 100%;
+  }
   .h1 {
     margin-bottom: 30px;
     padding-bottom: 4px;
@@ -25,10 +29,12 @@ a[href="#step2"] {
     }
   }
   .membership-type label {
-    bottom: 30px;
+    border-bottom: 1px solid #333;
+    bottom: 0;
     display: block;
+    padding-bottom: 30px;
     position: absolute;
-    width: calc(100% - 30px);
+    width: 100%;
   }
   .btn {
     line-height: 40px;
@@ -39,22 +45,11 @@ a[href="#step2"] {
   .text-center {
     margin-top: 40px;
   }
-  .fieldset-wrapper > div {
-    @include breakpoint($screen-xs) {
-      //display: flex;
-    }
-  }
-  .form-element-wrapper .btn {
-    display: block;
-    &:after {
-      content: "";
+  .form-element-wrapper {
+    height: 100%;
+    position: relative;
+    .btn {
       display: block;
-      width: 100%;
-      background-color: #333;
-      height: 1px;
-      position: absolute;
-      bottom: -30px;
-      left:0;
     }
   }
   input[name="type"] {
@@ -69,12 +64,27 @@ a[href="#step2"] {
       position: static;
     }
     .node--view-mode-calc-preview {
-      margin-bottom: 110px;
       img {
         height: auto;
+        margin-bottom: 10px;
         width: 100%;
       }
     }
+  }
+  input[type="radio"]:checked + .form-element-wrapper label .btn {
+    background-color: $purple;
+    box-shadow: 0 0 5px $purple;
+  }
+  .pull-left,
+  .pull-right {
+    margin: 20px 0 10px 0;
+  }
+  .node--type-membership.node--view-mode-calc-preview {
+    margin-bottom: 90px;
+  }
+  .pull-right,
+  .complete-registration {
+    background-color: $purple;
   }
 }
 
@@ -95,11 +105,11 @@ a[href="#step2"] {
     vertical-align: middle;
     width: 34%;
     &:last-child {
-      a {
+      div {
         padding-left: 25px;
       }
     }
-    a {
+    div {
       text-decoration: none;
       position: relative;
       white-space: nowrap;
@@ -108,6 +118,7 @@ a[href="#step2"] {
       background-color: #92278f;
       width: calc(100% - 30px);
       text-align: center;
+      padding: 9px;
       @include breakpoint($screen-xs) {
         display: block;
       }
@@ -146,21 +157,21 @@ a[href="#step2"] {
         z-index: 3;
       }
     }
-    a[href="#step1"],
-    a[href="#step2"] {
+    .step-1,
+    .step-2 {
       width: calc(100% - 15px);
     }
-    a[href="#step2"] {
+    .step-2 {
       .nav-pills__text {
         margin-left: 5px;
       }
     }
-    &.active a,
-    &:first-child a{
+    &.active div,
+    &:first-child div {
       background-color: $purple;
     }
-    &:first-child a:after,
-    &.active a:after {
+    &:first-child div:after,
+    &.active div:after {
       border-left: 30px solid $purple;;
     }
   }
@@ -219,7 +230,6 @@ a[href="#step2"] {
   label {
     max-width: calc(100% - 40px);
     margin-bottom: 0;
-
     vertical-align: middle;
   }
 }

--- a/themes/openy_themes/openy_rose/scss/modules/_membership.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_membership.scss
@@ -103,10 +103,17 @@ a[href="#step2"] {
     display: table-cell;
     float: none;
     vertical-align: middle;
-    width: 34%;
-    &:last-child {
-      div {
-        padding-left: 25px;
+    @include breakpoint(0 $screen-xs) {
+      margin-bottom: 5px;
+      display: block;
+      overflow: hidden;
+    }
+    @include breakpoint($screen-xs) {
+      width: 34%;
+      &:last-child {
+        div {
+          padding-left: 25px;
+        }
       }
     }
     div {
@@ -116,11 +123,12 @@ a[href="#step2"] {
       border-radius: 0;
       color: white;
       background-color: #92278f;
-      width: calc(100% - 30px);
       text-align: center;
       padding: 9px;
+      width: 90%;
       @include breakpoint($screen-xs) {
         display: block;
+        width: calc(100% - 30px);
       }
       &:before {
         content: " ";
@@ -159,7 +167,9 @@ a[href="#step2"] {
     }
     .step-1,
     .step-2 {
-      width: calc(100% - 15px);
+      @include breakpoint($screen-xs) {
+        width: calc(100% - 15px);
+      }
     }
     .step-2 {
       .nav-pills__text {
@@ -174,6 +184,9 @@ a[href="#step2"] {
     &.active div:after {
       border-left: 30px solid $purple;;
     }
+  }
+  li + li {
+    margin-left: 0;
   }
 }
 

--- a/themes/openy_themes/openy_rose/templates/custom/openy-calc-form-header.html.twig
+++ b/themes/openy_themes/openy_rose/templates/custom/openy-calc-form-header.html.twig
@@ -1,11 +1,11 @@
 <h2 class="h1">{{ 'Find the Membership That’s Best For You'|t }}</h2>
-<p class="description purple">{{ 'Your membership gives you access to all 13 YMCA branch locations!'|t }}</p>
+<p class="description purple">{{ 'Your membership gives you access to all YMCA branch locations!'|t }}</p>
 <div class="navbar">
   <div class="navbar-inner">
     <ul class="nav nav-pills">
       {% for step in steps %}
       <li{% if step.active %} class="active"{% endif %}>
-        <a href="#step{{ step.number }}" data-toggle="tab" data-step="{{ step.number }}"><span class="nav-pills__text">{{ step.number }}. {{ step.title }}</span></a>
+        <div class="step-{{ step.number }}" data-toggle="tab" data-step="{{ step.number }}"><span class="nav-pills__text">{{ step.number }}. {{ step.title }}</span></div>
       </li>
       {% endfor %}
     </ul>

--- a/themes/openy_themes/openy_rose/templates/custom/openy-calc-form-summary.html.twig
+++ b/themes/openy_themes/openy_rose/templates/custom/openy-calc-form-summary.html.twig
@@ -1,5 +1,5 @@
 <div class="calc-summary">
-  <div class="row">
+  <div class="row row-eq-height">
     <div class="col-md-6 col-sm-12 selected-branch calc-summary-col">
       <h2>{{ 'Your selected branch'|t }}</h2>
       <div class="selected-branch-map">{{ map }}</div>

--- a/themes/openy_themes/openy_rose/templates/form/radios--type.html.twig
+++ b/themes/openy_themes/openy_rose/templates/form/radios--type.html.twig
@@ -1,0 +1,13 @@
+{#
+/**
+ * @file
+ * Theme override for a 'radios' #type form element.
+ *
+ * Available variables
+ * - attributes: A list of HTML attributes for the wrapper element.
+ * - children: The rendered radios.
+ *
+ * @see template_preprocess_radios()
+ */
+#}
+<div{{ attributes.addClass('form-radios', 'row', 'row-eq-height') }}>{{ children }}</div>

--- a/themes/openy_themes/openy_rose/templates/node/node--branch--calc_summary.html.twig
+++ b/themes/openy_themes/openy_rose/templates/node/node--branch--calc_summary.html.twig
@@ -84,6 +84,7 @@ set classes = [
 
 {# Branch header #}
 <article{{ attributes }}>
+  <h3{{ title_attributes }}>{{ label }}</h3>
   <div{{ content_attributes.addClass('node__content') }}>
     {{ content }}
   </div>

--- a/themes/openy_themes/openy_rose/templates/node/node--membership--calc_summary.html.twig
+++ b/themes/openy_themes/openy_rose/templates/node/node--membership--calc_summary.html.twig
@@ -83,7 +83,7 @@
 <article{{ attributes.addClass(classes) }}>
   <div{{ content_attributes.addClass('node__content') }}>
     {{ content.field_mbrshp_image }}
-    <h4{{ title_attributes }}>{{ label }}</h4>
+    <h3{{ title_attributes }}>{{ label }}</h3>
     {{ content.field_mbrshp_description }}
   </div>
 </article>


### PR DESCRIPTION
- [x] Add the membership calculator paragraph to a page.
- [x] View the page and go through each step of the form.
- [x] Verify styling changes.

I did the following:
- remove 13 from the header
- changed the header links from a tags to divs.
- made membership types equal height
- added a highlight to the button when membership is selected (I experimented with highlighting different parts of the membership box and the whole box, but none looked good. The problem is the image and text are already full width without and padding. If I add padding it will disrupt the existing look.)
- made the map and image on the summary the same size and the columns equal height just in case
- made the size of the membership type name on the summary the same size as on the first step
- made the next and complete registration buttons purple so they are more prominent, and to be UX consistent with colors uses to show progression. (purple for everything active or selected)

The only thing I didn't do was adjust the header chevron on phone size. I wanted to get these changed looked at first. For the header I may have to do something different other than just keep shrinking. The header was not designed well to allow each piece to move from the others, like stacking.

![screen shot 2017-02-22 at 6 12 04 pm](https://cloud.githubusercontent.com/assets/1504038/23237644/489dd8e2-f92c-11e6-8d1d-80b6e93aabe3.png)

![screen shot 2017-02-22 at 6 12 21 pm](https://cloud.githubusercontent.com/assets/1504038/23237651/4d06df1e-f92c-11e6-881d-54c7abea471c.png)

![screen shot 2017-02-22 at 6 12 40 pm](https://cloud.githubusercontent.com/assets/1504038/23237656/52b2b0dc-f92c-11e6-8517-1505db7050b4.png)

