### PR TITLE
[OYPD-302] Demo alerts.

### DIFF
--- a/modules/openy_features/openy_demo_content/modules/openy_demo_nalert/config/install/migrate_plus.migration.node_alert.yml
+++ b/modules/openy_features/openy_demo_content/modules/openy_demo_nalert/config/install/migrate_plus.migration.node_alert.yml
@@ -1,0 +1,182 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - openy_node_alert
+      - openy_demo_nlanding
+id: openy_demo_node_alert
+migration_tags: {  }
+migration_group: openy_demo_nalert
+label: 'Import demo alert posts'
+source:
+  plugin: embedded_data
+  data_rows:
+    -
+      id: 1
+      title: 'OpenY Distribution'
+      description: |
+        <p>Visit the OpenY Distribution site.</p>
+      background_color: 12
+      text_color: 2
+      icon_color: 2
+      placement: 'header'
+      link_url: http://www.openymca.org
+      link_text: 'OpenY Distribution'
+    -
+      id: 2
+      title: 'About OpenY'
+      description: |
+        <p>Learn more about OpenY.</p>
+      background_color: 6
+      text_color: 1
+      icon_color: 4
+      placement: 'header'
+      link_url: http://www.openymca.org/about
+      link_text: 'About OpenY'
+    -
+      id: 3
+      title: 'OpenY Features'
+      description: |
+        <p>See everything OpenY has to offer.</p>
+      background_color: 4
+      text_color: 2
+      icon_color: 2
+      placement: 'header'
+      link_url: http://www.openymca.org/features
+      link_text: 'OpenY Features'
+    -
+      id: 4
+      title: 'OpenY FAQ'
+      description: |
+        <p>Have questions about OpenY? Visit the FAQ.</p>
+      background_color: 3
+      text_color: 2
+      icon_color: 2
+      placement: 'footer'
+      link_url: http://www.openymca.org/faq
+      link_text: 'OpenY FAQ'
+    -
+      id: 5
+      title: 'OpenY Community'
+      description: |
+        <p>Get more involved with the OpenY community.</p>
+      background_color: 15
+      text_color: 2
+      icon_color: 2
+      placement: 'footer'
+      link_url: http://www.openymca.org/community
+      link_text: 'OpenY Community'
+    -
+      id: 6
+      title: 'OpenY Partners'
+      description: |
+        <p>See who OpenY is working with on our partners page.</p>
+      background_color: 11
+      text_color: 2
+      icon_color: 2
+      placement: 'footer'
+      link_url: http://www.openymca.org/partners
+      link_text: 'OpenY Partners'
+    -
+      id: 7
+      title: 'Be a part of OpenY'
+      description: |
+        <p>OpenY is growing, be a part of it's success!</p>
+      background_color: 14
+      text_color: 12
+      icon_color: 12
+      placement: 'header'
+      link_url: http://www.openymca.org
+      link_text: 'Build OpenY'
+      reference_id: blog
+    -
+      id: 8
+      title: 'OpenY the foundation you need'
+      description: |
+        <p>OpenY is the site foundation you need!</p>
+      background_color: 7
+      text_color: 2
+      icon_color: 2
+      placement: 'footer'
+      link_url: http://www.openymca.org
+      link_text: 'Get OpenY Now'
+      reference_id: blog
+  ids:
+    id:
+      type: integer
+process:
+  title:
+    -
+      plugin: get
+      source: title
+  type:
+    -
+      plugin: default_value
+      default_value: alert
+  status:
+    -
+      plugin: default_value
+      default_value: 1
+  promote:
+    -
+      plugin: get
+      source: promote
+  uid:
+    -
+      plugin: default_value
+      default_value: 1
+
+  field_location_area:
+    -
+      plugin: migration
+      migration: openy_demo_taxonomy_term_area
+      source: area
+  field_content:
+      plugin: iterator
+      source: content_ids
+      process:
+        target_id:
+          plugin: migration
+          migration:
+            - openy_demo_prgf_blog_branch
+          source: content_id
+        target_revision_id:
+          plugin: migration
+          migration:
+            - openy_demo_prgf_blog_branch
+          source: content_id
+  field_alert_description/value: description
+  field_alert_description/format:
+    plugin: default_value
+    default_value: full_html
+  field_alert_color:
+    plugin: migration
+    migration: openy_demo_taxonomy_term_color
+    source: background_color
+  field_alert_text_color:
+    plugin: migration
+    migration: openy_demo_taxonomy_term_color
+    source: text_color
+  field_alert_icon_color:
+    plugin: migration
+    migration: openy_demo_taxonomy_term_color
+    source: icon_color
+  field_alert_place: placement
+  field_alert_link/uri: link_url
+  field_alert_link/title: link_text
+  field_alert_belongs/target_id:
+    -
+      plugin: migration
+      migration: openy_demo_node_landing
+      source: reference_id
+    -
+      plugin: default_value
+      default_value: NULL
+destination:
+  plugin: 'entity:node'
+migration_dependencies:
+  required:
+    - openy_demo_taxonomy_term_color
+    - openy_demo_node_landing
+  optional: {  }

--- a/modules/openy_features/openy_demo_content/modules/openy_demo_nalert/config/install/migrate_plus.migration_group.openy_demo_nalert.yml
+++ b/modules/openy_features/openy_demo_content/modules/openy_demo_nalert/config/install/migrate_plus.migration_group.openy_demo_nalert.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: openy_demo_nalert
+label: 'Branch'
+description: 'Imports alert demo content.'
+module: openy_demo_nalert

--- a/modules/openy_features/openy_demo_content/modules/openy_demo_nalert/openy_demo_nalert.info.yml
+++ b/modules/openy_features/openy_demo_content/modules/openy_demo_nalert/openy_demo_nalert.info.yml
@@ -1,0 +1,10 @@
+name: 'OpenY Demo Node Alert'
+description: 'OpenY demo node alert.'
+type: module
+core: 8.x
+dependencies:
+  - migrate
+  - migrate_plus
+  - migrate_tools
+  - openy_demo_tcolor
+  - openy_demo_nlanding

--- a/openy.install
+++ b/openy.install
@@ -128,3 +128,19 @@ function openy_update_8008() {
     'block.block.useraccountmenu',
   ]);
 }
+
+/**
+ * Add Demo alerts.
+ */
+function openy_update_8009() {
+  if (\Drupal::service('module_handler')->moduleExists('openy_migrate')) {
+    // Enable module.
+    \Drupal::service('module_installer')->install([
+      'openy_demo_nalert',
+    ], TRUE);
+
+    // Run openy_demo_node_alert migration.
+    $importer = \Drupal::service('openy_migrate.importer');
+    $importer->import('openy_demo_node_alert');
+  }
+}

--- a/openy.profile
+++ b/openy.profile
@@ -61,6 +61,11 @@ function openy_demo_content_configs_map($key = NULL) {
         'openy_demo_block_content_footer',
       ],
     ],
+    'alerts' => [
+      'openy_demo_nalert' => [
+        'openy_demo_node_alert',
+      ],
+    ],
     'branches' => [
       'openy_demo_nbranch' => [
         'openy_demo_node_branch',

--- a/src/Form/ContentSelectForm.php
+++ b/src/Form/ContentSelectForm.php
@@ -24,6 +24,7 @@ class ContentSelectForm extends FormBase {
     $form['#title'] = $this->t('Content');
 
     $options = [
+      'alerts' => $this->t('Demo Alerts'),
       'branches' => $this->t('Demo Branches'),
       'camps' => $this->t('Demo Camps'),
       'blog' => $this->t('Demo Blog Posts'),


### PR DESCRIPTION
Jira https://propeople-us.atlassian.net/browse/OYPD-302
D.o https://www.drupal.org/node/2859411

Steps to review:
- [x] Visit homepage
- [x] See 3 header alerts & 3 footer alerts (in a slider)
- [x] Visit /blog
- [x] See an additional header and footer alert in separate view below the global alerts.

## Two tests fail.
1. SEEMINGLY UNRELATED Feature: Latest Blogs Paragraphs "Scenario: Paste latest blog post (branch)", fails on `And I should see "Type: Latest blog posts (branch)" in the "content_area" ` with the message `(The text 'Type: Latest blog posts (branch)' was not found in the region 'content_area' on the page http://openy-dev.ffwua.com/build720/node/1/edit)` This is demo content and should probably not be relied on for tests.
![image](https://cloud.githubusercontent.com/assets/5031409/23778648/83c90926-0509-11e7-8457-0089f996d798.png)
2. UNRELATED Feature: Static Paragraphs "Scenario: Create Small Banner", fails on `When I press "Add Small Banner" in the "header_area" ` with the message `(The button 'Add Small Banner' was not found in the region 'header_area' on the page http://openy-dev.ffwua.com/build709/node/add/landing_page)`. This test failure was missed on https://github.com/ymcatwincities/openy/pull/215 for https://propeople-us.atlassian.net/browse/OYPD-293 which removed the small banner from the header content field options.
![image](https://cloud.githubusercontent.com/assets/5031409/23721458/d51bc570-040f-11e7-8c60-8f18469202f6.png)