### PR TITLE
[OYPD-574] Untitled body in page outline.

### DIFF
--- a/themes/openy_themes/openy_rose/openy_rose.theme
+++ b/themes/openy_themes/openy_rose/openy_rose.theme
@@ -365,6 +365,13 @@ function openy_rose_preprocess_html(&$variables) {
       }
     }
   }
+  // Get title from node or page.
+  if (isset($variables['node'])) {
+    $variables['title'] = $variables['node']->title->value;
+  }
+  else {
+    $variables['title'] = $variables['page']['#title'];
+  }
 }
 
 /**

--- a/themes/openy_themes/openy_rose/templates/page/html--footer.html.html.twig
+++ b/themes/openy_themes/openy_rose/templates/page/html--footer.html.html.twig
@@ -47,6 +47,7 @@
       Keyboard navigation/accessibility link to main content section in
       page.html.twig.
     #}
+    <h1 class="visually-hidden" aria-hidden="true">{{ title }}</h1>
     <a href="#main-content" class="visually-hidden focusable">
       {{ 'Skip to main content'|t }}
     </a>

--- a/themes/openy_themes/openy_rose/templates/page/html--header.html.html.twig
+++ b/themes/openy_themes/openy_rose/templates/page/html--header.html.html.twig
@@ -49,6 +49,7 @@
       Keyboard navigation/accessibility link to main content section in
       page.html.twig.
     #}
+    <h1 class="visually-hidden" aria-hidden="true">{{ title }}</h1>
     <a href="#main-content" class="visually-hidden focusable skip-link">
       {{ 'Skip to main content'|t }}
     </a>

--- a/themes/openy_themes/openy_rose/templates/page/html.html.twig
+++ b/themes/openy_themes/openy_rose/templates/page/html.html.twig
@@ -44,6 +44,7 @@
       Keyboard navigation/accessibility link to main content section in
       page.html.twig.
     #}
+    <h1 class="visually-hidden" aria-hidden="true">{{ title }}</h1>
     <a href="#main-content" class="visually-hidden focusable skip-link">
       {{ 'Skip to main content'|t }}
     </a>


### PR DESCRIPTION
Make sure these boxes are checked before asking for review of your pull request - thank you!

## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/ci-errors.png" width="200" alt="CI code sniffer errors">
- [ ] All tests are running and there are no failed tests reported by CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/behat.png" width="200" alt="Behat test results">
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!

# Jira issue: 
https://propeople-us.atlassian.net/browse/OYPD-574
Drupal.org issue: https://www.drupal.org/node/2907317

# Steps to review:
- [x] open google chrome browser
- [x] install extention HTML5 outliner
- [x] go to any page 
- [x] verify you don't see untitled body as here https://propeople-us.atlassian.net/secure/thumbnail/44909/image-2017-08-09-16-12-43-249.png?default=false