### PR TITLE
Add descriptions & placeholders to  Location finder filter paragraf

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_loc_finder/config/install/field.field.paragraph.prgf_location_finder.field_prgf_location_finder.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_loc_finder/config/install/field.field.paragraph.prgf_location_finder.field_prgf_location_finder.yml
@@ -15,7 +15,7 @@ field_name: field_prgf_location_finder
 entity_type: paragraph
 bundle: prgf_location_finder
 label: 'Location finder'
-description: ''
+description: 'Block reference to the location_finder block. Should have default value and should be hidden in form display.'
 required: false
 translatable: true
 default_value:

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_loc_finder/config/install/field.field.paragraph.prgf_location_finder_filters.field_prgf_lf_tags_style.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_loc_finder/config/install/field.field.paragraph.prgf_location_finder_filters.field_prgf_lf_tags_style.yml
@@ -11,7 +11,7 @@ field_name: field_prgf_lf_tags_style
 entity_type: paragraph
 bundle: prgf_location_finder_filters
 label: 'Tags style'
-description: ''
+description: 'Tags style that will be used for map tags filter. Default - checkboxes. Second option is multiselect widget with checkboxes.'
 required: true
 translatable: false
 default_value:


### PR DESCRIPTION
Location finder filter paragraph descriptions & placeholders #481
## Steps for review

- [x] login as admin
- [x] Go to /node/add/landing_page
- [x] Add paragraf block Location finder filter 
- [x] Check description for fields and compare with docs.  https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Content structure/Paragraphs/Location finder filters.md