### PR TITLE
[OYPD-515] Adding a JS function to move the top nav when the skip link is in focus

### DIFF
--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -5787,4 +5787,9 @@ a:focus,
   outline: 5px auto #69ff00;
 }
 
+.focusable.skip-link:focus {
+  position: fixed !important;
+  top: 0;
+}
+
 /*# sourceMappingURL=styles.css.map */

--- a/themes/openy_themes/openy_rose/scripts/openy_rose.js
+++ b/themes/openy_themes/openy_rose/scripts/openy_rose.js
@@ -192,4 +192,21 @@
     }
   };
 
+  /**
+   * Adjust the top nav position when the skip link is in focus.
+   */
+  Drupal.behaviors.adjustSkipLink = {
+    attach: function (context, settings) {
+      // On focus, move the top nav down to show the skip link.
+      $('.skip-link').on('focus', function () {
+        var link_height = $(this).height();
+        $('.top-navs').css({'margin-top': link_height});
+      });
+      // When focus is lost, remove the unneeded height.
+      $('.skip-link').on('focusout', function () {
+        $('.top-navs').css({'margin-top': '0'});
+      });
+    }
+  };
+
 })(jQuery);

--- a/themes/openy_themes/openy_rose/scss/state/_state.scss
+++ b/themes/openy_themes/openy_rose/scss/state/_state.scss
@@ -11,3 +11,8 @@ a:focus,
 .navbar-toggle:focus {
   outline: 5px auto $bright-green;
 }
+
+.focusable.skip-link:focus {
+  position: fixed !important;
+  top: 0;
+}


### PR DESCRIPTION
- [x]  Tab to get to the "skip to main content" link.
- [x] Verify the link appears at the top of the page, and not under the menu.
- [x] Verify the menu moves back to its correct position when the link is not in focus.

![screen shot 2017-06-22 at 11 26 30 am](https://user-images.githubusercontent.com/1504038/27442870-74622e8a-573f-11e7-8e9f-ea8dc041226a.png)
