### PR TITLE
Fix description in the module openy_block_basic 

### DIFF
--- a/modules/openy_features/openy_block/modules/openy_block_basic/config/install/block_content.type.basic_block.yml
+++ b/modules/openy_features/openy_block/modules/openy_block_basic/config/install/block_content.type.basic_block.yml
@@ -4,4 +4,4 @@ dependencies: {  }
 id: basic_block
 label: 'Basic block'
 revision: 1
-description: ''
+description: 'A simple block with a description.'

--- a/modules/openy_features/openy_block/modules/openy_block_basic/config/install/field.field.block_content.basic_block.field_block_content.yml
+++ b/modules/openy_features/openy_block/modules/openy_block_basic/config/install/field.field.block_content.basic_block.field_block_content.yml
@@ -11,7 +11,7 @@ field_name: field_block_content
 entity_type: block_content
 bundle: basic_block
 label: Content
-description: ''
+description: 'WYSIWYG field without summary.'
 required: true
 translatable: true
 default_value: {  }


### PR DESCRIPTION
Issue on drupal.org - https://www.drupal.org/node/2885219

Issue - https://github.com/ymcatwincities/openy/issues/499

Steps for review: 

- [x] Login as admin
- [x] Go to /admin/structure/block/block-content/manage/basic_block
- [x] Check that block description is exist
- [x] Go to /admin/structure/block/block-content/manage/basic_block/fields/block_content.basic_block.field_block_content
- [x] Check that field description is exist  