### PR TITLE
Fix logger_entity name length.

### DIFF
--- a/modules/custom/logger_entity/logger_entity.install
+++ b/modules/custom/logger_entity/logger_entity.install
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @file
+ * Contains logger_entity.install.
+ */
+
+use Drupal\Core\Database\Database;
+
+/**
+ * Fix logger_entity name length.
+ */
+function logger_entity_update_8001() {
+  $spec = [
+    'type' => 'varchar',
+    'length' => 128,
+  ];
+  $schema = Database::getConnection()->schema();
+  $schema->changeField('logger_entity', 'name', 'name', $spec);
+}

--- a/modules/custom/logger_entity/src/Entity/LoggerEntity.php
+++ b/modules/custom/logger_entity/src/Entity/LoggerEntity.php
@@ -204,7 +204,7 @@ class LoggerEntity extends ContentEntityBase implements LoggerEntityInterface {
       ->setLabel(t('Name'))
       ->setDescription(t('The name of the Logger Entity entity.'))
       ->setSettings(array(
-        'max_length' => 50,
+        'max_length' => 128,
         'text_processing' => 0,
       ))
       ->setDefaultValue('')


### PR DESCRIPTION
In logger entity name field can be more than 50 symbols. For example `core.entity_view_display.node.program_subcategory.header_program`

drupal.org issue - https://www.drupal.org/node/2886760

Steps for review:
- [ ] login as admin
- [ ] go to /admin/config/logger_entity/add/openy_config_upgrade_logs
- [ ] check that you can create new entity with name lenth more than 50 
- [ ] profit