### PR TITLE
[OYPD-180] Fixing issue with bottom social block border going over logo when the…

### DIFF
--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -163,6 +163,7 @@ body {
   background-size: contain;
   display: block;
   height: 56px;
+  margin-bottom: 20px;
   width: 72px;
 }
 @media (min-width: 48em) {
@@ -175,6 +176,9 @@ body {
   border-bottom: 1px solid #979797;
   margin-bottom: 20px;
   margin-right: -15px;
+}
+.footer .footer__nav nav:last-of-type {
+  border-bottom: none;
 }
 @media (min-width: 48em) {
   .footer .footer__nav nav {
@@ -223,8 +227,13 @@ body {
 }
 .footer .footer__social {
   border-top: 1px solid #979797;
-  margin: -21px -15px 0;
+  margin-left: -15px;
   padding: 25px 0px 10px 25px;
+}
+@media (min-width: 0) and (max-width: 62em) {
+  .footer .footer__social {
+    width: 110%;
+  }
 }
 @media (min-width: 30em) {
   .footer .footer__social {

--- a/themes/openy_themes/openy_rose/scss/modules/_footer.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_footer.scss
@@ -19,6 +19,7 @@
     background-size: contain;
     display: block;
     height: 56px;
+    margin-bottom: 20px;
     width: 72px;
     @include breakpoint(768px) {
       height: 75px;
@@ -31,6 +32,9 @@
       border-bottom: 1px solid $medium-grey;
       margin-bottom: 20px;
       margin-right: -15px;
+      &:last-of-type {
+        border-bottom: none;
+      }
       @include breakpoint(768px) {
         border-bottom: none;
         display: inline-block;
@@ -77,8 +81,11 @@
   }
   .footer__social {
     border-top: 1px solid $medium-grey;
-    margin: -21px -15px 0;
+    margin-left: -15px;
     padding: 25px 0px 10px 25px;
+    @include breakpoint(0 $screen-md) {
+      width: 110%;
+    }
     @include breakpoint($screen-xs) {
       padding: 25px 45px 10px 60px;
     }


### PR DESCRIPTION
- [x] Disable footer menu items.
- [x] Check how the border above the social block appears, with proper spacing.
- [x] Check responsive sizes.

![screen shot 2017-05-02 at 5 21 35 pm](https://cloud.githubusercontent.com/assets/1504038/25640187/b0b3c570-2f5c-11e7-8d28-e1ecac4c8d12.png)
![screen shot 2017-05-02 at 5 20 20 pm](https://cloud.githubusercontent.com/assets/1504038/25640188/b0b4ea0e-2f5c-11e7-98b1-d990a269fd19.png)
![screen shot 2017-05-02 at 5 19 47 pm](https://cloud.githubusercontent.com/assets/1504038/25640191/b0b869ea-2f5c-11e7-8d94-22c0b5c4a4fd.png)
![screen shot 2017-05-02 at 5 19 06 pm](https://cloud.githubusercontent.com/assets/1504038/25640190/b0b81512-2f5c-11e7-86cd-f05712e20ed3.png)
![screen shot 2017-05-02 at 5 18 52 pm](https://cloud.githubusercontent.com/assets/1504038/25640189/b0b6f600-2f5c-11e7-9f58-6b521100aef1.png)
