### PR TITLE
Add descriptions & placeholders to Gallery paragraph

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_gallery/config/install/core.entity_form_display.paragraph.gallery.default.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_gallery/config/install/core.entity_form_display.paragraph.gallery.default.yml
@@ -28,7 +28,7 @@ content:
     weight: 0
     settings:
       size: 60
-      placeholder: ''
+      placeholder: 'Provide title here'
     third_party_settings: {  }
     type: string_textfield
   field_prgf_images:
@@ -46,8 +46,8 @@ content:
   field_prgf_link:
     weight: 2
     settings:
-      placeholder_url: ''
-      placeholder_title: ''
+      placeholder_url: '/subpage_uri'
+      placeholder_title: 'Subpage title'
     third_party_settings: {  }
     type: link_default
 hidden:

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_gallery/config/install/field.field.paragraph.gallery.field_prgf_description.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_gallery/config/install/field.field.paragraph.gallery.field_prgf_description.yml
@@ -11,7 +11,7 @@ field_name: field_prgf_description
 entity_type: paragraph
 bundle: gallery
 label: Description
-description: ''
+description: 'WYSIWYG field without summary.'
 required: false
 translatable: true
 default_value: {  }

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_gallery/config/install/field.field.paragraph.gallery.field_prgf_headline.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_gallery/config/install/field.field.paragraph.gallery.field_prgf_headline.yml
@@ -9,7 +9,7 @@ field_name: field_prgf_headline
 entity_type: paragraph
 bundle: gallery
 label: Headline
-description: ''
+description: 'Headline of the gallery.'
 required: true
 translatable: true
 default_value: {  }

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_gallery/config/install/field.field.paragraph.gallery.field_prgf_images.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_gallery/config/install/field.field.paragraph.gallery.field_prgf_images.yml
@@ -10,7 +10,7 @@ field_name: field_prgf_images
 entity_type: paragraph
 bundle: gallery
 label: Images
-description: ''
+description: 'Link field that should store internal and external links.'
 required: false
 translatable: true
 default_value: {  }

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_gallery/config/install/field.field.paragraph.gallery.field_prgf_link.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_gallery/config/install/field.field.paragraph.gallery.field_prgf_link.yml
@@ -11,7 +11,7 @@ field_name: field_prgf_link
 entity_type: paragraph
 bundle: gallery
 label: Link
-description: ''
+description: 'Entityreference to media image. Multiple values.'
 required: false
 translatable: true
 default_value: {  }


### PR DESCRIPTION
Gallery paragraph descriptions & placeholders #480

## Steps for review
- [x] Go to /node/add/landing_page
- [x] Add paragraf block Gallery 
- [x] Check description for fields and compare with docs.  https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Content%20structure/Paragraphs/Gallery.md
