### PR TITLE
[OYPD-462] Resolve schedules page and class page popup behavior issues.

### DIFF
--- a/modules/custom/openy_popups/openy_popups.module
+++ b/modules/custom/openy_popups/openy_popups.module
@@ -30,7 +30,7 @@ function openy_popups_preprocess_radios(&$variables) {
 
   $variables['children'] = [];
 
-  if ($variables['element']['#all']) {
+  if (!empty($variables['element']['#all'])) {
     foreach ($variables['element']['#all'] as $id => $value) {
       $variables['children'][] = [
         '#markup' => $variables['element'][$id]['#markup'],
@@ -38,7 +38,7 @@ function openy_popups_preprocess_radios(&$variables) {
     }
   }
 
-  if ($variables['element']['#branches']) {
+  if (!empty($variables['element']['#branches'])) {
     $variables['children'][] = [
       '#markup' => '<h3>' . t('Branches') . '</h3>',
     ];
@@ -49,7 +49,7 @@ function openy_popups_preprocess_radios(&$variables) {
     }
   }
 
-  if ($variables['element']['#camps']) {
+  if (!empty($variables['element']['#camps'])) {
     $variables['children'][] = [
       '#markup' => '<h3>' . t('Camps') . '</h3>',
     ];

--- a/modules/custom/openy_popups/src/Form/ClassBranchesForm.php
+++ b/modules/custom/openy_popups/src/Form/ClassBranchesForm.php
@@ -81,6 +81,7 @@ class ClassBranchesForm extends FormBase {
     $destination['path'] = str_replace(base_path(), '/', $destination['path']);
     $branch = $form_state->getValue('branch');
     $destination['query']['location'] = $branch;
+    unset($destination['query']['session']);
     $uri = \Drupal::request()->getUriForPath($destination['path']);
     $response = new RedirectResponse($uri . '?' . UrlHelper::buildQuery($destination['query']));
 


### PR DESCRIPTION
Jira https://propeople-us.atlassian.net/browse/OYPD-462
D.o https://www.drupal.org/node/2883136

Make sure these boxes are checked before asking for review of your pull request - thank you!

## General checks
- [x] All coding styles are fulfilled and there are no any issues reported by CodeSniffer CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/ci-errors.png" width="200" alt="CI code sniffer errors">
- [x] All tests are running and there are no failed tests reported by CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/behat.png" width="200" alt="Behat test results">
- [x] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [x] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [x] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [x] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [x] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!

## Steps for review


- [x] As anonymous user
- [x] On schedules page
- [x] Selecting a location in the location popup does results are properly filtered.
- [x] Click on a class with a location & session id in the url parameters.
- [x] Class should load with proper content for the location & sessions.
- [x] Edit location on class page and select a location on the popup
- [x] The new page should strip the session from the url parameters and have the proper location set.