### PR TITLE
Fix for the notices about the not existing group and weight indexes in the tour JS library array.

### DIFF
--- a/modules/custom/openy_tour/openy_tour.module
+++ b/modules/custom/openy_tour/openy_tour.module
@@ -52,5 +52,7 @@ function openy_tour_page_attachments_alter(array &$attachments) {
  * Implements hook_js_alter().
  */
 function openy_tour_js_alter(&$javascript, AttachedAssetsInterface $assets) {
-  $javascript['core/modules/tour/js/tour.js']['data'] = drupal_get_path('module', 'openy_tour') . '/js/tour.js';
+  if (isset($javascript['core/modules/tour/js/tour.js'])) {
+    $javascript['core/modules/tour/js/tour.js']['data'] = drupal_get_path('module', 'openy_tour') . '/js/tour.js';
+  }
 }


### PR DESCRIPTION
Make sure these boxes are checked before asking for review of your pull request - thank you!

## General checks
- [x] All coding styles are fulfilled and there are no any issues reported by CodeSniffer CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/ci-errors.png" width="200" alt="CI code sniffer errors">
- [x] All tests are running and there are no failed tests reported by CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/behat.png" width="200" alt="Behat test results">
- [x] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [x] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [x] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [x] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [x] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!

## Issue
https://github.com/ymcatwincities/openy/issues/710

## Steps for review

- [x] Clear cache, go to the frontend (not admin) page, for example, /user/login, and check that there are not any notice/error messages.