### PR TITLE
Issue 509 - Fix description in the module openy_node_blog 

### DIFF
--- a/modules/openy_features/openy_node/modules/openy_node_blog/config/install/field.field.node.blog.field_blog_category.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_blog/config/install/field.field.node.blog.field_blog_category.yml
@@ -14,7 +14,7 @@ field_name: field_blog_category
 entity_type: node
 bundle: blog
 label: Category
-description: ''
+description: 'Reference field for choosing the term from "Blog Category" vocabulary. Multiple Values.'
 required: false
 translatable: true
 default_value: {  }

--- a/modules/openy_features/openy_node/modules/openy_node_blog/config/install/field.field.node.blog.field_blog_description.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_blog/config/install/field.field.node.blog.field_blog_description.yml
@@ -15,7 +15,7 @@ field_name: field_blog_description
 entity_type: node
 bundle: blog
 label: Description
-description: ''
+description: 'Textarea for the description/body with WYSIWYG, without summary.'
 required: false
 translatable: true
 default_value: {  }

--- a/modules/openy_features/openy_node/modules/openy_node_blog/config/install/field.field.node.blog.field_blog_image.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_blog/config/install/field.field.node.blog.field_blog_image.yml
@@ -10,7 +10,7 @@ field_name: field_blog_image
 entity_type: node
 bundle: blog
 label: Image
-description: ''
+description: 'Image field for the Blog item. Entity reference to Media bundle.'
 required: false
 translatable: true
 default_value: {  }

--- a/modules/openy_features/openy_node/modules/openy_node_blog/config/install/field.field.node.blog.field_blog_location.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_blog/config/install/field.field.node.blog.field_blog_location.yml
@@ -11,7 +11,7 @@ field_name: field_blog_location
 entity_type: node
 bundle: blog
 label: Locations
-description: ''
+description: 'Reference field to branch and camp nodes. Multiple Values.'
 required: true
 translatable: true
 default_value: {  }

--- a/modules/openy_features/openy_node/modules/openy_node_blog/config/install/field.field.node.blog.field_blog_style.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_blog/config/install/field.field.node.blog.field_blog_style.yml
@@ -15,19 +15,7 @@ field_name: field_blog_style
 entity_type: node
 bundle: blog
 label: Style
-description: 'Select list field with multiple options for choosing style(Story Card, Photo Card, New Card, Color Card)'
-Story Card
-Photo Card
-News Card (default)
-Color Card':
-Story Card
-Photo Card
-News Card (default)
-Color Card:
-Story Card
-Photo Card
-News Card (default)
-Color Card'
+description: ''
 required: true
 translatable: true
 default_value:

--- a/modules/openy_features/openy_node/modules/openy_node_blog/config/install/field.field.node.blog.field_blog_style.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_blog/config/install/field.field.node.blog.field_blog_style.yml
@@ -16,6 +16,18 @@ entity_type: node
 bundle: blog
 label: Style
 description: 'Select list field with multiple options for choosing style(Story Card, Photo Card, New Card, Color Card)'
+Story Card
+Photo Card
+News Card (default)
+Color Card':
+Story Card
+Photo Card
+News Card (default)
+Color Card:
+Story Card
+Photo Card
+News Card (default)
+Color Card'
 required: true
 translatable: true
 default_value:

--- a/modules/openy_features/openy_node/modules/openy_node_blog/config/install/field.field.node.blog.field_blog_style.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_blog/config/install/field.field.node.blog.field_blog_style.yml
@@ -15,7 +15,19 @@ field_name: field_blog_style
 entity_type: node
 bundle: blog
 label: Style
-description: ''
+description: 'Select list field with multiple options for choosing style(Story Card, Photo Card, New Card, Color Card)'
+Story Card
+Photo Card
+News Card (default)
+Color Card':
+Story Card
+Photo Card
+News Card (default)
+Color Card:
+Story Card
+Photo Card
+News Card (default)
+Color Card'
 required: true
 translatable: true
 default_value:

--- a/modules/openy_features/openy_node/modules/openy_node_blog/config/install/field.field.node.blog.field_blog_style.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_blog/config/install/field.field.node.blog.field_blog_style.yml
@@ -16,18 +16,6 @@ entity_type: node
 bundle: blog
 label: Style
 description: 'Select list field with multiple options for choosing style(Story Card, Photo Card, New Card, Color Card)'
-Story Card
-Photo Card
-News Card (default)
-Color Card':
-Story Card
-Photo Card
-News Card (default)
-Color Card:
-Story Card
-Photo Card
-News Card (default)
-Color Card'
 required: true
 translatable: true
 default_value:

--- a/modules/openy_features/openy_node/modules/openy_node_blog/config/install/field.field.node.blog.field_content.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_blog/config/install/field.field.node.blog.field_content.yml
@@ -11,7 +11,7 @@ field_name: field_content
 entity_type: node
 bundle: blog
 label: Content
-description: ''
+description: 'A paragraph embed field that will allow us to add various flexible content modules, from the predefined list of paragraph types.'
 required: false
 translatable: true
 default_value: {  }

--- a/modules/openy_features/openy_node/modules/openy_node_blog/config/install/field.field.node.blog.field_sidebar_content.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_blog/config/install/field.field.node.blog.field_sidebar_content.yml
@@ -11,7 +11,7 @@ field_name: field_sidebar_content
 entity_type: node
 bundle: blog
 label: Content
-description: ''
+description: 'A paragraph embed field that will allow us to add various flexible content modules, from the predefined list of paragraph types.'
 required: false
 translatable: true
 default_value: {  }


### PR DESCRIPTION
There is a module openy_node_blog. This module has an empty description in configuration files(6 files).

We need to add a description.

See for details
https://github.com/ymcatwincities/openy/blob/8.x-1.x/modules/openy_features/openy_node/modules/openy_node_blog/config/install/field.field.node.blog.field_blog_category.yml#L17

and documentation
https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Content%20structure/Content%20Types/Blog.md

Steps to find the content type:

Open openY
Login as admin
Go to Administration -> Structure -> Content types -> Blog Post

Drupal Issue - https://www.drupal.org/node/2885234