### PR TITLE
[OYPD-358] Adding padding for class pages

### DIFF
--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -4392,6 +4392,10 @@ html.js .branch__updates_queue__button {
   padding: 5px;
 }
 
+.page-node-type-class #block-openy-rose-content > .container {
+  padding: 20px 15px;
+}
+
 #schedules-search-form-wrapper .controls-wrapper {
   padding-top: 9px;
   padding-bottom: 9px;

--- a/themes/openy_themes/openy_rose/scss/modules/_class.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_class.scss
@@ -171,3 +171,11 @@
     padding: 5px;
   }
 }
+
+.page-node-type-class {
+  #block-openy-rose-content {
+    > .container {
+      padding: 20px 15px;
+    }
+  }
+}


### PR DESCRIPTION
Padding added to top and bottom of class pages. This should work with the header region because the padding is applied below the main block, so a banner in the header would still be flush with the top menu/header.

![screen shot 2017-05-30 at 11 32 08 am](https://cloud.githubusercontent.com/assets/1504038/26591439/aa2e4114-452b-11e7-850e-22b77efb589c.png)

![screen shot 2017-05-30 at 11 32 17 am](https://cloud.githubusercontent.com/assets/1504038/26591438/aa2cc2bc-452b-11e7-9023-ed2f91842b9a.png)