### PR TITLE
[OYPD-354] Disconnect Behat tests from demo content.

### DIFF
--- a/modules/custom/openy_map/js/map.js
+++ b/modules/custom/openy_map/js/map.js
@@ -554,14 +554,16 @@
       var data = settings.openyMap;
       var map = new Drupal.openyMap();
 
-      var i = 0;
       $('.locations-list .node--view-mode-teaser').each(function() {
         var $self = $(this);
-        if (typeof(data[i]) !== 'undefined') {
-          data[i].element = {};
-          data[i].element = $self.parent();
-        }
-        i++;
+        for (var i = 0; i < data.length; i++) {
+          if (typeof(data[i]) !== 'undefined' && $self.find("h2")[0].innerText !== 'undefined') {
+            if ($self.find("h2")[0].innerText == data[i]["name"]){
+              data[i].element = {};
+              data[i].element = $self.parent();
+            }
+          }
+        };
       });
 
       $('.openy-map-canvas', context).once().each(function () {

--- a/tests/features/bootstrap/OpenyDrupalContext.php
+++ b/tests/features/bootstrap/OpenyDrupalContext.php
@@ -30,7 +30,7 @@ class OpenyDrupalContext extends RawDrupalContext implements SnippetAcceptingCon
    * | my node key | My title | 1      | 2014-10-17 8:00am | text key             |
    * | ...         | ...      | ...    | ...               | ...                  |
    *
-   * @Given I create nodes :bundle content:
+   * @Given I create :bundle content:
    */
   public function iCreateNodes($bundle, TableNode $table) {
     $this->createNodes($bundle, $table->getHash());
@@ -87,7 +87,7 @@ class OpenyDrupalContext extends RawDrupalContext implements SnippetAcceptingCon
    * | Blue | Blue | 0000FF       | text key              |
    * | ...  | ...  | ...          | ...                   |
    *
-   * @Given I create :entity_type of type :bundle with key for reference:
+   * @Given I create :entity_type of type :bundle:
    */
   public function iCreateEntity($entity_type, $bundle, TableNode $table) {
     $this->createEntities($entity_type, $bundle, $table->getHash());
@@ -100,7 +100,7 @@ class OpenyDrupalContext extends RawDrupalContext implements SnippetAcceptingCon
    * | field_color           | 0000FF   | ... |
    * | field_reference_name  | text key | ... |
    *
-   * @Given I create large :entity_type of type :bundle with key for reference:
+   * @Given I create large :entity_type of type :bundle:
    */
   public function iCreateLargeEntity($entity_type, $bundle, TableNode $table) {
     $this->createEntities($entity_type, $bundle, $this->getColumnHashFromRows($table));

--- a/tests/features/camp_menu_integration/camp_menu_on_camp_and_landing_page.feature
+++ b/tests/features/camp_menu_integration/camp_menu_on_camp_and_landing_page.feature
@@ -5,6 +5,7 @@ Feature: Camp menu on camp and landing page
   Background: Log in
     Given I am logged in as a user with the "Administrator" role
 
+  # todo Refactor
   # Since no data persists between scenarios these steps had to be run under one.
   Scenario: Camp menu on camp and landing page
     # Create Landing page with camp menu

--- a/tests/features/content_types/blog_post.feature
+++ b/tests/features/content_types/blog_post.feature
@@ -2,15 +2,28 @@
 Feature: Blog Content type
   As Admin I want to make sure that Blog content type is OK
 
+  Background: Add background content as needed
+    Given I create "taxonomy_term" of type "blog_category":
+      | name               |
+      | BEHAT CATEGORY ONE |
+    And I create large branch content:
+      | title                               | BEHAT BRANCH 01 |
+      | field_location_address:country_code | US              |
+      | :address_line1                      | Main road 10    |
+      | :locality                           | Seattle         |
+      | :administrative_area                | WA              |
+      | :postal_code                        | 98101           |
+      | field_location_coordinates:lat      | 47.293433       |
+      | :lng                                | -122.238717     |
+      | field_location_phone                | +1234567890     |
+
   Scenario: Create basic blog and check fields
     Given I am logged in as a user with the Administrator role
-    And I create a branch
-    And I create a "Category One" term in the "Blog Category" taxonomy
     When I go to "/node/add/blog"
     And I fill in "Title" with "From OpenY Automation Blogger"
-    And I select "Test Branch" from "Location"
+    And I select "BEHAT BRANCH 01" from "Location"
     And I fill in the following:
-      | Category | Category One |
+      | Category    | BEHAT CATEGORY ONE                          |
       | Description | This could be a draft for a wonderful post. |
     When I press "Save and publish"
     Then I should see the message "Blog Post From OpenY Automation Blogger has been created."

--- a/tests/features/content_types/program_and_subcategory.feature
+++ b/tests/features/content_types/program_and_subcategory.feature
@@ -3,32 +3,37 @@ Feature: Program and Subcategory pages
   As Admin I want to make sure that Program and Subcategory can be created.
   And I should see paragraph with Subcategory teaser on Program page.
 
+  Background: Create necessary content for tests
+    Given I create taxonomy_term of type color:
+      | KEY     | name          | field_color |
+      | magenta | Behat Magenta | FF00FF      |
+
   Scenario: Create basic program and subcategory and check fields
     Given I am logged in as a user with the "Editor" role
     And I create a color term
     When I go to "/node/add/program"
-    And I fill in "Title" with "Fitness"
-    And I select "Magenta" from "Color"
+    And I fill in "Title" with "Behat Fitness"
+    And I select "Behat Magenta" from "Color"
     And I fill in the following:
       | Description | Program suggests fitness classes for all ages. |
     And I press "Add Categories Listing" in the "content_area"
     When I press "Save and publish"
-    Then I should see the message "Program Fitness has been created."
+    Then I should see the message "Program Behat Fitness has been created."
 
     Given I am logged in as a user with the "Editor" role
     When I go to "/node/add/program_subcategory"
-    And I fill in "Title" with "Personal Training"
-    And I fill in "Program" with "Fitness"
-    And I select "Magenta" from "Color"
+    And I fill in "Title" with "Behat Personal Training"
+    And I fill in "Program" with "Behat Fitness"
+    And I select "Behat Magenta" from "Color"
     And I fill media field "edit-field-category-image-target-id" with "media:1"
     And I fill in the following:
       | Description | Program suggests fitness classes for all ages. |
     When I press "Save and publish"
-    Then I should see the message "Program Subcategory Personal Training has been created."
+    Then I should see the message "Program Subcategory Behat Personal Training has been created."
 
-    When I go to "/programs/fitness"
-    Then I see the heading "Fitness"
-    And I should see the heading "Personal Training"
+    When I go to "/programs/behat-fitness"
+    Then I see the heading "Behat Fitness"
+    And I should see the heading "Behat Personal Training"
     And I should see a ".subprogram-listing-item img" element
     And I should see "Program suggests fitness classes for all ages."
     And I should see the link "Open category"

--- a/tests/features/custom_pages/location_finder.feature
+++ b/tests/features/custom_pages/location_finder.feature
@@ -2,40 +2,71 @@
 Feature: Location finder
   I want to make sure that Location Finder Page shows new branches. Given some content exists.
 
+  Background: Create necessary content for tests
+    Given I create branch content:
+      | title                |
+      | Behat Branch 01 YMCA |
+      | Behat Branch 02 YMCA |
+      | Behat Branch 03 YMCA |
+      | Behat Branch 04 YMCA |
+    And I create large camp content:
+      | title                               | Behat Camp 01 | Behat Camp 02 | Behat Camp 03 |
+      | field_camp_menu_links:uri           | internal:/    | internal:/    | internal:/    |
+      | :title                              | homepage      | homepage      | homepage      |
+      | field_location_address:country_code | US            | US            | US            |
+      | :address_line1                      | Main road 10  | Main road 10  | Main road 10  |
+      | :locality                           | Seattle       | Seattle       | Seattle       |
+      | :administrative_area                | WA            | WA            | WA            |
+      | :postal_code                        | 98101         | 98101         | 98101         |
+      | field_location_coordinates:lat      | 47.293433     | 47.293433     | 47.293433     |
+      | :lng                                | -122.238717   | -122.238717   | -122.238717   |
+      | field_location_phone                | +1234567890   | +1234567890   | +1234567890   |
+    Then I create paragraph of type prgf_location_finder_filters:
+      | KEY            |
+      | finder_filters |
+    And I create paragraph of type prgf_location_finder:
+      | KEY             |
+      | location_finder |
+    And I create landing_page content:
+      | KEY             | title           | field_header_content | field_content   |
+      | behat_locations | Behat Locations | finder_filters       | location_finder |
+
   @javascript
   Scenario: Make sure map element is present
-    When I go to "/locations"
+    When I go to "/behat-locations"
     Then I should see a ".map" element
     And I should not see a ".gm-err-message" element
 
   @javascript
   Scenario: Check locations displayed by default
-    When I go to "/locations"
-    And I should see "Downtown YMCA"
-    And I should see "East YMCA"
-    And I should see "South YMCA"
-    And I should see "West YMCA"
+    When I go to "/behat-locations"
+    And I should see "Behat Branch 01 YMCA"
+    And I should see "Behat Branch 02 YMCA"
+    And I should see "Behat Branch 03 YMCA"
+    And I should see "Behat Branch 04 YMCA"
 
   @javascript
   Scenario: Check camps displayed based on filters
-    When I go to "/locations"
+    When I go to "/behat-locations"
     And I check "Camps"
     And I uncheck "YMCA"
-    Then I should see "Camp Colman"
-    And I should see "Camp Orkila"
-    And I should see "Camp Terry"
+    And I wait 3 seconds
+    Then I should see "Behat Camp 01"
+    And I should see "Behat Camp 02"
+    And I should see "Behat Camp 03"
 
   Scenario: Check distance filters are available
-    When I go to "/locations"
+    When I go to "/behat-locations"
     And I should see a "input[placeholder^='Enter ZIP']" element
     And I should see a "select.distance_limit" element
 
   @javascript
   Scenario: Check unpublished
     Given "branch" content:
-      |title         | status |
-      |Hidden branch |   0    |
-    When I go to "/locations"
+      | title         | status |
+      | Hidden branch |   0    |
+    When I go to "/behat-locations"
+    And I wait 3 seconds
     Then I should not see "Hidden branch"
 
   @javascript
@@ -43,15 +74,17 @@ Feature: Location finder
     Given "branch" content:
       | title      | field_location_state |
       | New branch | 1                    |
-    When I go to "/locations"
+    When I go to "/behat-locations"
+    And I wait 3 seconds
     Then I should see "coming soon!"
 
   @javascript
   Scenario: Check facilities
     Given "facility" content:
-      | title |
+      | title        |
       | Facility One |
-    When I go to "/locations"
+    When I go to "/behat-locations"
     And I check "Facilities"
     And I uncheck "Camps"
+    And I wait 3 seconds
     Then I should see "Facility One"

--- a/tests/features/paragraphs/latest_blog_posts_paragraphs.feature
+++ b/tests/features/paragraphs/latest_blog_posts_paragraphs.feature
@@ -1,4 +1,4 @@
-@openy @api @testthis
+@openy @api
 Feature: Latest Blogs Paragraphs
   Check that Latest Blog Posts paragraphs output other nodes based on some rules
 

--- a/tests/features/paragraphs/latest_blog_posts_paragraphs.feature
+++ b/tests/features/paragraphs/latest_blog_posts_paragraphs.feature
@@ -1,62 +1,94 @@
-@openy @api
+@openy @api @testthis
 Feature: Latest Blogs Paragraphs
   Check that Latest Blog Posts paragraphs output other nodes based on some rules
 
   Background: Log in
     Given I am logged in as a user with the "Editor" role
+    And I create "taxonomy_term" of type "blog_category":
+      | name               |
+      | BEHAT CATEGORY ONE |
+    And I create paragraph of type latest_blog_posts:
+      | KEY          |
+      | latest_blogs |
+    And I create paragraph of type latest_blog_posts_branch:
+      | KEY            |
+      | branch_blogs   |
+      | branch_blogs_2 |
+    And I create paragraph of type latest_blog_posts_camp:
+      | KEY        |
+      | camp_blogs |
+    And I create large branch content:
+      | KEY                                 | behat_branch_01 | behat_branch_02 |
+      | title                               | BEHAT BRANCH 01 | BEHAT BRANCH 02 |
+      | field_location_address:country_code | US              | US              |
+      | :address_line1                      | Main road 10    | Main road 10    |
+      | :locality                           | Seattle         | Seattle         |
+      | :administrative_area                | WA              | WA              |
+      | :postal_code                        | 98101           | 98101           |
+      | field_location_coordinates:lat      | 47.293433       | 47.293433       |
+      | :lng                                | -122.238717     | -122.238717     |
+      | field_location_phone                | +1234567890     | +1234567890     |
+      | field_content                       | branch_blogs    | branch_blogs_2  |
+    And I create large camp content:
+      | KEY                                 | behat_camp_01      |
+      | title                               | BEHAT CAMP 01      |
+      | field_camp_menu_links:uri           | internal:/register |
+      | :title                              | Registration       |
+      | field_location_address:country_code | US                 |
+      | :address_line1                      | Main road 10       |
+      | :locality                           | Seattle            |
+      | :administrative_area                | WA                 |
+      | :postal_code                        | 98101              |
+      | field_location_coordinates:lat      | 47.293433          |
+      | :lng                                | -122.238717        |
+      | field_location_phone                | +1234567890        |
+      | field_content                       | camp_blogs         |
+    And I create blog content:
+      | title                                          | field_blog_location | promote |
+      | Behat Start training now for the Y Run         | behat_branch_01     | 1       |
+      | Behat Grown-up fun in Adult Sports Leagues     | behat_branch_01     | 1       |
+      | Behat Mood-boosting foods                      | behat_branch_01     | 1       |
+      | Behat Mango-Avocado Salsa                      | behat_branch_02     | 1       |
+      | Behat Add a water workout to your routine      | behat_branch_02     | 1       |
+      | Behat Don’t let summer sneak up on your family | behat_camp_01       | 1       |
+      | Behat Add a water workout to your routine      | behat_camp_01       | 1       |
+      | Behat Nourish yourself with healthy fats       | behat_camp_01       | 1       |
+      | Behat Cheddar-Cannelini Fondue                 | behat_camp_01       | 1       |
+      | Behat Why you should give walking a try        | behat_camp_01       | 1       |
+      | Behat Community Outreach                       | behat_camp_01       | 1       |
+    Then I create landing_page content:
+      | KEY                 | title               | field_lp_layout | field_content |
+      | behat_landing_blogs | Behat Landing Blogs | one_column      | latest_blogs  |
 
   Scenario: Paste latest blog post
-    And I go to "/node/add/landing_page"
-    And I fill in "Title" with "Landing"
-    And I select "One Column" from "Layout"
-    When I press "Add Latest blog posts"
-    And I press "Save and publish"
-    Then I should see "Community Outreach"
-    And I should see "Start training now for the Y Run"
-    And I should see "Why you should give walking a try"
-    And I should see "Don’t let summer sneak up on your family"
-    And I should see "Add a water workout to your routine"
-    And I should see "Grown-up fun in Adult Sports Leagues"
+    Given I view node "behat_landing_blogs"
+    Then I should see "Behat Community Outreach"
+    And I should see "Behat Why you should give walking a try"
+    And I should see "Behat Cheddar-Cannelini Fondue"
+    And I should see "Behat Nourish yourself with healthy fats"
+    And I should see "Behat Add a water workout to your routine"
+    And I should see "Behat Don’t let summer sneak up on your family"
     When I click "Load More"
-    Then I should see "Nourish yourself with healthy fats"
-    And I should see "Cheddar-Cannelini Fondue"
-    And I should see "Mood-boosting foods"
+    Then I should see "Behat Add a water workout to your routine"
+    And I should see "Behat Mango-Avocado Salsa"
+    And I should see "Behat Mood-boosting foods"
+    And I should see "Behat Grown-up fun in Adult Sports Leagues"
+    And I should see "Behat Start training now for the Y Run"
+    And I should see "Lifestyle changes beyond the first two weeks"
 
   Scenario: Paste latest blog post (branch)
-    When I go to "/locations/west-ymca"
-    And I click "Edit"
-    And I should see "Type: Latest blog posts (branch)" in the "content_area"
-    And I press "Save and keep published"
-    Then I should see "Mood-boosting foods"
-    And I should see "Grown-up fun in Adult Sports Leagues"
-    And I should see "Start training now for the Y Run"
-    And I should not see "Mango-Avocado Salsa"
-    And I should not see "Add a water workout to your routine"
+    Given I view node "behat_branch_01"
+    Then I should see "Behat Mood-boosting foods"
+    And I should see "Behat Grown-up fun in Adult Sports Leagues"
+    And I should see "Behat Start training now for the Y Run"
+    And I should not see "Behat Mango-Avocado Salsa"
+    And I should not see "Behat Add a water workout to your routine"
 
   Scenario: Paste latest blog post for camp
-    Given I go to "/node/add/camp"
-    And I press "Add Latest blog posts (camp)" in the "content_area"
-    And I fill in "Title" with "Camp One"
-    And I fill in the following:
-      | URL | /register |
-      | Link text | Registration |
-    And I fill in the following:
-      | Street address | Wood road 115  |
-      | City           | Seattle        |
-      | State          | WA             |
-      | Zip code       | 98101          |
-      | Latitude       | 46.293433      |
-      | Longitude      | -123.238717    |
-      | Phone          | +1234567890    |
-    And I press "Add Latest blog posts (camp)"
-    And I press "Save and publish"
-
-    And I go to "/node/add/blog"
-    And I fill in "Title" with "OpenY Blog post"
-    And I select "Camp One" from "Location"
-    And I fill in the following:
-      | Category | Category One |
-      | Description | This could be a draft for a wonderful post. |
-    When I press "Save and publish"
-    When I go to "/camps/camp-one"
-    And I should see "OpenY Blog post"
+    Given I view node "behat_camp_01"
+    Then I should see "Behat Community Outreach"
+    And I should see "Behat Why you should give walking a try"
+    And I should see "Behat Cheddar-Cannelini Fondue"
+    And I should see "Behat Nourish yourself with healthy fats"
+    And I should see "Behat Add a water workout to your routine"
+    And I should see "Behat Don’t let summer sneak up on your family"

--- a/tests/features/paragraphs/membership_calculator_paragraph.feature
+++ b/tests/features/paragraphs/membership_calculator_paragraph.feature
@@ -14,25 +14,25 @@ Feature: Membership Calculator Paragraph
       | field_location_coordinates:lat      | 47.293433     |
       | :lng                                | -122.238717   |
       | field_location_phone                | +1234567890   |
-    And I create "paragraph" of type "membership_info" with key for reference:
+    And I create "paragraph" of type "membership_info":
       | KEY               | field_mbrshp_location | field_mbrshp_join_fee | field_mbrshp_monthly_rate | field_mbrshp_link:uri | :title |
       | mem_in_adult_1    | behat_branch          | 100                   | 73                        | http://openymca.org   | Select |
       | mem_in_family_1_1 | behat_branch          | 100                   | 109                       | http://openymca.org   | Select |
       | mem_in_family_2_1 | behat_branch          | 125                   | 129                       | http://openymca.org   | Select |
-    And I create "media" of type "image" with key for reference:
+    And I create "media" of type "image":
       | KEY            | name         | field_media_image |
       | adult_image    | adult.jpg    | adult.jpg         |
       | family_1_image | family_1.jpg | family_1.jpg      |
       | family_2_image | family_2.jpg | family_2.jpg      |
-    And I create nodes "membership" content:
+    And I create "membership" content:
       | KEY          | title           | status | field_mbrshp_description:value                                | :format   | field_mbrshp_info | field_mbrshp_image |
       | mem_adult    | Behat: Adult    | 1      | <p>Adults (30-64)</p>                                         | full_html | mem_in_adult_1    | adult_image        |
       | mem_family_1 | Behat: Family 1 | 1      | <p>One adult plus dependents</p>                              | full_html | mem_in_family_1_1 | family_1_image     |
       | mem_family_2 | Behat: Family 2 | 0      | <p>Two adults in same&nbsp;household&nbsp;plus dependents</p> | full_html | mem_in_family_2_1 | family_2_image     |
-    And I create "paragraph" of type "openy_prgf_mbrshp_calc" with key for reference:
+    And I create "paragraph" of type "openy_prgf_mbrshp_calc":
       | KEY                    |
       | openy_prgf_mbrshp_calc |
-    And I create nodes "landing_page" content:
+    And I create "landing_page" content:
       | KEY             | title                            | field_lp_layout | field_content          |
       | membership_page | Behat Membership calculator test | one_column      | openy_prgf_mbrshp_calc |
     And I am an anonymous user

--- a/tests/features/paragraphs/static_paragraphs.feature
+++ b/tests/features/paragraphs/static_paragraphs.feature
@@ -4,106 +4,130 @@ Feature: Static Paragraphs
 
   Background: Create basic landing page
     Given I am logged in as a user with the "Editor" role
-    And I go to "/node/add/landing_page"
-    And I fill "Title" with "Landing"
-    And I select "One Column" from "Layout"
+    Then I create media of type image:
+      | KEY              | name             | field_media_image |
+      | image_01         | Image 01         | image_01.png      |
+      | gallery_image_01 | Gallery Image 01 | gallery_01.png    |
+      | gallery_image_02 | Gallery Image 02 | gallery_02.png    |
+      | story_image_01   | Story Image O1   | story_01.png      |
 
-  Scenario: Create Small Banner
-    When I press "Add Small Banner" in the "header_area"
-    And I fill the following:
-      |Headline | MY SMALL BANNER |
-    And I fill media field "edit-field-prgf-image-target-id" with "media:1"
-    And I select "Green" from "Color"
-    And I press "Save and publish"
-    Then I should see "MY SMALL BANNER"
-    And I should see a ".banner-image img" element
+    And I create taxonomy_term of type color:
+      | KEY     | name          | field_color |
+      | green   | Behat Green   | 00FF00      |
+    And I create large paragraph of type small_banner:
+      | KEY                 | behat_small_banner |
+      | field_prgf_headline | BEHAT SMALL BANNER |
+      | field_prgf_image    | image_01           |
+      | field_prgf_color    | green              |
+    And I create large paragraph of type banner:
+      | KEY                    | behat_banner        |
+      | field_prgf_headline    | BEHAT BANNER        |
+      | field_prgf_image       | image_01            |
+      | field_prgf_description | Enjoy the OpenY     |
+      | field_prgf_link:uri    | http://openymca.org |
+      | :title                 | Read about OpenY    |
+    And I create large paragraph of type gallery:
+      | KEY                    | behat_gallery                      |
+      | field_prgf_headline    | BEHAT GALLERY                      |
+      | field_prgf_images      | gallery_image_01, gallery_image_02 |
+      | field_prgf_description | The description is here.           |
+      | field_prgf_link:uri    | http://openymca.org                |
+      | :title                 | Read about OpenY                   |
+    And I create paragraph of type simple_content:
+      | KEY          | field_prgf_description |
+      | behat_simple | Simple text is here.   |
+    And I create large paragraph of type grid_columns:
+      | KEY                                   | behat_grid_column_01       |
+      | field_prgf_clm_headline               | We Appreciate Your Support |
+      | field_prgf_clm_class                  | flag                       |
+      | field_prgf_grid_clm_description:value | We rely on donations.      |
+      | :format                               | full_html                  |
+      | field_prgf_clm_link:uri               | internal:/donate           |
+      | :title                                | Donate                     |
+    And I create paragraph of type grid_content:
+      | KEY                | field_prgf_grid_style | field_grid_columns   |
+      | behat_grid_content | 2                     | behat_grid_column_01 |
+    And I create large paragraph of type promo_card:
+      | KEY                    | behat_promo_card                      |
+      | field_prgf_title       | BEHAT PROMO                           |
+      | field_prgf_headline    | OpenY is free to try!                 |
+      | field_prgf_description | Setup a website and see how it works. |
+      | field_prgf_link:uri    | http://openymca.org                   |
+      | :title                 | Go!                                   |
+    And I create large paragraph of type story_card:
+      | KEY                 | behat_story_card                          |
+      | field_prgf_title    | BEHAT NEW STORY                           |
+      | field_prgf_headline | I discovered OpenY. And that looks great! |
+      | field_prgf_link:uri | http://openymca.org                       |
+      | :title              | Discover OpenY                            |
+    And I create large paragraph of type teaser:
+      | KEY                    | behat_teaser           |
+      | field_prgf_title       | BEHAT MY TEASER        |
+      | field_prgf_description | Lorem ipsum dolor sit. |
+      | field_prgf_image       | story_image_01         |
+      | field_prgf_link:uri    | internal:/test         |
+      | :title                 | Test link              |
+    And I create landing_page content:
+      | KEY                  | title                      | field_lp_layout | field_header_content |
+      | landing_small_banner | Behat Landing Small Banner | one_column      | behat_small_banner   |
+      | landing_banner       | Behat Landing Banner       | one_column      | behat_banner         |
+      | landing_gallery      | Behat Landing Gallery      | one_column      | behat_gallery        |
+      | landing_simple       | Behat Landing Simple       | one_column      | behat_simple         |
+    And I create landing_page content:
+      | KEY            | title                | field_lp_layout | field_content      |
+      | landing_grid   | Behat Landing Grid   | one_column      | behat_grid_content |
+      | landing_teaser | Behat Landing Teaser | one_column      | behat_teaser       |
+    And I create landing_page content:
+      | KEY           | title               | field_lp_layout | field_sidebar_content |
+      | landing_promo | Behat Landing Promo | two_column      | behat_promo_card      |
+      | landing_story | Behat Landing Story | two_column      | behat_story_card      |
 
-  Scenario: Create Banner
-    When I press "Add Banner" in the "header_area"
-    When I fill the following:
-      |Headline | MY BANNER |
-      |Description | Enjoy the OpenY |
-      |URL      | http://openymca.org     |
-      |Link text | Read about OpenY |
-    And I fill media field "edit-field-prgf-image-target-id" with "media:1"
-    And I press "Save and publish"
-    Then I should see the heading "MY BANNER"
+  Scenario: See Small Banner On Landing Page
+    Given I view node "landing_small_banner"
+    Then I should see "BEHAT SMALL BANNER"
+    And I should see a ".paragraph--type--small-banner .banner-image img" element
+
+  Scenario: See Banner On Landing Page
+    Given I view node "landing_banner"
+    Then I should see the heading "BEHAT BANNER"
+    And I should see a ".paragraph--type--banner .banner-image img" element
     And I should see the text "Enjoy the OpenY"
-    And I should see a ".banner-image img" element
     And I should see the link "Read about OpenY"
 
-  Scenario: Create Gallery
-    When I press "Add Gallery" in the "header_area"
-    And I fill the following:
-      | Headline | My Gallery |
-      | Description | The description is here. |
-      | URL         | http://openymca.org      |
-      | Link text   | Read about OpenY         |
-    And I fill media field "edit-field-prgf-images-target-id" with "media:1 media:3"
-    And I press "Save and publish"
-    Then I should see the heading "My Gallery"
+  Scenario: See Gallery On Landing Page
+    Given I view node "landing_gallery"
+    Then I should see the heading "BEHAT GALLERY"
     And I should see "The description is here."
     And I should see a ".carousel img" element
     And I should see the link "Read about OpenY"
 
-  Scenario: Create Simple Content
-    When I press "Add Simple content" in the "content_area"
-    And I fill "Content" with "Simple text is here."
-    And I press "Save and publish"
+  Scenario: See Simple Content On Landing Page
+    Given I view node "landing_simple"
     Then I should see "Simple text is here."
 
-  Scenario: Create Grid Content
-    When I press "Add Grid Content"
-    And I select "2 items per row" from "Style"
-    And I press "Add Grid columns"
-    And I fill the following:
-      | Headline | We Appreciate Your Support |
-      | Icon Class | flag                     |
-      | Description | Every year, we rely on donations. |
-      | URL         | /donate                          |
-      | Link text   | Donate                       |
-    And I press "Save and publish"
+  Scenario: See Grid Content On Landing Page
+    Given I view node "landing_grid"
     Then I should see the heading "We Appreciate Your Support"
     And I should see a "i.fa-flag" element
-    And I should see "Every year, we rely on donations."
+    And I should see "We rely on donations."
     And I should see the link "Donate"
 
-  Scenario: Create Promo Card
-    When I press "Add Promo Card" in the "sidebar_area"
-    And I fill in "Title" with "Promo" in the "sidebar_area"
-    And I fill the following:
-      | Headline | OpenY is free to try! |
-      | Description | Setup a website and see how it works. |
-      | URL         | http://openymca.org   |
-      | Link text   | Go!                   |
-    And I press "Save and publish"
-    Then I should see the heading "Promo"
+  Scenario: See Promo Card On Landing Page
+    Given I view node "landing_promo"
+    Then I should see the heading "BEHAT PROMO"
     And I should see the heading "OpenY is free to try!"
     And I should see "Setup a website and see how it works."
     And I should see the link "Go!"
 
-  Scenario: Create Story Card
-    When I press "Add Story Card" in the "sidebar_area"
-    And I fill in "Title" with "New Story" in the "sidebar_area"
-    And I fill the following:
-      | Headline | I discovered OpenY. And that looks great! |
-      | URL      | http://openymca.org                       |
-      | Link text| Discover OpenY                            |
-    And I press "Save and publish"
-    Then I should see the heading "New Story"
+  Scenario: See Story Card On Landing Page
+    Given I view node "landing_story"
+    Then I should see the heading "BEHAT NEW STORY"
     And I should see "I discovered OpenY. And that looks great!"
     And I should see the link "Discover OpenY"
 
-  Scenario: Create Teaser
-    When I press "Add Teaser" in the "content_area"
-    And I fill in "Title" with "My Teaser" in the "content_area"
-    And I fill in the following:
-      | Description | Lorem ipsum dolor sit. |
-      | URL         | /test                  |
-      | Link text   | Test link              |
-    And I fill media field "edit-field-prgf-image-target-id" with "media:1"
-    And I press "Save and publish"
-    Then I should see the heading "My Teaser"
+  Scenario: See Teaser On Landing Page
+    Given I view node "landing_teaser"
+    Then I should see the heading "BEHAT MY TEASER"
     And I should see "Lorem ipsum dolor sit."
     And I should see a ".subprogram-listing-item img" element
     And I should see the link "Test link"


### PR DESCRIPTION
Note "[OYPD-354] Resolve wrong items hidden by 'Location finder filters' in 'Location finder'." changes the location finder to get the appropriate items to display when the filters are used. There was an incorrect assumption items in settings.openyMap were in the same order as on the page.

Steps to review:
- [x] All tests pass
- [x] On /locations the YMCA, Camps, and Facilities filters correctly hide and show existing content appropriately.