### PR TITLE
Fix js errors in case of menu markup changes.

### DIFF
--- a/themes/openy_themes/openy_rose/scripts/openy_rose.js
+++ b/themes/openy_themes/openy_rose/scripts/openy_rose.js
@@ -111,10 +111,10 @@
     }
   };
 
-  // Horisontal scroll for camp menu.
+  // Horizontal scroll for camp menu.
   Drupal.behaviors.scrollableList = {
     attach: function (context, settings) {
-      $('.camp-menu-wrapper').once().each(function () {
+      $('.camp-menu-wrapper', context).once().each(function () {
         var $this = $(this),
             $list = $this.find('ul'),
             $items = $list.find('li'),
@@ -128,7 +128,11 @@
 
           $list.css('width', listWidth + listPadding + "px");
 
-          var scroll = new IScroll($this.find('.columns')[0], {
+          var columns = $this.find('.columns');
+          if (columns.length == 0) {
+            return;
+          }
+          var scroll = new IScroll(columns[0], {
             scrollX: true,
             scrollY: false,
             momentum: false,
@@ -140,7 +144,7 @@
 
           // GRADIENT BEHAVIOUR SCRIPT.
           var obj = $('.camp-menu');
-          var objWrap = $this.find('.columns').append('<div class="columns-gradient gradient-right" onclick="void(0)"></div>');
+          var objWrap = columns.append('<div class="columns-gradient gradient-right" onclick="void(0)"></div>');
           objWrap = document.querySelector('.columns-gradient');
           var sliderLength = listWidth - objWrap.offsetWidth + 40;
           var firstGap = 20;


### PR DESCRIPTION
On YLI we found some js errors due to changes in markup. To fix them here is a patch. 

## Steps for review

- [x] Review code changes. 
- [x] Review that Camp menu still working correctly. 
