### PR TITLE
[OYPD-517] Focus not shifting to start of new content when loading more blog posts.

### DIFF
--- a/themes/openy_themes/openy_rose/scripts/openy_rose.js
+++ b/themes/openy_themes/openy_rose/scripts/openy_rose.js
@@ -209,4 +209,33 @@
     }
   };
 
+  /**
+   * Add focus for first loaded element.
+   */
+  Drupal.behaviors.load_more_focus = {
+    attach: function (context, settings) {
+      $('.blog-more-teaser .load_more_button .button', context).click(function () {
+        var $viewsRow = $('.blog-more-teaser .views-row'),
+          indexLastRow = $viewsRow.length,
+          getElement,
+          itemFocus;
+        if (Drupal.views !== undefined) {
+          $.each(Drupal.views.instances, function (i, view) {
+            if (view.settings.view_name == "listing_blog_posts") {
+              $(document).ajaxComplete(function (event, xhr, settings) {
+                getElement = $('.blog-more-teaser .views-row');
+                itemFocus = getElement[indexLastRow];
+                // Add focus to element.
+                $(itemFocus).find('h3 a').focus();
+                // Update number indexLastRow.
+                $viewsRow = $('.blog-more-teaser .views-row');
+                indexLastRow = $viewsRow.length;
+              });
+            }
+          });
+        }
+      });
+    }
+  };
+
 })(jQuery);

--- a/themes/openy_themes/openy_rose/scripts/openy_rose.js
+++ b/themes/openy_themes/openy_rose/scripts/openy_rose.js
@@ -214,21 +214,21 @@
    */
   Drupal.behaviors.load_more_focus = {
     attach: function (context, settings) {
-      $('.blog-more-teaser .load_more_button .button', context).click(function () {
-        var $viewsRow = $('.blog-more-teaser .views-row'),
+      $('.views-element-container .load_more_button .button', context).click(function () {
+        var $viewsRow = $('.views-element-container .views-row'),
           indexLastRow = $viewsRow.length,
           getElement,
           itemFocus;
         if (Drupal.views !== undefined) {
           $.each(Drupal.views.instances, function (i, view) {
-            if (view.settings.view_name == "listing_blog_posts") {
+            if (view.settings.view_name.length != 0) {
               $(document).ajaxComplete(function (event, xhr, settings) {
-                getElement = $('.blog-more-teaser .views-row');
+                getElement = $('.views-element-container .views-row');
                 itemFocus = getElement[indexLastRow];
                 // Add focus to element.
                 $(itemFocus).find('h3 a').focus();
                 // Update number indexLastRow.
-                $viewsRow = $('.blog-more-teaser .views-row');
+                $viewsRow = $('.views-element-container .views-row');
                 indexLastRow = $viewsRow.length;
               });
             }


### PR DESCRIPTION
[OYPD-517] Add comment to part of code in the JS.

Make sure these boxes are checked before asking for review of your pull request - thank you!

## General checks
- [x] All coding styles are fulfilled and there are no any issues reported by CodeSniffer CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/ci-errors.png" width="200" alt="CI code sniffer errors">
- [x] All tests are running and there are no failed tests reported by CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/behat.png" width="200" alt="Behat test results">
- [x] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [x] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [x] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [x] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [x] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!

# Jira issue: 
https://propeople-us.atlassian.net/browse/OYPD-517
Drupal.org issue: https://www.drupal.org/node/2890014

# Steps to review:
- [x] go to /blog
- [x] find "Latest news & Updates"
- [x] click on search input "Search the blog..."
- [x] in the keybord click TAB until focus will be in 'Load more' buttom and press Enter
- [x] verify focus moved to the first loaded element