### PR TITLE
[OYPD-409] Adding drop shadow back to gallery control arrows

### DIFF
--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -1394,7 +1394,6 @@ body {
 @media (min-width: 48em) {
   .paragraph-gallery .carousel .carousel-control {
     background: none;
-    text-shadow: none;
     opacity: 0.5;
     height: 54px;
     width: 44px;

--- a/themes/openy_themes/openy_rose/scss/modules/_paragraphs.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_paragraphs.scss
@@ -127,7 +127,6 @@
 
       @include breakpoint (768px) {
         background: none;
-        text-shadow: none;
         opacity: 0.5;
         height: 54px;
         width: 44px;


### PR DESCRIPTION
- [x] Check that the white arrows are still visible in a gallery when there is a white background image.

![screen shot 2017-05-12 at 2 25 23 pm](https://cloud.githubusercontent.com/assets/1504038/26011478/41c2446e-371f-11e7-8355-eaaa0d40719a.png)
