### PR TITLE
[OYPD-497] Removing h2 from program subcategory

### DIFF
--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -2398,15 +2398,16 @@ body {
     margin: 0 0 45px;
   }
 }
-.program-header.program-header-sub-category h2 {
+.program-header.program-header-sub-category .field-category-program {
   color: #fff;
+  font-family: "Cachet W01 Book", "Ubuntu Condensed", sans-serif;
   font-size: 28px;
   letter-spacing: -0.8px;
   line-height: 28px;
   margin: 0;
 }
 @media (min-width: 48em) {
-  .program-header.program-header-sub-category h2 {
+  .program-header.program-header-sub-category .field-category-program {
     font-size: 36px;
   }
 }

--- a/themes/openy_themes/openy_rose/scss/modules/_program.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_program.scss
@@ -95,8 +95,9 @@
       }
     }
 
-    h2 {
+    .field-category-program {
       color: $white;
+      font-family: $font-style-cachet-ubuntu;
       font-size: 28px;
       letter-spacing: -0.8px;
       line-height: 28px;

--- a/themes/openy_themes/openy_rose/templates/node/node--program-subcategory--full.html.twig
+++ b/themes/openy_themes/openy_rose/templates/node/node--program-subcategory--full.html.twig
@@ -93,7 +93,7 @@ set classes = [
       <div class="row">
         <div class="col-md-8 main">
           <h1>{{ label }}</h1>
-          <h2>{{ content.field_category_program }}</h2>
+          {{ content.field_category_program }}
         </div>
         <div class="col-md-4 hidden-xs hidden-sm image">
           {{ content.field_category_image }}


### PR DESCRIPTION
Follow up to the origin issue. An H2 was missed in the program subcategory header.

- [x] Visit a subcategory, like this /programs/swimming/swim-team?location=1
- [x] Verify the subheader text (Swimming) is NOT wrapped in an H2.
- [x] Verify the styling stayed the same.