### PR TITLE
[OYPD-384] Changing quote icon to directly use svg instead of background image

### DIFF
--- a/themes/openy_themes/openy_rose/css/colors.css
+++ b/themes/openy_themes/openy_rose/css/colors.css
@@ -131,6 +131,9 @@ body .branch-popup .ui-dialog-content h3 {
 #membership-calc-wrapper .nav-pills > li.active div:after {
   border-left-color: #5c2e91;
 }
+.story-card .quote svg {
+  fill: #5c2e91;
+}
 
 /* Secondary highlight color (pink.) */
 .branch-header .desktop,

--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -1600,12 +1600,13 @@ body {
     line-height: 1.2;
   }
 }
-.story-card .quote .icon {
-  background: url("../img/icons/quote_purple.svg") no-repeat 0 0;
+.story-card .quote svg {
   display: block;
+  float: left;
   height: 24px;
-  margin: 13px 0 0px;
-  width: 44px;
+  fill: #5c2e91;
+  margin: 0 16px 0 0;
+  width: 28px;
 }
 .story-card .link {
   font-size: 15px;
@@ -3883,9 +3884,7 @@ html.js .branch__updates_queue__button {
   float: left;
   min-height: 360px;
 }
-.node--type-blog.node--view-mode-teaser .quote i {
-  background-size: 27px;
-  background-position: top left;
+.node--type-blog.node--view-mode-teaser .quote svg {
   margin-top: 21px;
 }
 

--- a/themes/openy_themes/openy_rose/img/icons/quote_purple.svg
+++ b/themes/openy_themes/openy_rose/img/icons/quote_purple.svg
@@ -2,9 +2,6 @@
 <!-- Generator: Adobe Illustrator 20.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 42.3 37.2" style="enable-background:new 0 0 42.3 37.2;" xml:space="preserve">
-<style type="text/css">
-	.st0{fill:#7044A2;}
-</style>
 <g>
 	<path class="st0" d="M0,37.2v-16c0-2.9,0.3-5.6,0.9-8.1c0.6-2.5,1.6-4.8,2.9-6.7c1.3-1.9,3-3.5,5-4.6S13.2,0,15.8,0v7.2
 		c-1.6,0-3,0.4-4,1.2c-1.1,0.8-1.9,1.9-2.6,3.2c-0.7,1.3-1.1,2.9-1.4,4.5c-0.2,1.7-0.4,3.3-0.4,5H16v16H0z M26.4,37.2v-16

--- a/themes/openy_themes/openy_rose/scss/modules/_blog.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_blog.scss
@@ -135,9 +135,7 @@
       float: left;
       min-height: 360px;
 
-      i {
-        background-size: 27px;
-        background-position: top left;
+      svg {
         margin-top: 21px;
       }
     }

--- a/themes/openy_themes/openy_rose/scss/modules/_paragraphs.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_paragraphs.scss
@@ -371,12 +371,13 @@
       line-height: 1.2;
     }
 
-    .icon {
-      background: url("../img/icons/quote_purple.svg") no-repeat 0 0;
+    svg {
       display: block;
+      float: left;
       height: 24px;
-      margin: 13px 0 0px;
-      width: 44px;
+      fill: $purple;
+      margin: 0 16px 0 0;
+      width: 28px;
     }
   }
 

--- a/themes/openy_themes/openy_rose/templates/node/node--blog--teaser.html.twig
+++ b/themes/openy_themes/openy_rose/templates/node/node--blog--teaser.html.twig
@@ -96,7 +96,7 @@
       {% if ( node.field_blog_style.value == "story" ) %}
         <div class="story-card">
           <div class="quote">
-            <i class="icon"></i>
+            {% include active_theme_path() ~ '/img/icons/quote_purple.svg' %}
           </div>
         </div>
       {% endif %}

--- a/themes/openy_themes/openy_rose/templates/paragraph/paragraph--story-card--default.html.twig
+++ b/themes/openy_themes/openy_rose/templates/paragraph/paragraph--story-card--default.html.twig
@@ -51,7 +51,7 @@ set classes = [
       {{ content.field_prgf_title }}
     </h3>
     <div class="quote">
-      <i class="icon"></i>
+      {% include active_theme_path() ~ '/img/icons/quote_purple.svg' %}
       {{ content.field_prgf_headline }}
     </div>
     <div class="link">


### PR DESCRIPTION
- [x] Check that places where the quote icon (") appears are replaced with direct use of SVG instead of a background image.
- [x] Change primary highlight color from the theme settings page.
- [x] Verify that the quote icons change color.

The two places I found where this appears is "story card" which you can add to sidebar of landing pages, and blog teaser that has style set to "story card".

Before color change:
![screen shot 2017-04-19 at 5 25 05 pm](https://cloud.githubusercontent.com/assets/1504038/25203240/7762ade4-2526-11e7-8289-7ffbb6f0c2b1.png)
![screen shot 2017-04-19 at 5 25 00 pm](https://cloud.githubusercontent.com/assets/1504038/25203242/7767d530-2526-11e7-9096-c664ee254f88.png)

After color change:
![screen shot 2017-04-19 at 5 27 27 pm](https://cloud.githubusercontent.com/assets/1504038/25203241/7763b0b8-2526-11e7-85e3-d053f770d498.png)
![screen shot 2017-04-19 at 5 27 15 pm](https://cloud.githubusercontent.com/assets/1504038/25203239/776257ea-2526-11e7-898b-96665012852f.png)
