### PR TITLE
[OYPD-550] adding hover effects to schedules page tiles

### DIFF
--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -4918,6 +4918,9 @@ html.js .branch__updates_queue__button {
   text-decoration: none;
   position: relative;
 }
+#schedules-search-listing-wrapper .results .views-row:hover h3 {
+  text-decoration: underline;
+}
 #schedules-search-listing-wrapper .results .views-row .included-in-membership {
   background: url("../img/icons/included-in-membership.png") no-repeat 0 0;
   background-size: contain;

--- a/themes/openy_themes/openy_rose/scss/modules/_schedules.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_schedules.scss
@@ -336,6 +336,12 @@
       text-decoration: none;
       position: relative;
 
+      &:hover {
+        h3 {
+          text-decoration: underline;
+        }
+      }
+
       .included-in-membership {
         background: url("../img/icons/included-in-membership.png") no-repeat 0 0;
         background-size: contain;


### PR DESCRIPTION
Make sure these boxes are checked before asking for review of your pull request - thank you!

## General checks
- [x] All coding styles are fulfilled and there are no any issues reported by CodeSniffer CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/ci-errors.png" width="200" alt="CI code sniffer errors">
- [x] All tests are running and there are no failed tests reported by CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/behat.png" width="200" alt="Behat test results">
- [x] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [x] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [x] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [x] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [x] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!

## Steps for review

- [x] Go to schedules/ page and check the hover effect of class tiles. The title should underline on hover when hovering in other areas of the tile, not just on the title text. This worked on the subcategory pages, but not the schedule page.

![screen shot 2017-10-13 at 9 14 34 am](https://user-images.githubusercontent.com/1504038/31548004-63111324-aff7-11e7-9f98-a2c866c0dcb2.png)

