### PR TITLE
[MInor-Fix][366] Add textfield to the "Small Banner”.

### DIFF
--- a/docs/Content structure/Paragraphs/Small Banner.md
+++ b/docs/Content structure/Paragraphs/Small Banner.md
@@ -7,3 +7,4 @@ This is a paragraph type that will be used for the banner content.
 | Color | field\_prgf_color | Yes | Reference field for choosing the term from "Color" vocabulary. | |
 | Headline | field\_prgf_headline | Yes | Headline of the Small banner. | Plain text, 255 characters |
 | Image | field\_prgf_image | No | Entityreference to media image. Single value. | |
+| Description | field\_prgf_description | No | WYSIWYG field without summary. | |

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_small_banner/config/install/core.entity_form_display.paragraph.small_banner.default.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_small_banner/config/install/core.entity_form_display.paragraph.small_banner.default.yml
@@ -4,11 +4,13 @@ dependencies:
   config:
     - entity_browser.browser.images_library
     - field.field.paragraph.small_banner.field_prgf_color
+    - field.field.paragraph.small_banner.field_prgf_description
     - field.field.paragraph.small_banner.field_prgf_headline
     - field.field.paragraph.small_banner.field_prgf_image
     - paragraphs.paragraphs_type.small_banner
   module:
     - entity_browser
+    - text
 id: paragraph.small_banner.default
 targetEntityType: paragraph
 bundle: small_banner
@@ -19,6 +21,15 @@ content:
     weight: 2
     settings: {  }
     third_party_settings: {  }
+    region: content
+  field_prgf_description:
+    weight: 3
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: text_textarea
+    region: content
   field_prgf_headline:
     type: string_textfield
     weight: 0
@@ -26,6 +37,7 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+    region: content
   field_prgf_image:
     type: entity_browser_entity_reference
     weight: 1
@@ -38,6 +50,7 @@ content:
       open: false
       field_widget_display_settings: {  }
     third_party_settings: {  }
+    region: content
 hidden:
   created: true
   status: true

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_small_banner/config/install/core.entity_view_display.media.image.prgf_small_banner.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_small_banner/config/install/core.entity_view_display.media.image.prgf_small_banner.yml
@@ -24,6 +24,7 @@ content:
       image_link: ''
     third_party_settings: {  }
     type: image
+    region: content
 hidden:
   created: true
   field_media_caption: true

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_small_banner/config/install/core.entity_view_display.paragraph.small_banner.default.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_small_banner/config/install/core.entity_view_display.paragraph.small_banner.default.yml
@@ -3,9 +3,12 @@ status: true
 dependencies:
   config:
     - field.field.paragraph.small_banner.field_prgf_color
+    - field.field.paragraph.small_banner.field_prgf_description
     - field.field.paragraph.small_banner.field_prgf_headline
     - field.field.paragraph.small_banner.field_prgf_image
     - paragraphs.paragraphs_type.small_banner
+  module:
+    - text
 id: paragraph.small_banner.default
 targetEntityType: paragraph
 bundle: small_banner
@@ -19,6 +22,14 @@ content:
       link: false
     third_party_settings: {  }
     type: entity_reference_entity_view
+    region: content
+  field_prgf_description:
+    weight: 3
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
   field_prgf_headline:
     weight: 0
     label: hidden
@@ -26,6 +37,7 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     type: string
+    region: content
   field_prgf_image:
     weight: 1
     label: hidden
@@ -34,6 +46,7 @@ content:
       link: false
     third_party_settings: {  }
     type: entity_reference_entity_view
+    region: content
 hidden:
   created: true
   uid: true

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_small_banner/config/install/field.field.paragraph.small_banner.field_prgf_description.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_small_banner/config/install/field.field.paragraph.small_banner.field_prgf_description.yml
@@ -1,0 +1,25 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_prgf_description
+    - paragraphs.paragraphs_type.small_banner
+  module:
+    - datalayer
+    - text
+third_party_settings:
+  datalayer:
+    expose: 0
+    label: field_prgf_description
+id: paragraph.small_banner.field_prgf_description
+field_name: field_prgf_description
+entity_type: paragraph
+bundle: small_banner
+label: Description
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_small_banner/openy_prgf_small_banner.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_small_banner/openy_prgf_small_banner.info.yml
@@ -3,14 +3,16 @@ description: 'OpenY paragraph small banner'
 type: module
 core: 8.x
 dependencies:
+  - datalayer
   - entity_browser
   - field
   - image
   - jquery_colorpicker
   - media_entity
   - openy_media_image
-  - openy_txnm_color
   - openy_prgf
+  - openy_txnm_color
   - paragraphs
   - taxonomy
+  - text
 version: 8.x-1.0

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_small_banner/openy_prgf_small_banner.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_small_banner/openy_prgf_small_banner.install
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @file
+ * OpenY Paragraph banner install file.
+ */
+
+/**
+ * Update Paragraph Small Banner with field_prgf_description.
+ */
+function openy_prgf_small_banner_update_8001() {
+  $config_dir = drupal_get_path('module', 'openy_prgf_small_banner') . '/config/install/';
+  // Import new configuration
+  $config_importer = \Drupal::service('openy_upgrade_tool.importer');
+  $config_importer->setDirectory($config_dir);
+  $config_importer->importConfigs([
+    'field.field.paragraph.small_banner.field_prgf_description',
+  ]);
+
+  // Update multiple configurations.
+  $configs = [
+    'core.entity_form_display.paragraph.small_banner.default' =>[
+      'dependencies.config',
+      'content.field_prgf_description',
+      'content.field_prgf_color.weight',
+      'content.field_prgf_image.weight',
+    ],
+    'core.entity_view_display.paragraph.small_banner.default' => [
+      'dependencies.config',
+      'content.field_prgf_description',
+      'content.field_prgf_color.weight',
+      'content.field_prgf_image.weight',
+    ],
+  ];
+
+  $config_updater = \Drupal::service('openy_upgrade_tool.param_updater');
+  foreach ($configs as $config_name => $params) {
+    $config = $config_dir . $config_name . '.yml';
+    foreach ($params as $param) {
+      $config_updater->update($config, $config_name, $param);
+    }
+  }
+}

--- a/tests/features/paragraphs/static_paragraphs.feature
+++ b/tests/features/paragraphs/static_paragraphs.feature
@@ -14,10 +14,11 @@ Feature: Static Paragraphs
       | KEY     | name          | field_color |
       | green   | Behat Green   | 00FF00      |
     And I create large paragraph of type small_banner:
-      | KEY                 | behat_small_banner |
-      | field_prgf_headline | BEHAT SMALL BANNER |
-      | field_prgf_image    | image_01           |
-      | field_prgf_color    | green              |
+      | KEY                    | behat_small_banner |
+      | field_prgf_headline    | BEHAT SMALL BANNER |
+      | field_prgf_image       | image_01           |
+      | field_prgf_color       | green              |
+      | field_prgf_description | Enjoy the OpenY    |
     And I create large paragraph of type banner:
       | KEY                    | behat_banner        |
       | field_prgf_headline    | BEHAT BANNER        |
@@ -86,6 +87,7 @@ Feature: Static Paragraphs
     Given I view node "landing_small_banner"
     Then I should see "BEHAT SMALL BANNER"
     And I should see a ".paragraph--type--small-banner .banner-image img" element
+    And I should see the text "Enjoy the OpenY"
 
   Scenario: See Banner On Landing Page
     Given I view node "landing_banner"

--- a/themes/openy_themes/openy_rose/templates/paragraph/paragraph--small-banner.html.twig
+++ b/themes/openy_themes/openy_rose/templates/paragraph/paragraph--small-banner.html.twig
@@ -46,6 +46,7 @@
   ]
 %}
 {% set color = '#' ~ content.field_prgf_color['#items'].entity.field_color.value %}
+{% set description_text = content.field_prgf_description.0['#text'] %}
 
 <div{{ attributes.addClass(classes) }} style="background-color: {{ color }}">
   <div class="banner-image">
@@ -60,6 +61,11 @@
           <h3 class="banner-title">
             {{ content.field_prgf_headline }}
           </h3>
+          {% if description_text is not empty %}
+            <div class="banner-description">
+              {{ content.field_prgf_description }}
+            </div>
+          {% endif %}
         </div>
       </div>
     </div>

--- a/themes/openy_themes/openy_rose/templates/paragraph/paragraph--small-banner.html.twig
+++ b/themes/openy_themes/openy_rose/templates/paragraph/paragraph--small-banner.html.twig
@@ -46,7 +46,7 @@
   ]
 %}
 {% set color = '#' ~ content.field_prgf_color['#items'].entity.field_color.value %}
-{% set description_text = content.field_prgf_description.0['#text'] %}
+{% set description_text = content.field_prgf_description.0['#text'] is not empty %}
 
 <div{{ attributes.addClass(classes) }} style="background-color: {{ color }}">
   <div class="banner-image">
@@ -61,7 +61,7 @@
           <h3 class="banner-title">
             {{ content.field_prgf_headline }}
           </h3>
-          {% if description_text is not empty %}
+          {% if description_text %}
             <div class="banner-description">
               {{ content.field_prgf_description }}
             </div>


### PR DESCRIPTION
Issue #366 
Drupal.org issue: https://www.drupal.org/node/2882621

Steps:
- [x] log in as admin
- [x] go to frontpage or any page
- [x] click 'Edit' above main content
- [x] add small banner
- [x] add some text to the description for small banner also headline text and image.
- [x] save
- [x] verify you can see your text in small banner also check if description empty you don't see in page source div with class "banner-description".