### PR TITLE
[OYPD-177] Adjusting menu column classes and positioning

### DIFF
--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -929,8 +929,25 @@ body {
   }
 }
 @media (min-width: 62em) and (max-width: 74.9375em) {
-  .row-level-2 > li:nth-child(3n + 1) {
+  .row-level-2 > li:nth-child(4n + 1) {
     clear: both;
+  }
+}
+@media (min-width: 74.9375em) {
+  .row-level-2 > li:nth-child(6n + 1) {
+    clear: both;
+  }
+  .row-level-2.menu-columns-1 {
+    left: auto;
+  }
+  .row-level-2.menu-columns-2 {
+    left: auto;
+  }
+  .row-level-2.menu-columns-3 {
+    left: auto;
+  }
+  .row-level-2.menu-columns-4, .row-level-2.menu-columns-5, .row-level-2.menu-columns-6 {
+    left: 10%;
   }
 }
 .section-icon {

--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -937,17 +937,11 @@ body {
   .row-level-2 > li:nth-child(6n + 1) {
     clear: both;
   }
-  .row-level-2.menu-columns-1 {
-    left: auto;
-  }
-  .row-level-2.menu-columns-2 {
-    left: auto;
-  }
-  .row-level-2.menu-columns-3 {
-    left: auto;
-  }
-  .row-level-2.menu-columns-4, .row-level-2.menu-columns-5, .row-level-2.menu-columns-6 {
-    left: 10%;
+}
+@media (min-width: 62em) {
+  .row-level-2 {
+    left: 0;
+    right: 0;
   }
 }
 .section-icon {

--- a/themes/openy_themes/openy_rose/scss/modules/_menu.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_menu.scss
@@ -307,9 +307,7 @@
 
 @include breakpoint($screen-desktop $screen-md-max) {
   .row-level-2 {
-
     > li {
-
       &:nth-child(4n + 1) {
         clear: both;
       }
@@ -324,20 +322,13 @@
         clear: both;
       }
     }
-    &.menu-columns-1 {
-      left: auto;
-    }
-    &.menu-columns-2 {
-      left: auto;
-    }
-    &.menu-columns-3 {
-      left: auto;
-    }
-    &.menu-columns-4,
-    &.menu-columns-5,
-    &.menu-columns-6 {
-      left: 10%;
-    }
+  }
+}
+
+@include breakpoint($screen-desktop) {
+  .row-level-2 {
+    left: 0;
+    right: 0;
   }
 }
 

--- a/themes/openy_themes/openy_rose/scss/modules/_menu.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_menu.scss
@@ -310,9 +310,33 @@
 
     > li {
 
-      &:nth-child(3n + 1) {
+      &:nth-child(4n + 1) {
         clear: both;
       }
+    }
+  }
+}
+
+@include breakpoint($screen-md-max) {
+  .row-level-2 {
+    > li {
+      &:nth-child(6n + 1) {
+        clear: both;
+      }
+    }
+    &.menu-columns-1 {
+      left: auto;
+    }
+    &.menu-columns-2 {
+      left: auto;
+    }
+    &.menu-columns-3 {
+      left: auto;
+    }
+    &.menu-columns-4,
+    &.menu-columns-5,
+    &.menu-columns-6 {
+      left: 10%;
     }
   }
 }

--- a/themes/openy_themes/openy_rose/templates/menu/menu--main.html.twig
+++ b/themes/openy_themes/openy_rose/templates/menu/menu--main.html.twig
@@ -65,13 +65,16 @@
 {% macro menu_links_level_2(items, attributes, menu_level) %}
   {% import _self as menus %}
   {% if items %}
-    {% set attributes = attributes.addClass(['row-level-2', 'row']) %}
-    <ul class="nav dropdown-menu row-level-2 row">
+    {% set col_size = items|length %}
+    {% set menu_size_class = 'menu-columns-' ~ col_size %}
+    {% set menu_size_class = col_size > 5 ? 'menu-columns-6' : menu_size_class %}
+    <ul class="nav dropdown-menu row-level-2 row {{ menu_size_class }}">
     {% for item in items %}
-      {% set ia = item.attributes %}
-      {% set ia = ia.addClass(['nav-level-3', 'col-md-4', 'col-lg-2', 'menu-item-' ~ item.title|clean_class]) %}
+      {% set lg = 12 // col_size %}
+      {% set lg = lg < 2 ? 2 : lg %}
+      {% set md = lg < 4 ? 3 : lg %}
+      {% set ia = item.attributes.addClass(['nav-level-3', 'col-md-' ~ md, 'col-lg-' ~ lg, 'menu-item-' ~ item.title|clean_class]) %}
       <li{{ ia }}>
-
         {% if item.below %}
           <a href="{{ item.url }}">
             <div class="section-icon"></div>

--- a/themes/openy_themes/openy_rose/templates/menu/menu--main.html.twig
+++ b/themes/openy_themes/openy_rose/templates/menu/menu--main.html.twig
@@ -65,15 +65,9 @@
 {% macro menu_links_level_2(items, attributes, menu_level) %}
   {% import _self as menus %}
   {% if items %}
-    {% set col_size = items|length %}
-    {% set menu_size_class = 'menu-columns-' ~ col_size %}
-    {% set menu_size_class = col_size > 5 ? 'menu-columns-6' : menu_size_class %}
-    <ul class="nav dropdown-menu row-level-2 row {{ menu_size_class }}">
+    <ul class="nav dropdown-menu row-level-2 row">
     {% for item in items %}
-      {% set lg = 12 // col_size %}
-      {% set lg = lg < 2 ? 2 : lg %}
-      {% set md = lg < 4 ? 3 : lg %}
-      {% set ia = item.attributes.addClass(['nav-level-3', 'col-md-' ~ md, 'col-lg-' ~ lg, 'menu-item-' ~ item.title|clean_class]) %}
+      {% set ia = item.attributes.addClass(['nav-level-3', 'col-md-3', 'col-lg-2', 'menu-item-' ~ item.title|clean_class]) %}
       <li{{ ia }}>
         {% if item.below %}
           <a href="{{ item.url }}">


### PR DESCRIPTION
- [x] Check the main menu drop down with different number of menu items so that there are multiple columns.

- [x] Check one column
- [x] Check two columns
- [x] Check three columns
- [x] Check four columns
- [x] Check five columns
- [x] Check six columns
- [x] Check seven columns

Here is one column

![screen shot 2017-03-07 at 3 41 34 pm](https://cloud.githubusercontent.com/assets/1504038/23710595/422cf10e-03eb-11e7-9f8c-f93b7b31a3c2.png)

This solution isn't done. I'm posting for visibility. There is still a problem with the positioning of the drop down. I don't think the original design for the menu took into count variable positioning of the drop down. It could be far left or far right, with only a couple top level items. This will still cause positioning problems.

I propose making the drop down full width, but that also has issues that should be discussed.