### PR TITLE
[OYPD-399] Fixing bounds on location finder and maps where it zooms too much on …

### DIFF
--- a/modules/custom/location_finder/js/location_finder.js
+++ b/modules/custom/location_finder/js/location_finder.js
@@ -158,6 +158,13 @@
             } else {
               bounds = new google.maps.LatLngBounds();
               bounds.extend(this.search_center_point);
+              // Don't zoom in too far on only one marker
+              if (bounds.getNorthEast().equals(bounds.getSouthWest())) {
+                var extendPoint1 = new google.maps.LatLng(bounds.getNorthEast().lat() + 0.001, bounds.getNorthEast().lng() + 0.001);
+                var extendPoint2 = new google.maps.LatLng(bounds.getNorthEast().lat() - 0.001, bounds.getNorthEast().lng() - 0.001);
+                bounds.extend(extendPoint1);
+                bounds.extend(extendPoint2);
+              }
               this.map.fitBounds(bounds);
             }
             this.search_center = this.map.getCenter();
@@ -421,6 +428,13 @@
           loc.marker.setVisible(true);
         }
 
+        // Don't zoom in too far on only one marker
+        if (bounds.getNorthEast().equals(bounds.getSouthWest())) {
+          var extendPoint1 = new google.maps.LatLng(bounds.getNorthEast().lat() + 0.001, bounds.getNorthEast().lng() + 0.001);
+          var extendPoint2 = new google.maps.LatLng(bounds.getNorthEast().lat() - 0.001, bounds.getNorthEast().lng() - 0.001);
+          bounds.extend(extendPoint1);
+          bounds.extend(extendPoint2);
+        }
         this.map.fitBounds(bounds);
 
       },

--- a/modules/custom/openy_map/js/map.js
+++ b/modules/custom/openy_map/js/map.js
@@ -151,13 +151,22 @@
         var f = function (results, status) {
           if (status == 'OK') {
             this.search_center_point = results[0].geometry.location;
+
             if (results[0].geometry.bounds) {
               this.map.fitBounds(results[0].geometry.bounds);
             } else {
               var bounds = new google.maps.LatLngBounds();
               bounds.extend(this.search_center_point);
+              // Don't zoom in too far on only one marker
+              if (bounds.getNorthEast().equals(bounds.getSouthWest())) {
+                var extendPoint1 = new google.maps.LatLng(bounds.getNorthEast().lat() + 0.001, bounds.getNorthEast().lng() + 0.001);
+                var extendPoint2 = new google.maps.LatLng(bounds.getNorthEast().lat() - 0.001, bounds.getNorthEast().lng() - 0.001);
+                bounds.extend(extendPoint1);
+                bounds.extend(extendPoint2);
+              }
               this.map.fitBounds(bounds);
             }
+
             this.search_center = this.map.getCenter();
             this.draw_search_center();
             this.apply_distance_limit();
@@ -419,6 +428,13 @@
           loc.marker.setVisible(true);
         }
 
+        // Don't zoom in too far on only one marker
+        if (bounds.getNorthEast().equals(bounds.getSouthWest())) {
+          var extendPoint1 = new google.maps.LatLng(bounds.getNorthEast().lat() + 0.001, bounds.getNorthEast().lng() + 0.001);
+          var extendPoint2 = new google.maps.LatLng(bounds.getNorthEast().lat() - 0.001, bounds.getNorthEast().lng() - 0.001);
+          bounds.extend(extendPoint1);
+          bounds.extend(extendPoint2);
+        }
         this.map.fitBounds(bounds);
 
       },


### PR DESCRIPTION
- [x] Check default zoom level when there is only one pin.
- [x] Verify a user can still zoom in and out as much as they want.

Setting zoom level doesn't work consistently when the map updates because the look up happens asynchronously from Google. Also, setting maxZoom makes it permanent so the user can't zoom more if they wanted too. The code added checks if there is only one pin and sets the bound to a reasonable level instead of trying to set zoom. It should be street level. Note that it won't be consistently perfect for every map. This seems to vary slightly between 100m and 200m, but that is street level, so it should be ok. 

![screen shot 2017-05-09 at 6 21 48 pm](https://cloud.githubusercontent.com/assets/1504038/25875579/4225fd14-34e6-11e7-95be-98c37c4e5414.png)
