### PR TITLE
[OYPD-456] Changes to make the membership calculator radio buttons usable with k…

### DIFF
--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -5145,7 +5145,12 @@ a[href="#step2"] {
   display: block;
 }
 #membership-calc-wrapper input[name="type"] {
-  display: none;
+  position: absolute !important;
+  clip: rect(1px, 1px, 1px, 1px);
+  overflow: hidden;
+  height: 1px;
+  width: 1px;
+  word-wrap: normal;
 }
 #membership-calc-wrapper .membership-type {
   margin: 0 0 20px 0;

--- a/themes/openy_themes/openy_rose/scss/modules/_membership.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_membership.scss
@@ -62,7 +62,12 @@ a[href="#step2"] {
     }
   }
   input[name="type"] {
-    display: none;
+    position: absolute !important;
+    clip: rect(1px, 1px, 1px, 1px);
+    overflow: hidden;
+    height: 1px;
+    width: 1px;
+    word-wrap: normal;
   }
   .membership-type {
     margin: 0 0 20px 0;

--- a/themes/openy_themes/openy_rose/templates/form/form-element-membership-type.html.twig
+++ b/themes/openy_themes/openy_rose/templates/form/form-element-membership-type.html.twig
@@ -92,7 +92,8 @@
       <h3>{{ data.title }}</h3>
       {{ data.description }}
       <label for="{{ element['#attributes'].id }}">
-        <div class="btn btn-default blue btn-lg">{{ 'select'|t }}</div>
+        <span class="visually-hidden">{{ data.title }}</span>
+        <div class="btn btn-default blue btn-lg" aria-hidden="true">{{ 'select'|t }}</div>
       </label>
     </div>
   {% endif %}


### PR DESCRIPTION
- [x] Got to membership calculator, /join
- [x] Verify that you can navigate the membership types with a keyboard.
- [x] Verify that a screen reader will correctly read the labels for each type instead of saying "Select".

To fix this, I unhid the label for each radio and added visually hidden text inside the label that matches the membership type. I then added aria-hidden=true to the "select" text so the screen reader will ignore it.

Navigating with keyboard seems to work and I can chose a membership and navigate to the next step in the form.