### PR TITLE
[OYPD-492] Adjusting h2 and h3 of paragraphs

### DIFF
--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -1591,7 +1591,7 @@ body {
     margin-bottom: 27px;
   }
 }
-.sidebar-card h3 {
+.sidebar-card h2 {
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
   text-transform: uppercase;
   color: #636466;
@@ -1601,11 +1601,14 @@ body {
   line-height: 1.2;
   letter-spacing: 2px;
 }
-.sidebar-card h2 {
+.sidebar-card .field-prgf-description h2 {
   color: #5c2e91;
+  font-family: "Cachet W01 Book", "Ubuntu Condensed", sans-serif;
   font-weight: bold;
+  letter-spacing: normal;
+  text-transform: none;
 }
-.sidebar-card h2 a {
+.sidebar-card .field-prgf-description h2 a {
   text-decoration: none;
   color: inherit;
 }

--- a/themes/openy_themes/openy_rose/scss/modules/_paragraphs.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_paragraphs.scss
@@ -331,7 +331,7 @@
     margin-bottom: 27px;
   }
 
-  h3 {
+  h2 {
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
     text-transform: uppercase;
     color: $default-grey;
@@ -342,9 +342,12 @@
     letter-spacing: 2px;
   }
 
-  h2 {
+  .field-prgf-description h2 {
     color: $purple;
+    font-family: $font-style-cachet-ubuntu;
     font-weight: bold;
+    letter-spacing: normal;
+    text-transform: none;
 
     a {
       text-decoration: none;

--- a/themes/openy_themes/openy_rose/templates/paragraph/paragraph--featured-content--default.html.twig
+++ b/themes/openy_themes/openy_rose/templates/paragraph/paragraph--featured-content--default.html.twig
@@ -45,9 +45,9 @@ set classes = [
 ]
 %}
 <div{{ attributes.addClass(classes) }}>
-  <h3 class="h1">
+  <h2 class="h1">
     {{ content.field_prgf_headline }}
-  </h3>
+  </h2>
   <div class="description">
       {{ content.field_prgf_description }}
   </div>

--- a/themes/openy_themes/openy_rose/templates/paragraph/paragraph--promo-card--default.html.twig
+++ b/themes/openy_themes/openy_rose/templates/paragraph/paragraph--promo-card--default.html.twig
@@ -46,13 +46,13 @@ set classes = [
 ]
 %}
 <div{{ attributes.addClass(classes) }}>
-  <h3>
+  <h2>
     {{ content.field_prgf_title }}
-  </h3>
+  </h2>
   <div class="description">
-    <h4>
+    <h3>
       {{ content.field_prgf_headline }}
-    </h4>
+    </h3>
     {{ content.field_prgf_description }}
   </div>
   {% if content.field_prgf_link.0['#title'] %}

--- a/themes/openy_themes/openy_rose/templates/paragraph/paragraph--story-card--default.html.twig
+++ b/themes/openy_themes/openy_rose/templates/paragraph/paragraph--story-card--default.html.twig
@@ -47,9 +47,9 @@ set classes = [
 %}
 <div{{ attributes.addClass(classes) }}>
   <a href="{{ content.field_prgf_link.0['#url'] }}">
-    <h3>
+    <h2>
       {{ content.field_prgf_title }}
-    </h3>
+    </h2>
     <div class="quote">
       {% include active_theme_path() ~ '/img/icons/quote_purple.svg' %}
       {{ content.field_prgf_headline }}


### PR DESCRIPTION
- [x] Verify the paragraph types of story card, promo card, featured content, and grid, have been adjusted according to OYPD-492.

I may be mistaken but some of the changes requested are not needed. The grid titles, for example, were already H2. Also, the featured content intro paragraph is already in a <p> tag.

I did not change the quote, since it is not in a H tag. Is that change necessary?