### PR TITLE
[Minor-Fix] Remove search bar for tablet and mobile viewport.

### DIFF
--- a/themes/openy_themes/openy_rose/templates/page/page.html.twig
+++ b/themes/openy_themes/openy_rose/templates/page/page.html.twig
@@ -68,14 +68,6 @@
   </div>
 
   <div id="sidebar" class="sidebar sidebar-left collapse width">
-    <div class="search-form-wrapper col-xs-12">
-      <form method="get" action="{{ base_path }}search">
-        <i class="fa fa-search search-input-decoration" aria-hidden="true"></i>
-        <input type="search" name="query" class="search-input" placeholder="Search">
-        <input type="submit" type="submit" value="Search">
-      </form>
-    </div>
-
     <div class="col-xs-12 page-head__top-menu">
       {{ page.mobile_menu.useraccountmenu }}
     </div>


### PR DESCRIPTION
Drupal.org issue - https://www.drupal.org/node/2877920
Issue details here - #324

Steps for review:
- [x] go to frontpage or any another page
- [x] change your screen to tablet and mobile
- [x] click on icon menu in the top
- [x] verify search bar doesn't show in tablet and mobile