### PR TITLE
[OYPD-474] alt text field needs to be required for all images added to the site.

### DIFF
--- a/modules/openy_features/openy_media/modules/openy_media_image/config/install/field.field.media.image.field_media_image.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_image/config/install/field.field.media.image.field_media_image.yml
@@ -23,7 +23,7 @@ settings:
   max_resolution: ''
   min_resolution: ''
   alt_field: true
-  alt_field_required: false
+  alt_field_required: true
   title_field: false
   title_field_required: false
   default_image:

--- a/modules/openy_features/openy_media/modules/openy_media_image/openy_media_image.install
+++ b/modules/openy_features/openy_media/modules/openy_media_image/openy_media_image.install
@@ -13,3 +13,17 @@ use Drupal\openy_media\EmbedButtonIconHelper;
 function openy_media_image_install() {
   EmbedButtonIconHelper::setEmbedButtonIcon('openy_media_image', 'image.png', 'embed_image');
 }
+
+/**
+ * Update field media image.
+ */
+function openy_media_image_update_8001() {
+  $config_importer = \Drupal::service('openy_upgrade_tool.param_updater');
+  $config = drupal_get_path('module', 'openy_media_image');
+  $config .= '/config/install/';
+  $config .= 'field.field.media.image.field_media_image.yml';
+  $config_importer->update($config,
+    'field.field.media.image.field_media_image',
+    'settings.alt_field_required'
+  );
+}


### PR DESCRIPTION
Issue: https://propeople-us.atlassian.net/browse/OYPD-474
Drupal.org issue: https://www.drupal.org/node/2884035

Steps to review:
- [ ] login as admin
- [ ] add image (go to [sitename]/media/add/image)
- [ ] find field Image and click on "Choose File"
- [ ] select any file
- [ ] verify "Alternative text" is required with red star
Please look https://monosnap.com/file/AeOxZz6kWxU53XUZYcPciSG1dzYtHr