### PR TITLE
#508 Fix description in the module openy_node_alert

### DIFF
--- a/modules/openy_features/openy_node/modules/openy_node_alert/config/install/field.field.node.alert.field_alert_color.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_alert/config/install/field.field.node.alert.field_alert_color.yml
@@ -10,7 +10,7 @@ field_name: field_alert_color
 entity_type: node
 bundle: alert
 label: 'Background color'
-description: ''
+description: 'Reference field for choosing the term from "Color" vocabulary.'
 required: true
 translatable: false
 default_value: {  }

--- a/modules/openy_features/openy_node/modules/openy_node_alert/config/install/field.field.node.alert.field_alert_description.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_alert/config/install/field.field.node.alert.field_alert_description.yml
@@ -11,7 +11,7 @@ field_name: field_alert_description
 entity_type: node
 bundle: alert
 label: Description
-description: ''
+description: 'Textarea for the description/body with WYSIWYG, without summary.'
 required: true
 translatable: false
 default_value: {  }

--- a/modules/openy_features/openy_node/modules/openy_node_alert/config/install/field.field.node.alert.field_alert_link.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_alert/config/install/field.field.node.alert.field_alert_link.yml
@@ -11,7 +11,7 @@ field_name: field_alert_link
 entity_type: node
 bundle: alert
 label: Link
-description: ''
+description: 'Internal or external link.'
 required: false
 translatable: false
 default_value: {  }

--- a/modules/openy_features/openy_node/modules/openy_node_alert/config/install/field.field.node.alert.field_alert_place.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_alert/config/install/field.field.node.alert.field_alert_place.yml
@@ -11,7 +11,7 @@ field_name: field_alert_place
 entity_type: node
 bundle: alert
 label: Placement
-description: ''
+description: 'Select list field (singular) for choosing place: Header, Footer'
 required: true
 translatable: false
 default_value: {  }

--- a/modules/openy_features/openy_node/modules/openy_node_alert/config/install/field.field.node.alert.field_alert_text_color.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_alert/config/install/field.field.node.alert.field_alert_text_color.yml
@@ -10,7 +10,7 @@ field_name: field_alert_text_color
 entity_type: node
 bundle: alert
 label: 'Text color'
-description: ''
+description: 'Reference field for choosing the term from "Color" vocabulary.'
 required: true
 translatable: false
 default_value: {  }


### PR DESCRIPTION
Issue on drupal.org - https://www.drupal.org/node/2885228

Issue - #508 

Steps for review:

- [ ] Login as admin
- [ ] Go to /admin/structure/types/manage/alert/fields/node.alert.field_alert_description
- [ ] Check description on 'Description Field' field exists
- [ ] Go to /admin/structure/types/manage/alert/fields/node.alert.field_alert_color
- [ ] Check description on 'Background color' field exists
- [ ] Go to /admin/structure/types/manage/alert/fields/node.alert.field_alert_link
- [ ] Check description on 'Link' field exists
- [ ] Go to /admin/structure/types/manage/alert/fields/node.alert.field_alert_place
- [ ] Check description on 'Placement' field exists
- [ ] Go to /admin/structure/types/manage/alert/fields/node.alert.field_alert_text_color
- [ ] Check description on 'Text Color' field exists

Drupal Issue
https://www.drupal.org/node/2885228#comment-12123575