### PR TITLE
Bug 517

### DIFF
--- a/modules/openy_features/openy_node/modules/openy_node_blog/openy_node_blog.module
+++ b/modules/openy_features/openy_node/modules/openy_node_blog/openy_node_blog.module
@@ -9,16 +9,18 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\State\StateInterface;
 
 /**
- * Implements hook_form_FORM_ID_alter().
+ * Implements hook_form_alter().
  */
-function openy_node_form_node_blog_form_alter(&$form, FormStateInterface $form_state, $form_id) {
-  $visible = [
-    'visible' => [
-      [
-        'select[name="field_blog_style"]' => ['value' => 'color'],
+function openy_node_blog_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  if ($form_id == 'node_blog_edit_form' || $form_id == 'node_blog_form') {
+    $visible = [
+      'visible' => [
+        [
+          'select[name="field_blog_style"]' => ['value' => 'color'],
+        ],
       ],
-    ],
-  ];
-  $form['field_blog_color']['widget']['#states'] = $visible;     
-  $form['field_blog_text_color']['widget']['#states'] = $visible;
+    ];
+    $form['field_blog_color']['widget']['#states'] = $visible;     
+    $form['field_blog_text_color']['widget']['#states'] = $visible;
+  }
 }

--- a/themes/openy_themes/openy_rose/templates/node/node--blog--teaser.html.twig
+++ b/themes/openy_themes/openy_rose/templates/node/node--blog--teaser.html.twig
@@ -85,7 +85,7 @@
 {% set bg_color  = content.field_blog_color['#items'].entity.field_color.value ? 'background-color: #' ~ content.field_blog_color['#items'].entity.field_color.value ~ '; ' : null %}
 
 <article{{ attributes.addClass(classes) }}>
-  <div class="inner-wrapper" {{ attributes.setAttribute('style', bg_color ~ color) }}>
+  <div class="inner-wrapper" {% if ( node.field_blog_style.value == "color" ) %}{{ attributes.setAttribute('style', bg_color ~ color) }}{% endif %}>
     {% if ( node.field_blog_style.value == "photo" ) %}
       <div>
         {{ content.field_blog_image }}
@@ -100,13 +100,13 @@
             </div>
           </div>
         {% endif %}
-        <h2 {{ attributes.setAttribute('style', color) }}>
+        <h2 {% if ( node.field_blog_style.value == "color" ) %}{{ attributes.setAttribute('style', color) }}{% endif %}>
           <a href="{{ url }}" rel="bookmark">
             {{ label }}
           </a>
         </h2>
       </div>
-      <h4 {{ attributes.setAttribute('style', color) }}>{{ category }}</h4>
+      <h4 {% if ( node.field_blog_style.value == "color" ) %}{{ attributes.setAttribute('style', color) }}{% endif %}>{{ category }}</h4>
     </div>
   </div>
 </article>


### PR DESCRIPTION
Make sure these boxes are checked before asking for review of your pull request - thank you!

## General checks
- [x] All coding styles are fulfilled and there are no any issues reported by CodeSniffer CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/ci-errors.png" width="200" alt="CI code sniffer errors">
- [x] All tests are running and there are no failed tests reported by CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/behat.png" width="200" alt="Behat test results">
- [x] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [x] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [x] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [x] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [x] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!

## Steps for review

- [x] Login as admin.
- [x] Go to the front page and select colored teaser of blog post below.
- [x] Click to view full blog post end edit it.
- [x] Change style from Color Card to another type and save the post.
- [x] Go back to the front page and clear cache.
- [x] If the teaser of that post became default view (not colored) than you can set this issue in resolved.
