### PR TITLE
[OYPD-20] Analytics - Google Analytics

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -160,6 +160,7 @@
         "drupal/slick_views": "1.0-rc2",
         "drupal/libraries": "3.x-dev",
         "drupal/datalayer": "1.x-dev",
-        "drupal/optimizely": "1.2"
+        "drupal/optimizely": "1.2",
+        "drupal/google_analytics": "^2.1"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1986,6 +1986,58 @@
             }
         },
         {
+            "name": "drupal/google_analytics",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupal.org/project/google_analytics",
+                "reference": "8.x-2.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/google_analytics-8.x-2.1.zip",
+                "reference": null,
+                "shasum": "9b5c76802ca28d5072bb9bb552bbfeb660b0734a"
+            },
+            "require": {
+                "drupal/core": "~8.0"
+            },
+            "require-dev": {
+                "drupal/php": "*",
+                "drupal/token": "*"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-2.1",
+                    "datestamp": "1470845408"
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "hass",
+                    "homepage": "https://www.drupal.org/u/hass"
+                },
+                {
+                    "name": "See other contributors",
+                    "homepage": "https://www.drupal.org/node/49388/committers"
+                }
+            ],
+            "description": "Allows your site to be tracked by Google Analytics by adding a Javascript tracking code to every page.",
+            "homepage": "https://www.drupal.org/project/google_analytics",
+            "support": {
+                "source": "http://git.drupal.org/project/google_analytics.git",
+                "issues": "https://www.drupal.org/project/issues/google_analytics"
+            }
+        },
+        {
             "name": "drupal/inline_entity_form",
             "version": "1.0.0-beta1",
             "source": {

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -42,6 +42,7 @@ projects[slick] = 1.0-rc1
 projects[slick_views] = 1.0-rc2
 projects[blazy] = 1.0-rc1
 projects[geolocation] = 1.9
+projects[google_analytics] : 2.1
 projects[confi][subdir] = contrib
 projects[confi][version] = 1.3
 projects[confi][patch][] = "https://www.drupal.org/files/issues/confi-drush-call-hooks-from-disabled-2856910.patch"

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -42,7 +42,7 @@ projects[slick] = 1.0-rc1
 projects[slick_views] = 1.0-rc2
 projects[blazy] = 1.0-rc1
 projects[geolocation] = 1.9
-projects[google_analytics] : 2.1
+projects[google_analytics] = 2.1
 projects[confi][subdir] = contrib
 projects[confi][version] = 1.3
 projects[confi][patch][] = "https://www.drupal.org/files/issues/confi-drush-call-hooks-from-disabled-2856910.patch"

--- a/openy.info.yml
+++ b/openy.info.yml
@@ -68,6 +68,7 @@ dependencies:
   - blazy
   - blazy_ui
   - geolocation
+  - google_analytics
   # OpenY features.
   - openy_media_image
   - openy_media_document

--- a/openy.install
+++ b/openy.install
@@ -159,3 +159,12 @@ function openy_update_8010() {
   $importer->import('openy_demo_node_landing');
   $importer->import('openy_demo_node_membership');
 }
+
+/**
+ * Enable Google Analytics module.
+ */
+function openy_update_8011() {
+  // Enable module.
+  \Drupal::service('module_installer')->install(['google_analytics']);
+}
+

--- a/src/Form/ThirdPartyServicesForm.php
+++ b/src/Form/ThirdPartyServicesForm.php
@@ -74,6 +74,23 @@ class ThirdPartyServicesForm extends FormBase {
   /**
    * {@inheritdoc}
    */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    parent::validateForm($form, $form_state);
+
+    // Trim some text values.
+    $form_state->setValue('google_analytics_account', trim($form_state->getValue('google_analytics_account')));
+
+    // Replace all type of dashes (n-dash, m-dash, minus) with normal dashes.
+    $form_state->setValue('google_analytics_account', str_replace(['–', '—', '−'], '-', $form_state->getValue('google_analytics_account')));
+
+    if (!preg_match('/^UA-\d+-\d+$/', $form_state->getValue('google_analytics_account'))) {
+      $form_state->setErrorByName('google_analytics_account', t('A valid Google Analytics Web Property ID is case sensitive and formatted like UA-xxxxxxx-yy.'));
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     // Save Google Maps API Key.
     $config_factory = \Drupal::service('config.factory');

--- a/src/Form/ThirdPartyServicesForm.php
+++ b/src/Form/ThirdPartyServicesForm.php
@@ -84,9 +84,11 @@ class ThirdPartyServicesForm extends FormBase {
     $geo_loc_config->save();
 
     // Set Google Analytics Account TODO: Add other values?
-    $ga_config = $config_factory->getEditable('google_analytics.settings');
-    $ga_config->set('account', $form_state->getValue('google_analytics_account'));
-    $ga_config->save();
+    if (!empty($form_state->getValue('google_analytics_account'))) {
+      $ga_config = $config_factory->getEditable('google_analytics.settings');
+      $ga_config->set('account', $form_state->getValue('google_analytics_account'));
+      $ga_config->save();
+    }
 
     $optimizely_id = $form_state->getValue('optimizely_id');
     $optimizely_config->set('optimizely_id', $optimizely_id);

--- a/src/Form/ThirdPartyServicesForm.php
+++ b/src/Form/ThirdPartyServicesForm.php
@@ -77,14 +77,20 @@ class ThirdPartyServicesForm extends FormBase {
   public function validateForm(array &$form, FormStateInterface $form_state) {
     parent::validateForm($form, $form_state);
 
-    // Trim some text values.
-    $form_state->setValue('google_analytics_account', trim($form_state->getValue('google_analytics_account')));
+    if (!empty(trim($form_state->getValue('google_analytics_account')))) {
+      // Trim some text values.
+      $form_state->setValue('google_analytics_account', trim($form_state->getValue('google_analytics_account')));
 
-    // Replace all type of dashes (n-dash, m-dash, minus) with normal dashes.
-    $form_state->setValue('google_analytics_account', str_replace(['–', '—', '−'], '-', $form_state->getValue('google_analytics_account')));
+      // Replace all type of dashes (n-dash, m-dash, minus) with normal dashes.
+      $form_state->setValue('google_analytics_account', str_replace([
+        '–',
+        '—',
+        '−'
+      ], '-', $form_state->getValue('google_analytics_account')));
 
-    if (!preg_match('/^UA-\d+-\d+$/', $form_state->getValue('google_analytics_account'))) {
-      $form_state->setErrorByName('google_analytics_account', t('A valid Google Analytics Web Property ID is case sensitive and formatted like UA-xxxxxxx-yy.'));
+      if (!preg_match('/^UA-\d+-\d+$/', $form_state->getValue('google_analytics_account'))) {
+        $form_state->setErrorByName('google_analytics_account', t('A valid Google Analytics Web Property ID is case sensitive and formatted like UA-xxxxxxx-yy.'));
+      }
     }
   }
 

--- a/src/Form/ThirdPartyServicesForm.php
+++ b/src/Form/ThirdPartyServicesForm.php
@@ -5,6 +5,7 @@ namespace Drupal\openy\Form;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Database\Database;
+use Drupal\Core\Url;
 
 /**
  * Defines a form for setting Google Maps API Key during install.
@@ -26,6 +27,8 @@ class ThirdPartyServicesForm extends FormBase {
     $config_factory = \Drupal::service('config.factory');
     // Get Google Maps API settings container.
     $geo_loc_config = $config_factory->get('geolocation.settings');
+    // Get Google Analytics Account settings container.
+    $ga_config = $config_factory->get('google_analytics.settings');
     // Get Optimizely settings container.
     $optimizely_config = $config_factory->get('optimizely.settings');
 
@@ -37,6 +40,16 @@ class ThirdPartyServicesForm extends FormBase {
       '#title' => $this->t('Google Maps API key'),
       '#default_value' => $geo_loc_config->get('google_map_api_key'),
       '#description' => $this->t('Google Maps requires users to use a valid API key. Using the <a href="https://console.developers.google.com/apis" target="_blank">Google API Manager</a>, you can enable the <em>Google Maps JavaScript API</em>. That will create (or reuse) a <em>Browser key</em> which you can paste here.'),
+    ];
+
+    // Google Analytics Account ID.
+    $form['google_analytics_account'] = [
+      '#default_value' => $ga_config->get('account'),
+      '#description' => $this->t('This ID is unique to each site you want to track separately, and is in the form of UA-xxxxxxx-yy. To get a Web Property ID, <a href=":analytics">register your site with Google Analytics</a>, or if you already have registered your site, go to your Google Analytics Settings page to see the ID next to every site profile. <a href=":webpropertyid">Find more information in the documentation</a>.', [':analytics' => 'http://www.google.com/analytics/', ':webpropertyid' => Url::fromUri('https://developers.google.com/analytics/resources/concepts/gaConceptsAccounts', ['fragment' => 'webProperty'])->toString()]),
+      '#maxlength' => 20,
+      '#placeholder' => 'UA-',
+      '#title' => $this->t('Google Analytics Web Property ID'),
+      '#type' => 'textfield',
     ];
 
     // Optimizely ID Number.
@@ -69,6 +82,11 @@ class ThirdPartyServicesForm extends FormBase {
 
     $geo_loc_config->set('google_map_api_key', $form_state->getValue('google_map_api_key'));
     $geo_loc_config->save();
+
+    // Set Google Analytics Account TODO: Add other values?
+    $ga_config = $config_factory->getEditable('google_analytics.settings');
+    $ga_config->set('account', $form_state->getValue('google_analytics_account'));
+    $ga_config->save();
 
     $optimizely_id = $form_state->getValue('optimizely_id');
     $optimizely_config->set('optimizely_id', $optimizely_id);


### PR DESCRIPTION
Adds Google Analytics module to the installation profile, and adds a form field within the installation process for providing the Google Analytics account ID. If provided, Google Analytics will be enabled with defaults, sitewide, using the provided account ID.

To review, install from scratch using a new project build. Ensure Google Analytics account ID field is provided on the 3rd party services form page, and GA script with provided account ID is rendered once installation is complete.

https://www.drupal.org/node/2865146