### PR TITLE
[OYPD-375] Make color of the banner configurable.

### DIFF
--- a/docs/Content structure/Paragraphs/Banner.md
+++ b/docs/Content structure/Paragraphs/Banner.md
@@ -5,6 +5,7 @@ This is a paragraph type that will be used for the banner content.
 | Name  | Machine name | Required | Description | Notes |
 | ------------- | ------------- | ------------- | ------------- | ------------- | 
 | Headline | field\_prgf_headline | Yes | Headline of the banner. | Plain text, 255 characters |
+| Color | field\_prgf_color | Yes | Reference field for choosing the term from "Color" vocabulary. | |
 | Image | field\_prgf_image | No | Entityreference to media image. Single value. | |
 | Description | field\_prgf_description | No | WYSIWYG field without summary. | |
 | Link | field\_prgf_link | No | Link field that should store internal and external links. | |

--- a/modules/openy_features/openy_demo_content/modules/openy_demo_nlanding/config/install/migrate_plus.migration.lp_paragraph_banner.yml
+++ b/modules/openy_features/openy_demo_content/modules/openy_demo_nlanding/config/install/migrate_plus.migration.lp_paragraph_banner.yml
@@ -11,6 +11,7 @@ label: 'Create banner paragraph(s) for demo landing page nodes'
 migration_dependencies:
   required:
     - openy_demo_lp_media_image
+    - openy_demo_taxonomy_term_color
 source:
   plugin: embedded_data
   data_rows:
@@ -18,6 +19,7 @@ source:
       id: homepage_banner
       parent_id: homepage
       headline: 'Explore the Open Y!'
+      color: 15
       image: homepage_banner
       description: |
         <p>
@@ -53,6 +55,10 @@ process:
     plugin: default_value
     default_value: field_header_content
   field_prgf_headline: headline
+  field_prgf_color:
+    plugin: migration
+    migration: openy_demo_taxonomy_term_color
+    source: color
   field_prgf_link/uri:
     plugin: default_value
     default_value: 'internal:/user/login?destination=admin/structure/menu?tour=1'

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_banner/config/install/core.entity_form_display.paragraph.banner.default.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_banner/config/install/core.entity_form_display.paragraph.banner.default.yml
@@ -3,6 +3,7 @@ status: true
 dependencies:
   config:
     - entity_browser.browser.images_library
+    - field.field.paragraph.banner.field_prgf_color
     - field.field.paragraph.banner.field_prgf_description
     - field.field.paragraph.banner.field_prgf_headline
     - field.field.paragraph.banner.field_prgf_image
@@ -17,8 +18,13 @@ targetEntityType: paragraph
 bundle: banner
 mode: default
 content:
-  field_prgf_description:
+  field_prgf_color:
     weight: 1
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+  field_prgf_description:
+    weight: 2
     settings:
       rows: 5
       placeholder: ''
@@ -32,7 +38,7 @@ content:
     third_party_settings: {  }
     type: string_textfield
   field_prgf_image:
-    weight: 2
+    weight: 3
     settings:
       entity_browser: images_library
       field_widget_display: label
@@ -44,7 +50,7 @@ content:
     third_party_settings: {  }
     type: entity_browser_entity_reference
   field_prgf_link:
-    weight: 3
+    weight: 4
     settings:
       placeholder_url: ''
       placeholder_title: ''

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_banner/config/install/core.entity_view_display.paragraph.banner.default.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_banner/config/install/core.entity_view_display.paragraph.banner.default.yml
@@ -2,6 +2,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.paragraph.banner.field_prgf_color
     - field.field.paragraph.banner.field_prgf_description
     - field.field.paragraph.banner.field_prgf_headline
     - field.field.paragraph.banner.field_prgf_image
@@ -15,8 +16,16 @@ targetEntityType: paragraph
 bundle: banner
 mode: default
 content:
-  field_prgf_description:
+  field_prgf_color:
     weight: 1
+    label: hidden
+    settings:
+      view_mode: color
+      link: false
+    third_party_settings: {  }
+    type: entity_reference_entity_view
+  field_prgf_description:
+    weight: 2
     label: hidden
     settings: {  }
     third_party_settings: {  }
@@ -29,7 +38,7 @@ content:
     third_party_settings: {  }
     type: string
   field_prgf_image:
-    weight: 2
+    weight: 3
     label: hidden
     settings:
       view_mode: prgf_banner
@@ -37,7 +46,7 @@ content:
     third_party_settings: {  }
     type: entity_reference_entity_view
   field_prgf_link:
-    weight: 3
+    weight: 4
     label: hidden
     settings:
       trim_length: 80

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_banner/config/install/field.field.paragraph.banner.field_prgf_color.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_banner/config/install/field.field.paragraph.banner.field_prgf_color.yml
@@ -1,0 +1,33 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_prgf_color
+    - paragraphs.paragraphs_type.banner
+    - taxonomy.vocabulary.color
+  module:
+    - datalayer
+third_party_settings:
+  datalayer:
+    expose: 0
+    label: field_prgf_color
+id: paragraph.banner.field_prgf_color
+field_name: field_prgf_color
+entity_type: paragraph
+bundle: banner
+label: Color
+description: ''
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      color: color
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_banner/openy_prgf_banner.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_banner/openy_prgf_banner.info.yml
@@ -6,10 +6,13 @@ dependencies:
   - entity_browser
   - field
   - image
+  - jquery_colorpicker
   - link
   - media_entity
   - openy_media_image
   - openy_prgf
+  - openy_txnm_color
   - paragraphs
+  - taxonomy
   - text
 version: 8.x-1.0

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_banner/openy_prgf_banner.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_banner/openy_prgf_banner.install
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @file
+ * OpenY Paragraph banner install file.
+ */
+
+/**
+ * Update Paragraph banner with field_prgf_color in the Landing page.
+ */
+function openy_prgf_banner_update_8001() {
+  $config_dir = drupal_get_path('module', 'openy_prgf_banner') . '/config/install/';
+  // Import new configuration
+  $config_importer = \Drupal::service('openy_upgrade_tool.importer');
+  $config_importer->setDirectory($config_dir);
+  $config_importer->importConfigs([
+    'field.field.paragraph.banner.field_prgf_color',
+  ]);
+
+  // Update multiple configurations.
+  $configs = [
+    'core.entity_form_display.paragraph.banner.default' =>[
+      'dependencies.config',
+      'content.field_prgf_color',
+      'content.field_prgf_headline.weight',
+      'content.field_prgf_description.weight',
+      'content.field_prgf_image.weight',
+      'content.field_prgf_link.weight',
+    ],
+    'core.entity_view_display.paragraph.banner.default' => [
+      'dependencies.config',
+      'content.field_prgf_color',
+      'content.field_prgf_headline.weight',
+      'content.field_prgf_description.weight',
+      'content.field_prgf_image.weight',
+      'content.field_prgf_link.weight',
+    ],
+  ];
+
+  $config_updater = \Drupal::service('openy_upgrade_tool.param_updater');
+  foreach ($configs as $config_name => $params) {
+    $config = $config_dir . $config_name . '.yml';
+    foreach ($params as $param) {
+      $config_updater->update($config, $config_name, $param);
+    }
+  }
+}

--- a/tests/features/paragraphs/static_paragraphs.feature
+++ b/tests/features/paragraphs/static_paragraphs.feature
@@ -22,6 +22,7 @@ Feature: Static Paragraphs
       | KEY                    | behat_banner        |
       | field_prgf_headline    | BEHAT BANNER        |
       | field_prgf_image       | image_01            |
+      | field_prgf_color       | green               |
       | field_prgf_description | Enjoy the OpenY     |
       | field_prgf_link:uri    | http://openymca.org |
       | :title                 | Read about OpenY    |

--- a/themes/openy_themes/openy_rose/templates/field/field--paragraph--field-prgf-color--banner.html.twig
+++ b/themes/openy_themes/openy_rose/templates/field/field--paragraph--field-prgf-color--banner.html.twig
@@ -1,0 +1,43 @@
+{#
+/**
+ * @file
+ * Default theme implementation for a field.
+ *
+ * To override output, copy the "field.html.twig" from the templates directory
+ * to your theme's directory and customize it, just like customizing other
+ * Drupal templates such as page.html.twig or node.html.twig.
+ *
+ * Instead of overriding the theming for all fields, you can also just override
+ * theming for a subset of fields using
+ * @link themeable Theme hook suggestions. @endlink For example,
+ * here are some theme hook suggestions that can be used for a field_foo field
+ * on an article node type:
+ * - field--node--field-foo--article.html.twig
+ * - field--node--field-foo.html.twig
+ * - field--node--article.html.twig
+ * - field--field-foo.html.twig
+ * - field--text-with-summary.html.twig
+ * - field.html.twig
+ *
+ * Available variables:
+ * - attributes: HTML attributes for the containing element.
+ * - label_hidden: Whether to show the field label or not.
+ * - title_attributes: HTML attributes for the title.
+ * - label: The label for the field.
+ * - multiple: TRUE if a field can contain multiple items.
+ * - items: List of all the field items. Each item contains:
+ *   - attributes: List of HTML attributes for each item.
+ *   - content: The field item's content.
+ * - entity_type: The entity type to which the field belongs.
+ * - field_name: The name of the field.
+ * - field_type: The type of the field.
+ * - label_display: The display settings for the label.
+ *
+ * @see template_preprocess_field()
+ *
+ * @ingroup themeable
+ */
+#}
+{% for item in items %}
+  {{- item.content -}}
+{% endfor %}

--- a/themes/openy_themes/openy_rose/templates/paragraph/paragraph--banner.html.twig
+++ b/themes/openy_themes/openy_rose/templates/paragraph/paragraph--banner.html.twig
@@ -45,7 +45,7 @@
   ]
 %}
 
-<div{{ attributes.addClass(classes) }}>
+<div{{ attributes.addClass(classes) }} style="background-color:# {{- content.field_prgf_color -}}">
   <div class="banner-image">
     <div class="banner-image-wrapper">
       {{ content.field_prgf_image }}


### PR DESCRIPTION
Issue https://propeople-us.atlassian.net/browse/OYPD-375

Steps to review:
- [x] log in as admin /user, login: _admin_ and pass: openy
- [x] go to loading page, /openy
**Please look** https://monosnap.com/file/592WqeChnjy3PW8Ia6qiZD6cjJcwKz
- [x] find the banner with the name "EXPLORE THE OPEN Y!"
- [x] Inspect banner and make sure you can see background color #01A490
**Please look** https://monosnap.com/file/h3qSzUMXJXly5OIRcPxwgBhSzgW4A5
- [x] click edit banner
- [x] change color for background banner. **Please look** https://monosnap.com/file/UnkctsP0efmwqiAS3OqmzjP2D2RBje
- [x] save and verify background color was changed into selected color 
**Also**
- [x] go to doc page: https://github.com/ivan-berezhnov/openy/blob/features/OYPD-375/docs/Content%20structure/Paragraphs/Banner.md and link in PR https://github.com/ymcatwincities/openy/pull/295/files#diff-3727fb183718a48597d10ddb79d1c5d4R7
- [x] verify you can see added information about field color
**And**
- [x] please check hook_update, go to https://github.com/ymcatwincities/openy/pull/295/files#diff-53bb1e996b0db39c61c4e53c49c54fd4R1

My issue in the Drupal.org: https://www.drupal.org/node/2869492