### PR TITLE
Add missing dependency to profile.

### DIFF
--- a/openy.info.yml
+++ b/openy.info.yml
@@ -92,6 +92,7 @@ dependencies:
   - custom_formatters
   - token_filter
   - views_field_formatter
+  - ctools
   # OpenY features.
   - openy_svg_formatter
   - openy_media_image


### PR DESCRIPTION
I found that `ctools` module is not in the list of profile dependencies, while it's required for some modules which are in the list of dependencies. Make sense to list this module in the list as well. 

## Steps for review
- [ ] review code changes