### PR TITLE
Removing unneeded JS function

### DIFF
--- a/modules/openy_features/openy_node/modules/openy_node_alert/js/openy_node_alert.js
+++ b/modules/openy_features/openy_node/modules/openy_node_alert/js/openy_node_alert.js
@@ -91,12 +91,4 @@
     }
   };
 
-  Drupal.behaviors.removeAriaLive = {
-    attach: function (context, settings) {
-      $('.slick-list', context).once().each(function () {
-        $(this).removeAttr('aria-live');
-      });
-    }
-  };
-
 })(jQuery);


### PR DESCRIPTION
I forgot to remove this function. The same functionality was moved to the function above.

- [x] Verify that this functionality to remove the aria-live is in the function above.
