### PR TITLE
[OYPD-346] Changing membership summary image to not crop height

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_mbrshp_calc/config/install/image.style.node_mbrshp_calc_summary.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_mbrshp_calc/config/install/image.style.node_mbrshp_calc_summary.yml
@@ -4,10 +4,11 @@ dependencies: {  }
 name: node_mbrshp_calc_summary
 label: 'Node mbrshp calculator summary'
 effects:
-  76d79abc-d228-4ba8-8b03-db34526dc725:
-    uuid: 76d79abc-d228-4ba8-8b03-db34526dc725
-    id: image_scale_and_crop
-    weight: 1
+  7b904298-ddbc-43d2-a97a-592895914c8d:
+    uuid: 7b904298-ddbc-43d2-a97a-592895914c8d
+    id: image_scale
+    weight: 2
     data:
-      width: 555
+      width: null
       height: 300
+      upscale: true


### PR DESCRIPTION
- [x] Go through the steps for the membership calculator
- [x] On the summary page, check the image. It should not get cut off.

I played with leaving the image set left or centering it. It looks better left if we are mostly using these  mostly white images. Especially, because all text is left. When centered the image starts looking pushed too far to the right.

![screen shot 2017-03-27 at 8 37 23 pm](https://cloud.githubusercontent.com/assets/1504038/24383828/6f26d1b0-132d-11e7-828a-68aef4a77c1d.png)
