### PR TITLE
Fix fatal error

### DIFF
--- a/modules/openy_features/openy_location/modules/openy_loc_camp/openy_loc_camp.module
+++ b/modules/openy_features/openy_location/modules/openy_loc_camp/openy_loc_camp.module
@@ -5,6 +5,8 @@
  * OpenY Camp module file.
  */
 
+use Drupal\node\NodeInterface;
+
 /**
  * Implements hook_theme_suggestions_page_alter().
  */
@@ -17,7 +19,7 @@ function openy_loc_camp_theme_suggestions_page_alter(array &$suggestions, array 
   }
 
   // Exit if node type is not landing_page or if not related to a camp.
-  if (($node_type = $node->getType()) != 'landing_page' || !$camp_service->nodeHasOrIsCamp($node)) {
+  if (!$node instanceof NodeInterface || ($node_type = $node->getType()) != 'landing_page' || !$camp_service->nodeHasOrIsCamp($node)) {
     return;
   }
 


### PR DESCRIPTION
Drupal.org issue  - https://www.drupal.org/node/2883059

I got next error on my progect:
`Fatal error: Call to a member function getType() on string in /var/www/docroot/profiles/contrib/openy/modules/openy_features/openy_location/modules/openy_loc_camp/openy_loc_camp.module on line 20`

Short investigation show that in my case $node variable contain only ID.
Solution - add additional check that  $node is instanceof NodeInterface.