### PR TITLE
Add descriptions & placeholders to teaser paragraph

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_teaser/config/install/core.entity_form_display.paragraph.teaser.default.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_teaser/config/install/core.entity_form_display.paragraph.teaser.default.yml
@@ -39,15 +39,15 @@ content:
   field_prgf_link:
     weight: 3
     settings:
-      placeholder_url: ''
-      placeholder_title: ''
+      placeholder_url: '/teaser_subpage_uri'
+      placeholder_title: 'Teaser subpage title'
     third_party_settings: {  }
     type: link_default
   field_prgf_title:
     weight: 0
     settings:
       size: 60
-      placeholder: ''
+      placeholder: 'Provide a title here'
     third_party_settings: {  }
     type: string_textfield
 hidden:

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_teaser/config/install/field.field.paragraph.teaser.field_prgf_description.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_teaser/config/install/field.field.paragraph.teaser.field_prgf_description.yml
@@ -11,7 +11,7 @@ field_name: field_prgf_description
 entity_type: paragraph
 bundle: teaser
 label: Description
-description: ''
+description: 'WYSIWYG field without summary.'
 required: false
 translatable: true
 default_value: {  }

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_teaser/config/install/field.field.paragraph.teaser.field_prgf_image.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_teaser/config/install/field.field.paragraph.teaser.field_prgf_image.yml
@@ -10,7 +10,7 @@ field_name: field_prgf_image
 entity_type: paragraph
 bundle: teaser
 label: Image
-description: ''
+description: 'Entityreference to media image. Single value.'
 required: false
 translatable: true
 default_value: {  }

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_teaser/config/install/field.field.paragraph.teaser.field_prgf_link.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_teaser/config/install/field.field.paragraph.teaser.field_prgf_link.yml
@@ -11,7 +11,7 @@ field_name: field_prgf_link
 entity_type: paragraph
 bundle: teaser
 label: Link
-description: ''
+description: 'Link field that should store internal and external links.'
 required: false
 translatable: true
 default_value: {  }

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_teaser/config/install/field.field.paragraph.teaser.field_prgf_title.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_teaser/config/install/field.field.paragraph.teaser.field_prgf_title.yml
@@ -9,7 +9,7 @@ field_name: field_prgf_title
 entity_type: paragraph
 bundle: teaser
 label: Title
-description: ''
+description: 'Title of the Teaser.'
 required: false
 translatable: true
 default_value: {  }


### PR DESCRIPTION
Teaser paragraph descriptions & placeholders #482

- [x] login as admin
- [x] Go to /node/add/landing_page
- [x] Add paragraf block teaser
- [x] Check description for fields and compare with docs.  https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Content%20structure/Paragraphs/Teaser.md