### PR TITLE
openy_map: Add ability use map_location param in URL to search by ZIP or address.

### DIFF
--- a/modules/custom/openy_map/js/map.js
+++ b/modules/custom/openy_map/js/map.js
@@ -451,17 +451,23 @@
 
       // Update url params.
       set_url_parameters: function () {
-        var url = document.location.pathname;
-        var filters_tags_raw = this.tag_filters;
-        var filters_tags = '';
-        if (filters_tags_raw) {
-          filters_tags = '?type=';
-          filters_tags_raw.forEach(function(tag) {
-            filters_tags += this.encode_to_url_format(tag) + ',';
-          }, this, filters_tags);
-          filters_tags = filters_tags.substring(0, filters_tags.length - 1);
+        var url = document.location.pathname
+          , params = this.get_parameters()
+          , filterTagsRaw = this.tag_filters
+          , filterTags = ''
+          , mapLocation = $('.search_field').val() || (params.hasOwnProperty('map_location') && params['map_location']) || '';
+        if (mapLocation) {
+          mapLocation = '?map_location=' + this.encode_to_url_format(mapLocation);
         }
-        window.history.replaceState(null, null, url + filters_tags);
+        if (filterTagsRaw) {
+          filterTags = !mapLocation ? '?' : '&';
+          filterTags += 'type=';
+          filterTagsRaw.forEach(function(tag) {
+            filterTags += this.encode_to_url_format(tag) + ',';
+          }, this, filterTags);
+          filterTags = filterTags.substring(0, filterTags.length - 1);
+        }
+        window.history.replaceState(null, null, url + mapLocation + filterTags);
       },
 
       // Renders an extra set of filter boxes below the map.


### PR DESCRIPTION
Make sure these boxes are checked before asking for review of your pull request - thank you!

## General checks
- [x] All coding styles are fulfilled and there are no any issues reported by CodeSniffer CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/ci-errors.png" width="200" alt="CI code sniffer errors">
- [x] All tests are running and there are no failed tests reported by CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/behat.png" width="200" alt="Behat test results">
- [x] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [x] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [x] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [x] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [x] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!

## Issue
There is no ability to use map_location param in URL to search by ZIP or address. For example, go to the page /locations?map_location=11706 The page /locations should contain Map object with filter form. The map_location value should be written to the field "Enter ZIP or street address" and Map object should be positioned to the location acceptable for ZIP code 11706. But it doesn't work this way.

issue: https://github.com/ymcatwincities/openy/issues/709

## Steps for review

- [x] Go to the page /locations?map_location=11706
- [x] URL must contain the param "map_location=11706" and the field "Enter ZIP or street address" must contain the value "11706".
- [x] Map object must be positioned on the object that has ZIP code 11706.