### PR TITLE
[OYPD-550] Allowing hover underline for class teaser titles

### DIFF
--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -2764,6 +2764,9 @@ body {
 .sub-category-classes-view .activity-group .activity-group-slider .views-field-rendered-entity * {
   text-decoration: none;
 }
+.sub-category-classes-view .activity-group .activity-group-slider .views-field-rendered-entity a:hover h3 {
+  text-decoration: underline;
+}
 .sub-category-classes-view .activity-group .activity-group-slider .slick-track {
   display: -webkit-box;
   display: -webkit-flex;

--- a/themes/openy_themes/openy_rose/scss/modules/_program.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_program.scss
@@ -437,6 +437,9 @@
         * {
           text-decoration: none;
         }
+        a:hover h3 {
+          text-decoration: underline;
+        }
       }
 
       .slick-track {


### PR DESCRIPTION
- [x] Verify when hovering on class teasers that the title gets underline.

This should work on any of the class listing pages, like /programs/child-care/after-school-child-care.

![screen shot 2017-07-14 at 3 14 25 pm](https://user-images.githubusercontent.com/1504038/28227335-7b49015a-68a7-11e7-9cf1-035606aedd12.png)
