### PR TITLE
[Minor-Fix][417] "Home" link leads to 404.

### DIFF
--- a/modules/openy_features/openy_demo_content/modules/openy_demo_menu/modules/openy_demo_menu_main/config/install/migrate_plus.migration.menu_link_main.yml
+++ b/modules/openy_features/openy_demo_content/modules/openy_demo_menu/modules/openy_demo_menu_main/config/install/migrate_plus.migration.menu_link_main.yml
@@ -18,7 +18,7 @@ source:
       id: 1
       title: 'Home'
       menu_name: 'main'
-      link: 'openy'
+      link: 'internal:/'
       weight: 1
       parent_id: 0
       expanded: 0


### PR DESCRIPTION
Issue: https://github.com/ymcatwincities/openy/issues/417
Drupal.org issue: https://www.drupal.org/node/2884279

Steps for review:
- [x] go to any page
- [x] in the top find the main menu 
- [x] click on link "Home"
- [x] verify you follow to the frontpage and don't see 404 page.