### PR TITLE
[OYPD-506] Removing role=option that gets added by the Slick JS. This interferes…

### DIFF
--- a/modules/custom/openy_schedules/js/openy_schedules.js
+++ b/modules/custom/openy_schedules/js/openy_schedules.js
@@ -244,4 +244,13 @@
       });
     }
   };
+
+  Drupal.behaviors.openy_schedules_removeUnneededAria = {
+    attach: function (context, settings) {
+      $('.schedule-sessions-group-slider .slick-slide', context).once().each(function () {
+        $(this).removeAttr('role');
+      });
+    }
+  };
+
 })(jQuery);

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_classes_listing/js/openy-classes-listing.js
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_classes_listing/js/openy-classes-listing.js
@@ -75,4 +75,12 @@
     }
   };
 
+  Drupal.behaviors.openy_prgf_class_listing_removeUnneededAria = {
+    attach: function (context, settings) {
+      $('.activity-group-slider .slick-slide', context).once().each(function () {
+        $(this).removeAttr('role');
+      });
+    }
+  };
+
 })(jQuery, Drupal, drupalSettings);


### PR DESCRIPTION
- [x] Visit a subprogram page, like /programs/health-and-fitness/active-older-adults
- [x] Verify the header links for the items in the activity group (slideshow) are seen as links by the screen reader.

To reproduce this on Mac:
Press VO+U or Capslock + U
In the overlay that appears, which lists links on the page, the slide headers should appear in the list.