### PR TITLE
[OYPD-381] Incorrect prefix is being stored with urls during default content migration for menu items.

### DIFF
--- a/modules/openy_features/openy_demo_content/modules/openy_demo_menu/modules/openy_demo_menu_footer/config/install/migrate_plus.migration.menu_link_footer.yml
+++ b/modules/openy_features/openy_demo_content/modules/openy_demo_menu/modules/openy_demo_menu_footer/config/install/migrate_plus.migration.menu_link_footer.yml
@@ -13,7 +13,7 @@ source:
       id: 1
       title: 'Programs'
       menu_name: 'footer-menu-left'
-      link: 'base:openy'
+      link: 'openy'
       weight: 1
       parent_id: 0
       expanded: 1
@@ -22,7 +22,7 @@ source:
       id: 2
       title: 'Health and Fitness'
       menu_name: 'footer-menu-left'
-      link: 'base:programs/health-and-fitness'
+      link: 'programs/health-and-fitness'
       weight: 1
       parent_id: 1
       expanded: 0
@@ -31,7 +31,7 @@ source:
       id: 3
       title: 'Swimming'
       menu_name: 'footer-menu-left'
-      link: 'base:programs/swimming'
+      link: 'programs/swimming'
       weight: 2
       parent_id: 1
       expanded: 0
@@ -40,7 +40,7 @@ source:
       id: 4
       title: 'Kids and Family Activities'
       menu_name: 'footer-menu-left'
-      link: 'base:programs/kids-and-family-activities'
+      link: 'programs/kids-and-family-activities'
       weight: 3
       parent_id: 1
       expanded: 0
@@ -49,7 +49,7 @@ source:
       id: 5
       title: 'Child Care'
       menu_name: 'footer-menu-left'
-      link: 'base:programs/child-care'
+      link: 'programs/child-care'
       weight: 4
       parent_id: 1
       expanded: 0
@@ -58,7 +58,7 @@ source:
       id: 6
       title: 'Camps'
       menu_name: 'footer-menu-left'
-      link: 'base:programs/camps'
+      link: 'programs/camps'
       weight: 5
       parent_id: 1
       expanded: 0
@@ -67,7 +67,7 @@ source:
       id: 7
       title: 'Youth Programs'
       menu_name: 'footer-menu-left'
-      link: 'base:programs/youth-programs'
+      link: 'programs/youth-programs'
       weight: 6
       parent_id: 1
       expanded: 0
@@ -76,7 +76,7 @@ source:
       id: 8
       title: 'Home'
       menu_name: 'footer-menu-center'
-      link: 'base:openy'
+      link: 'openy'
       weight: 1
       parent_id: 0
       expanded: 0
@@ -85,7 +85,7 @@ source:
       id: 9
       title: 'Locations'
       menu_name: 'footer-menu-center'
-      link: 'base:locations'
+      link: 'locations'
       weight: 2
       parent_id: 0
       expanded: 0
@@ -94,7 +94,7 @@ source:
       id: 10
       title: 'Blog'
       menu_name: 'footer-menu-center'
-      link: 'base:blog'
+      link: 'blog'
       weight: 3
       parent_id: 0
       expanded: 0
@@ -103,7 +103,7 @@ source:
       id: 11
       title: 'Accelerator'
       menu_name: 'footer-menu-center'
-      link: 'base:accelerator'
+      link: 'accelerator'
       weight: 4
       parent_id: 0
       expanded: 0
@@ -112,7 +112,7 @@ source:
       id: 12
       title: 'About'
       menu_name: 'footer-menu-right'
-      link: 'base:about'
+      link: 'about'
       weight: 1
       parent_id: 0
       expanded: 0
@@ -121,7 +121,7 @@ source:
       id: 13
       title: 'Give'
       menu_name: 'footer-menu-right'
-      link: 'base:give'
+      link: 'give'
       weight: 2
       parent_id: 0
       expanded: 0
@@ -130,7 +130,7 @@ source:
       id: 14
       title: 'Join'
       menu_name: 'footer-menu-right'
-      link: 'base:join'
+      link: 'join'
       weight: 3
       parent_id: 0
       expanded: 0

--- a/modules/openy_features/openy_demo_content/modules/openy_demo_menu/modules/openy_demo_menu_main/config/install/migrate_plus.migration.menu_link_main.yml
+++ b/modules/openy_features/openy_demo_content/modules/openy_demo_menu/modules/openy_demo_menu_main/config/install/migrate_plus.migration.menu_link_main.yml
@@ -18,7 +18,7 @@ source:
       id: 1
       title: 'Home'
       menu_name: 'main'
-      link: 'base:openy'
+      link: 'openy'
       weight: 1
       parent_id: 0
       expanded: 0
@@ -27,7 +27,7 @@ source:
       id: 2
       title: 'Programs'
       menu_name: 'main'
-      link: 'base:openy'
+      link: 'openy'
       weight: 2
       parent_id: 0
       expanded: 1
@@ -36,7 +36,7 @@ source:
       id: 3
       title: 'Health and Fitness'
       menu_name: 'main'
-      link: 'base:programs/health-and-fitness'
+      link: 'programs/health-and-fitness'
       weight: 1
       parent_id: 2
       expanded: 1
@@ -46,7 +46,7 @@ source:
       id: 4
       title: 'Swimming'
       menu_name: 'main'
-      link: 'base:programs/swimming'
+      link: 'programs/swimming'
       weight: 2
       parent_id: 2
       expanded: 1
@@ -56,7 +56,7 @@ source:
       id: 5
       title: 'Kids and Family Activities'
       menu_name: 'main'
-      link: 'base:programs/kids-and-family-activities'
+      link: 'programs/kids-and-family-activities'
       weight: 3
       parent_id: 2
       expanded: 1
@@ -66,7 +66,7 @@ source:
       id: 6
       title: 'Camps'
       menu_name: 'main'
-      link: 'base:programs/camps'
+      link: 'programs/camps'
       weight: 4
       parent_id: 2
       expanded: 1
@@ -76,7 +76,7 @@ source:
       id: 7
       title: 'Child Care'
       menu_name: 'main'
-      link: 'base:programs/child-care'
+      link: 'programs/child-care'
       weight: 5
       parent_id: 2
       expanded: 1
@@ -86,7 +86,7 @@ source:
       id: 8
       title: 'Youth Programs'
       menu_name: 'main'
-      link: 'base:programs/youth-programs'
+      link: 'programs/youth-programs'
       weight: 6
       parent_id: 2
       expanded: 1
@@ -96,7 +96,7 @@ source:
       id: 9
       title: 'Locations'
       menu_name: 'main'
-      link: 'base:locations'
+      link: 'locations'
       weight: 3
       parent_id: 0
       expanded: 0
@@ -105,7 +105,7 @@ source:
       id: 10
       title: 'About'
       menu_name: 'main'
-      link: 'base:about'
+      link: 'about'
       weight: 4
       parent_id: 0
       expanded: 0
@@ -114,7 +114,7 @@ source:
       id: 11
       title: 'Give'
       menu_name: 'main'
-      link: 'base:give'
+      link: 'give'
       weight: 5
       parent_id: 0
       expanded: 0
@@ -123,7 +123,7 @@ source:
       id: 12
       title: 'Accelerator'
       menu_name: 'main'
-      link: 'base:accelerator'
+      link: 'accelerator'
       weight: 6
       parent_id: 0
       expanded: 0
@@ -132,7 +132,7 @@ source:
       id: 13
       title: 'Blog'
       menu_name: 'main'
-      link: 'base:blog'
+      link: 'blog'
       weight: 7
       parent_id: 0
       expanded: 0
@@ -330,7 +330,7 @@ source:
       id: 35
       title: 'Join'
       menu_name: 'main'
-      link: 'base:join'
+      link: 'join'
       weight: 8
       parent_id: 0
       expanded: 0

--- a/modules/openy_features/openy_demo_content/modules/openy_demo_nlanding/config/install/migrate_plus.migration.lp_paragraph_featured_content.yml
+++ b/modules/openy_features/openy_demo_content/modules/openy_demo_nlanding/config/install/migrate_plus.migration.lp_paragraph_featured_content.yml
@@ -122,7 +122,7 @@ process:
   field_prgf_link/title:
      plugin: default_value
      source: link_text
-     default_value: NULL
+     default_value: 'http://www.openymca.org'
   field_prgf_fc_clm_description:
     -
       plugin: iterator

--- a/modules/openy_features/openy_demo_content/modules/openy_demo_nlanding/config/install/migrate_plus.migration.lp_paragraph_gallery.yml
+++ b/modules/openy_features/openy_demo_content/modules/openy_demo_nlanding/config/install/migrate_plus.migration.lp_paragraph_gallery.yml
@@ -95,7 +95,7 @@ process:
   field_prgf_headline: headline
   field_prgf_link/uri:
     plugin: default_value
-    default_value: 'base:/openy'
+    default_value: 'internal:/openy'
   field_prgf_link/title:
     plugin: default_value
     default_value: 'Learn more'

--- a/modules/openy_features/openy_demo_content/modules/openy_demo_nlanding/config/install/migrate_plus.migration.lp_paragraph_teaser.yml
+++ b/modules/openy_features/openy_demo_content/modules/openy_demo_nlanding/config/install/migrate_plus.migration.lp_paragraph_teaser.yml
@@ -71,7 +71,7 @@ process:
   field_prgf_title: title
   field_prgf_link/uri:
     plugin: default_value
-    default_value: 'base:/openy'
+    default_value: 'internal:/openy'
   field_prgf_link/title:
     plugin: default_value
     default_value: 'Learn more'

--- a/modules/openy_features/openy_demo_content/modules/openy_demo_nprogram/config/install/migrate_plus.migration.paragraph_promo_card.yml
+++ b/modules/openy_features/openy_demo_content/modules/openy_demo_nprogram/config/install/migrate_plus.migration.paragraph_promo_card.yml
@@ -78,7 +78,7 @@ process:
     default_value: full_html
   field_prgf_link/uri:
     plugin: default_value
-    default_value: 'base:learn_more'
+    default_value: 'http://www.openymca.org'
   field_prgf_link/title:
     plugin: default_value
     default_value: 'Learn More'


### PR DESCRIPTION
Issue https://propeople-us.atlassian.net/browse/OYPD-381

- [x] login as admin.
- [x] go to [sitename] /openy page.
- [x] please check (click) all links in main and footer menus
- [x] verify all links work as needed and yo can't see an error.
- [x] go to [sitename] /admin/structure/menu/item/2/edit
Please look 
https://monosnap.com/file/qBSTUoDmNvjBKeSak4VV43D1CKFqyf
https://monosnap.com/file/H8W15sfIP9E3Ulct2YQPRwjERVoTao
- [x] verify in the link field chossen right link
- [x] go to [sitename] /about
- [x] find "Our Mission" and verify "Learn more" link follow to /openy page without any error.
- [x] go to [sitename] /accelerator
- [x] find "Housing & Transition Planning" and verify "Learn more" link follow to /openy page without any error.

Also please check my comment
https://github.com/ymcatwincities/openy/pull/303#issuecomment-295201674

Issue in Drupal.org https://www.drupal.org/node/2871041