### PR TITLE
[OYPD-331] Refactoring buttons to allow for better color override

### DIFF
--- a/themes/openy_themes/openy_rose/css/colors.css
+++ b/themes/openy_themes/openy_rose/css/colors.css
@@ -8,7 +8,15 @@ a,
   color: #337ab7;
 }
 .button,
-.btn {
+.btn,
+.button.blue,
+.btn.blue,
+.modal-body .button,
+.button:hover,
+.btn:hover,
+.button.blue:hover,
+.btn.blue:hover,
+.modal-body .button:hover {
   background-color: #00aeef;
 }
 .btn-default {

--- a/themes/openy_themes/openy_rose/css/colors.css
+++ b/themes/openy_themes/openy_rose/css/colors.css
@@ -12,11 +12,13 @@ a,
 .button.blue,
 .btn.blue,
 .modal-body .button,
+.btn-primary,
 .button:hover,
 .btn:hover,
 .button.blue:hover,
 .btn.blue:hover,
-.modal-body .button:hover {
+.modal-body .button:hover,
+.btn-primary:hover {
   background-color: #00aeef;
 }
 .btn-default {

--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -1004,7 +1004,6 @@ body {
   text-transform: uppercase;
 }
 .btn.blue, .blue.button, .modal-body .button {
-  background-color: #00aeef;
   color: #fff;
 }
 .btn.blue:hover, .blue.button:hover, .modal-body .button:hover {
@@ -1071,7 +1070,6 @@ body {
   padding: 12px 35px;
   border: none;
   border-radius: 0;
-  background-color: #00aeef;
   font-size: 20px;
 }
 
@@ -4049,7 +4047,6 @@ html.js .branch__updates_queue__button {
   width: 90px;
   height: 34px;
   padding: 7px 16px;
-  background-color: #00aeef;
   border: solid 1px #636466;
   font-size: 16px;
   font-weight: 600;

--- a/themes/openy_themes/openy_rose/scss/modules/_blog.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_blog.scss
@@ -279,7 +279,6 @@
     width: 90px;
     height: 34px;
     padding: 7px 16px;
-    background-color: #00aeef;
     border: solid 1px #636466;
     font-size: 16px;
     font-weight: 600;

--- a/themes/openy_themes/openy_rose/scss/modules/_forms.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_forms.scss
@@ -27,7 +27,6 @@
   text-transform: uppercase;
 
   &.blue {
-    background-color: $light-blue;
     color: $white;
 
     &:hover {
@@ -107,7 +106,6 @@
   padding: 12px 35px;
   border: none;
   border-radius: 0;
-  background-color: #00aeef;
   font-size: 20px;
 }
 


### PR DESCRIPTION
I tracked down existing blue button uses to refactor this in a way that would actually work properly. The colors need to be removed from their respective files and only implemented in the colors.css file for the color module to use. Pay particular attention to hovers.

I went through most of the default content and looked for various use cases. Seems ok. (again, check hovers.)

- [ ] Update code, check all the blue buttons look correct, even on hover.
- [ ] Go to theme settings and change the button color.
- [ ] Verify all buttons change color.

Places where you can find different buttons. Home page banner, homepage load more button, homepage explore all member benefits button, Join page banner, each membership type select buttons, prev button on membership calculator, featured stories filter on blog page, top level program pages.

![screen shot 2017-04-03 at 5 50 48 pm](https://cloud.githubusercontent.com/assets/1504038/24633775/3d10d8e0-1898-11e7-80fe-1b48e4ea2b65.png)
![screen shot 2017-04-03 at 5 50 35 pm](https://cloud.githubusercontent.com/assets/1504038/24633777/3d1167e2-1898-11e7-9479-9a290e99199a.png)
![screen shot 2017-04-03 at 5 49 24 pm](https://cloud.githubusercontent.com/assets/1504038/24633776/3d118394-1898-11e7-99ea-57183405d7be.png)
![screen shot 2017-04-03 at 5 48 48 pm](https://cloud.githubusercontent.com/assets/1504038/24633772/3d0eb07e-1898-11e7-9289-fc5a70d4b1b4.png)
![screen shot 2017-04-03 at 5 48 15 pm](https://cloud.githubusercontent.com/assets/1504038/24633773/3d0f3de6-1898-11e7-9207-e0631ca1465a.png)
![screen shot 2017-04-03 at 5 48 09 pm](https://cloud.githubusercontent.com/assets/1504038/24633774/3d110b6c-1898-11e7-93db-7883fa6a3a18.png)
![screen shot 2017-04-03 at 5 46 49 pm](https://cloud.githubusercontent.com/assets/1504038/24633778/3d18453a-1898-11e7-92c0-1f1e839f4439.png)
