### PR TITLE
[OYPD-248] Fixing JS bugs in maps.js for zip code searching

### DIFF
--- a/modules/custom/openy_map/js/map.js
+++ b/modules/custom/openy_map/js/map.js
@@ -77,7 +77,7 @@
         if (!navigator.geolocation) {
           $('.with-geo').remove();
         }
-        this.component_el.find('.loc .btn-submit')
+        this.component_el.find('.zip-code .btn-submit')
             .on('click', $.proxy(this.apply_search, this));
 
         this.search_field_el.on('keypress', function (e) {
@@ -88,7 +88,7 @@
               .val(mapLocation[1].replace(/\+/g, ' '));
 
           $('.distance_limit option').eq(2).attr('selected', true);
-          $('.loc .btn-submit').click();
+          $('.zip-code .btn-submit').click();
         }
       },
 
@@ -154,7 +154,7 @@
             if (results[0].geometry.bounds) {
               this.map.fitBounds(results[0].geometry.bounds);
             } else {
-              bounds = new google.maps.LatLngBounds();
+              var bounds = new google.maps.LatLngBounds();
               bounds.extend(this.search_center_point);
               this.map.fitBounds(bounds);
             }


### PR DESCRIPTION
The zip code search was not working at all when a zip code is entered into the box, under certain circumstances, because of a variable declaration error. We are using strict mode, so all variables have to be declared.

Also, the url paramater search does not work because the click() event was not identifying the button. The css classes on it changed.

- [x] Go to locations page, enter zip code to search. With default content, these work. 77001, 98108, 98115. Make sure the distance, and location type are changed to see if locations appear. The distance works by distance from center of zip code to location, not edge of zip code.
- [x] Verify the map changes and pin added when entering zip code and hitting enter on keyboard.
- [x] Verify the map changes and pin added when entering zip code and clicking the search button.
- [x] Verify url parameters work. Example, /locations?map_location=98059 . The map should get a pin automatically. When changing a filter, like distance, the map should update automatically.