### PR TITLE
Add description to Simple content paragraph

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_simple_content/config/install/field.field.paragraph.simple_content.field_prgf_description.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_simple_content/config/install/field.field.paragraph.simple_content.field_prgf_description.yml
@@ -11,7 +11,7 @@ field_name: field_prgf_description
 entity_type: paragraph
 bundle: simple_content
 label: Content
-description: ''
+description: 'WYSIWYG field without summary.'
 required: true
 translatable: true
 default_value: {  }


### PR DESCRIPTION
Simple content paragraph descriptions & placeholders #479
- [x] login as admin
- [x] Go to /node/add/landing_page
- [x] Add paragraf block Simple content 
- [x] Check description for fields and compare with docs.  https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Content%20structure/Paragraphs/Simple%20Content.md
