### PR TITLE
[OYPD-494] Adding underline hover to various text elements

### DIFF
--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -212,7 +212,6 @@ body {
   font-size: 20px;
   text-transform: uppercase;
   line-height: 22px;
-  text-decoration: none;
 }
 .footer .footer__nav nav ul li ul {
   padding-top: 5px;
@@ -868,10 +867,6 @@ body {
     padding-right: 15px;
   }
 }
-.viewport .page-head__main-menu .nav-level-2 > a:hover,
-.viewport .page-head__main-menu .nav-level-2 > a:focus {
-  text-decoration: none;
-}
 .viewport .page-head__main-menu .dropdown-menu > li > a:focus,
 .viewport .page-head__main-menu .dropdown-menu > li > a:hover {
   background: none;
@@ -1000,6 +995,10 @@ body {
 }
 .page-head__main-menu .nav-level-2.open .fa-caret-down {
   display: none;
+}
+
+.nav > li > a:hover {
+  text-decoration: underline;
 }
 
 ::-webkit-input-placeholder {
@@ -1642,6 +1641,9 @@ body {
 .story-card .link {
   font-size: 15px;
   color: #0089d0;
+}
+.story-card .link:hover {
+  text-decoration: underline;
 }
 
 .promo-card .description {
@@ -5460,7 +5462,6 @@ a[href="#step2"] {
   color: #fff;
   display: block;
   font-size: 14px;
-  text-decoration: none;
 }
 @media (min-width: 48em) {
   .camp-menu__item a {

--- a/themes/openy_themes/openy_rose/scss/modules/_camp-menu.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_camp-menu.scss
@@ -68,7 +68,6 @@
       color: $white;
       display: block;
       font-size: 14px;
-      text-decoration: none;
 
       @include breakpoint($screen-sm) {
         @include rem(padding, 0 20px);

--- a/themes/openy_themes/openy_rose/scss/modules/_footer.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_footer.scss
@@ -54,7 +54,6 @@
             font-size: 20px;
             text-transform: uppercase;
             line-height: 22px;
-            text-decoration: none;
           }
 
           ul {

--- a/themes/openy_themes/openy_rose/scss/modules/_menu.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_menu.scss
@@ -190,11 +190,6 @@
 
   .page-head__main-menu {
 
-    .nav-level-2 > a:hover,
-    .nav-level-2 > a:focus {
-      text-decoration: none;
-    }
-
     .dropdown-menu>li>a:focus,
     .dropdown-menu>li>a:hover {
       background: none;
@@ -360,4 +355,9 @@
       }
     }
   }
+}
+
+// Overriding Bootstrap text decoration.
+.nav > li > a:hover {
+  text-decoration: underline;
 }

--- a/themes/openy_themes/openy_rose/scss/modules/_paragraphs.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_paragraphs.scss
@@ -389,6 +389,9 @@
   .link {
     font-size: 15px;
     color: $blue;
+    &:hover {
+      text-decoration: underline;
+    }
   }
 }
 


### PR DESCRIPTION
Check that links get an underline when hovered for:
- [x] Top nav main links
- [x] Top nav secondary links
- [x] Login link
- [x] Footer links
- [x] Camp menu links
- [x] Story card links
![screen shot 2017-06-28 at 11 37 21 am](https://user-images.githubusercontent.com/1504038/27647486-8dc5d00c-5bf9-11e7-9e9d-32738ea7f0b1.png)
![screen shot 2017-06-28 at 11 03 04 am](https://user-images.githubusercontent.com/1504038/27647488-8dc6b882-5bf9-11e7-94c4-4beac1b51a25.png)
![screen shot 2017-06-28 at 10 09 10 am](https://user-images.githubusercontent.com/1504038/27647485-8dc5643c-5bf9-11e7-83b2-c0cd631ee604.png)
![screen shot 2017-06-28 at 10 00 29 am](https://user-images.githubusercontent.com/1504038/27647489-8dc8b420-5bf9-11e7-8525-e09ce1798d62.png)
![screen shot 2017-06-28 at 9 48 39 am](https://user-images.githubusercontent.com/1504038/27647490-8dd0d7cc-5bf9-11e7-8b65-a09ea48a071e.png)

