### PR TITLE
[OYPD-470] Remove <meta http-equiv="content-language" content="en" /> from all pages 

### DIFF
--- a/modules/openy_features/openy_node/config/install/metatag.metatag_defaults.node.yml
+++ b/modules/openy_features/openy_node/config/install/metatag.metatag_defaults.node.yml
@@ -5,7 +5,6 @@ id: node
 label: Content
 tags:
   canonical_url: '[node:path]'
-  content_language: '[node:langcode]'
   description: '[node:summary]'
   title: '[node:title] | [site:name]'
   og_title: '[node:title]'


### PR DESCRIPTION
Issue: https://propeople-us.atlassian.net/browse/OYPD-470
Drupal.org issue: 

Steps for review:
- [x] go to [sitename]/about
- [x] use "View Page source" open page source code
- [x] verify you don't see meta http-equiv="content-language"