### PR TITLE
[OYPD-340] Removing gap between camp menu items

### DIFF
--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -5162,7 +5162,7 @@ a[href="#step2"] {
 .camp-menu__item {
   height: 50px;
   height: 5rem;
-  display: inline-block;
+  float: left;
   list-style: none;
 }
 .camp-menu__item a {

--- a/themes/openy_themes/openy_rose/scss/modules/_camp-menu.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_camp-menu.scss
@@ -58,7 +58,7 @@
 
   &__item {
     @include rem(height, 50px);
-    display: inline-block;
+    float: left;
     list-style: none;
 
     a {


### PR DESCRIPTION
- [x] Visit camp landing page
- [x] Verify gap between camp menu items is gone.

![screen shot 2017-03-27 at 9 10 26 pm](https://cloud.githubusercontent.com/assets/1504038/24384493/2ec88d52-1332-11e7-8745-b00c4e47e9e1.png)
