### PR TITLE
[OYPD-513] Moving the slick override JS into one function and removing role attr…

### DIFF
--- a/modules/openy_features/openy_node/modules/openy_node_alert/js/openy_node_alert.js
+++ b/modules/openy_features/openy_node/modules/openy_node_alert/js/openy_node_alert.js
@@ -76,10 +76,17 @@
     }
   };
 
-  Drupal.behaviors.removeAriaDescribedby = {
+  Drupal.behaviors.removeUnneededAria = {
     attach: function (context, settings) {
+      $('.slick-list', context).once().each(function () {
+        $(this).removeAttr('aria-live');
+      });
+      $('.slick-track', context).once().each(function () {
+        $(this).removeAttr('role');
+      });
       $('.slick__slide', context).once().each(function () {
         $(this).removeAttr('aria-describedby');
+        $(this).removeAttr('role');
       });
     }
   };


### PR DESCRIPTION
I moved the JS overrides for the slick slider into one function and added additional ones to remove the role="listbox" and role="option" from the slider. I can find no reason to have them, but they are causing the "you are on a text element in a listbox" problems.

With them removed I can get the screen reader to identify the close button as a separate item. It also identifies the alert link as a separate item now and a properly clickable link.