### PR TITLE
[OYPD-249] Removing unneeded padding from blog post titles

### DIFF
--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -3902,7 +3902,6 @@ html.js .branch__updates_queue__button {
 }
 .node--type-blog h1 {
   letter-spacing: -1.2px;
-  padding-top: 32px;
   padding-bottom: 8px;
 }
 .node--type-blog.node--view-mode-sidebar {

--- a/themes/openy_themes/openy_rose/scss/modules/_blog.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_blog.scss
@@ -7,7 +7,6 @@
 
   h1 {
     letter-spacing: -1.2px;
-    padding-top: 32px;
     padding-bottom: 8px;
   }
 


### PR DESCRIPTION
Depending on the text of the title it may not appear perfectly aligned, but it is matched to the line height.

- [x] Verify blog post titles are now in alignment with the sidebar boxes.
- [x] Verify that nothing else on other displays was broken.

![screen shot 2017-05-03 at 2 47 39 pm](https://cloud.githubusercontent.com/assets/1504038/25676371/ccc0cfa2-300f-11e7-957e-6b8f9db84267.png)
