### PR TITLE
[OYPD-586] Config changes for blazy lazy loading

### DIFF
--- a/modules/openy_features/openy_media/config/install/blazy.settings.yml
+++ b/modules/openy_features/openy_media/config/install/blazy.settings.yml
@@ -1,0 +1,7 @@
+admin_css: true
+responsive_image: false
+one_pixel: true
+blazy:
+  loadInvisible: true
+  offset: 100
+  saveViewportOffsetDelay: 50

--- a/modules/openy_features/openy_media/modules/openy_media_image/config/install/core.entity_view_display.media.image.default.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_image/config/install/core.entity_view_display.media.image.default.yml
@@ -8,7 +8,7 @@ dependencies:
     - field.field.media.image.field_media_tags
     - media_entity.bundle.image
   module:
-    - image
+    - blazy
 id: media.image.default
 targetEntityType: media
 bundle: image
@@ -19,9 +19,55 @@ content:
     label: hidden
     settings:
       image_style: ''
-      image_link: ''
+      thumbnail_style: ''
+      media_switch: ''
+      ratio: ''
+      sizes: ''
+      breakpoints:
+        xs:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        sm:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        md:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        lg:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        xl:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+      current_view_mode: default
+      background: false
+      caption:
+        title: '0'
+        alt: '0'
+      iframe_lazy: true
+      icon: ''
+      layout: ''
+      view_mode: ''
+      cache: 0
+      optionset: default
+      skin: ''
+      style: ''
+      box_caption: ''
+      box_caption_custom: ''
+      box_style: ''
+      box_media_style: ''
+      responsive_image_style: ''
+      grid: 0
+      grid_header: ''
+      grid_medium: 0
+      grid_small: 0
     third_party_settings: {  }
-    type: image
+    type: blazy
     region: content
 hidden:
   created: true

--- a/modules/openy_features/openy_media/modules/openy_media_image/config/install/core.entity_view_display.media.image.embedded_full.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_image/config/install/core.entity_view_display.media.image.embedded_full.yml
@@ -7,10 +7,9 @@ dependencies:
     - field.field.media.image.field_media_image
     - field.field.media.image.field_media_in_library
     - field.field.media.image.field_media_tags
-    - image.style.media_full
     - media_entity.bundle.image
   module:
-    - image
+    - blazy
 id: media.image.embedded_full
 targetEntityType: media
 bundle: image
@@ -21,9 +20,55 @@ content:
     label: hidden
     settings:
       image_style: media_full
-      image_link: ''
+      thumbnail_style: ''
+      media_switch: ''
+      ratio: enforced
+      sizes: ''
+      breakpoints:
+        xs:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        sm:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        md:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        lg:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        xl:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+      current_view_mode: embedded_full
+      background: false
+      caption:
+        title: '0'
+        alt: '0'
+      iframe_lazy: true
+      icon: ''
+      layout: ''
+      view_mode: ''
+      cache: 0
+      optionset: default
+      skin: ''
+      style: ''
+      box_caption: ''
+      box_caption_custom: ''
+      box_style: ''
+      box_media_style: ''
+      responsive_image_style: ''
+      grid: 0
+      grid_header: ''
+      grid_medium: 0
+      grid_small: 0
     third_party_settings: {  }
-    type: image
+    type: blazy
     region: content
 hidden:
   created: true

--- a/modules/openy_features/openy_media/modules/openy_media_image/config/install/core.entity_view_display.media.image.embedded_half.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_image/config/install/core.entity_view_display.media.image.embedded_half.yml
@@ -7,10 +7,9 @@ dependencies:
     - field.field.media.image.field_media_image
     - field.field.media.image.field_media_in_library
     - field.field.media.image.field_media_tags
-    - image.style.media_half
     - media_entity.bundle.image
   module:
-    - image
+    - blazy
 id: media.image.embedded_half
 targetEntityType: media
 bundle: image
@@ -21,9 +20,55 @@ content:
     label: hidden
     settings:
       image_style: media_half
-      image_link: ''
+      thumbnail_style: ''
+      media_switch: ''
+      ratio: enforced
+      sizes: ''
+      breakpoints:
+        xs:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        sm:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        md:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        lg:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        xl:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+      current_view_mode: embedded_half
+      background: false
+      caption:
+        title: '0'
+        alt: '0'
+      iframe_lazy: true
+      icon: ''
+      layout: ''
+      view_mode: ''
+      cache: 0
+      optionset: default
+      skin: ''
+      style: ''
+      box_caption: ''
+      box_caption_custom: ''
+      box_style: ''
+      box_media_style: ''
+      responsive_image_style: ''
+      grid: 0
+      grid_header: ''
+      grid_medium: 0
+      grid_small: 0
     third_party_settings: {  }
-    type: image
+    type: blazy
     region: content
 hidden:
   created: true

--- a/modules/openy_features/openy_media/modules/openy_media_image/config/install/core.entity_view_display.media.image.icon.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_image/config/install/core.entity_view_display.media.image.icon.yml
@@ -9,7 +9,7 @@ dependencies:
     - field.field.media.image.field_media_tags
     - media_entity.bundle.image
   module:
-    - image
+    - blazy
 id: media.image.icon
 targetEntityType: media
 bundle: image
@@ -20,9 +20,55 @@ content:
     label: hidden
     settings:
       image_style: ''
-      image_link: ''
+      thumbnail_style: ''
+      media_switch: ''
+      ratio: enforced
+      sizes: ''
+      breakpoints:
+        xs:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        sm:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        md:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        lg:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        xl:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+      current_view_mode: icon
+      background: false
+      caption:
+        title: '0'
+        alt: '0'
+      iframe_lazy: true
+      icon: ''
+      layout: ''
+      view_mode: ''
+      cache: 0
+      optionset: default
+      skin: ''
+      style: ''
+      box_caption: ''
+      box_caption_custom: ''
+      box_style: ''
+      box_media_style: ''
+      responsive_image_style: ''
+      grid: 0
+      grid_header: ''
+      grid_medium: 0
+      grid_small: 0
     third_party_settings: {  }
-    type: image
+    type: blazy
     region: content
 hidden:
   created: true

--- a/modules/openy_features/openy_media/modules/openy_media_image/openy_media_image.info.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_image/openy_media_image.info.yml
@@ -4,6 +4,7 @@ type: module
 core: 8.x
 package: OpenY
 dependencies:
+  - blazy
   - dropzonejs_eb_widget
   - embed
   - entity_browser

--- a/modules/openy_features/openy_media/modules/openy_media_image/openy_media_image.install
+++ b/modules/openy_features/openy_media/modules/openy_media_image/openy_media_image.install
@@ -146,3 +146,19 @@ function openy_media_image_update_8005() {
     }
   }
 }
+
+/**
+ * Update OpenY media image feature configs for Blazy support.
+ */
+function openy_media_image_update_8006() {
+  $config_dir = drupal_get_path('module', 'openy_media_image') . '/config/install/';
+  // Import configuration.
+  $config_importer = \Drupal::service('openy_upgrade_tool.importer');
+  $config_importer->setDirectory($config_dir);
+  $config_importer->importConfigs([
+    'core.entity_view_display.media.image.default',
+    'core.entity_view_display.media.image.embedded_full',
+    'core.entity_view_display.media.image.embedded_half',
+    'core.entity_view_display.media.image.icon',
+  ]);
+}

--- a/modules/openy_features/openy_media/openy_media.install
+++ b/modules/openy_features/openy_media/openy_media.install
@@ -17,3 +17,16 @@ function openy_media_update_8001() {
     'rabbit_hole.behavior_settings.taxonomy_vocabulary_media_tags',
   ]);
 }
+
+/**
+ * Import Blazy config.
+ */
+function openy_media_update_8002() {
+  $config_dir = drupal_get_path('module', 'openy_media') . '/config/install/';
+  // Import new configuration
+  $config_importer = \Drupal::service('openy_upgrade_tool.importer');
+  $config_importer->setDirectory($config_dir);
+  $config_importer->importConfigs([
+    'blazy.settings',
+  ]);
+}

--- a/modules/openy_features/openy_node/modules/openy_node_category/config/install/core.entity_view_display.media.image.node_program_subcategory_teaser.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_category/config/install/core.entity_view_display.media.image.node_program_subcategory_teaser.yml
@@ -7,10 +7,9 @@ dependencies:
     - field.field.media.image.field_media_image
     - field.field.media.image.field_media_in_library
     - field.field.media.image.field_media_tags
-    - image.style.node_program_subcategory_teaser
     - media_entity.bundle.image
   module:
-    - image
+    - blazy
 id: media.image.node_program_subcategory_teaser
 targetEntityType: media
 bundle: image
@@ -21,14 +20,62 @@ content:
     label: hidden
     settings:
       image_style: node_program_subcategory_teaser
-      image_link: ''
+      thumbnail_style: ''
+      media_switch: ''
+      ratio: enforced
+      sizes: ''
+      breakpoints:
+        xs:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        sm:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        md:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        lg:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        xl:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+      current_view_mode: node_program_subcategory_teaser
+      background: false
+      caption:
+        title: '0'
+        alt: '0'
+      iframe_lazy: true
+      icon: ''
+      layout: ''
+      view_mode: ''
+      cache: 0
+      optionset: default
+      skin: ''
+      style: ''
+      box_caption: ''
+      box_caption_custom: ''
+      box_style: ''
+      box_media_style: ''
+      responsive_image_style: ''
+      grid: 0
+      grid_header: ''
+      grid_medium: 0
+      grid_small: 0
     third_party_settings: {  }
-    type: image
+    type: blazy
+    region: content
 hidden:
   created: true
   field_media_caption: true
   field_media_in_library: true
   field_media_tags: true
+  langcode: true
   name: true
   thumbnail: true
   uid: true

--- a/modules/openy_features/openy_node/modules/openy_node_category/openy_node_category.info.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_category/openy_node_category.info.yml
@@ -4,6 +4,8 @@ type: module
 core: 8.x
 package: OpenY
 dependencies:
+  - blazy
+  - datalayer
   - entity_browser
   - entity_reference_revisions
   - field

--- a/modules/openy_features/openy_node/modules/openy_node_category/openy_node_category.install
+++ b/modules/openy_features/openy_node/modules/openy_node_category/openy_node_category.install
@@ -214,3 +214,16 @@ function openy_node_category_update_8009() {
     'third_party_settings.field_group.group_header_area.format_settings.description'
   );
 }
+
+/**
+ * Update OpenY node category feature configs for Blazy support.
+ */
+function openy_node_category_update_8010() {
+  $config_dir = drupal_get_path('module', 'openy_node_category') . '/config/install/';
+  // Import configuration.
+  $config_importer = \Drupal::service('openy_upgrade_tool.importer');
+  $config_importer->setDirectory($config_dir);
+  $config_importer->importConfigs([
+    'core.entity_view_display.media.image.node_program_subcategory_teaser',
+  ]);
+}

--- a/modules/openy_features/openy_node/modules/openy_node_program/config/install/core.entity_view_display.media.image.node_program_header.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_program/config/install/core.entity_view_display.media.image.node_program_header.yml
@@ -7,10 +7,9 @@ dependencies:
     - field.field.media.image.field_media_image
     - field.field.media.image.field_media_in_library
     - field.field.media.image.field_media_tags
-    - image.style.node_program_header
     - media_entity.bundle.image
   module:
-    - image
+    - blazy
 id: media.image.node_program_header
 targetEntityType: media
 bundle: image
@@ -21,9 +20,55 @@ content:
     label: hidden
     settings:
       image_style: node_program_header
-      image_link: ''
+      thumbnail_style: ''
+      media_switch: ''
+      ratio: ''
+      sizes: ''
+      breakpoints:
+        xs:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        sm:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        md:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        lg:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        xl:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+      current_view_mode: node_program_header
+      background: false
+      caption:
+        title: '0'
+        alt: '0'
+      iframe_lazy: true
+      icon: ''
+      layout: ''
+      view_mode: ''
+      cache: 0
+      optionset: default
+      skin: ''
+      style: ''
+      box_caption: ''
+      box_caption_custom: ''
+      box_style: ''
+      box_media_style: ''
+      responsive_image_style: ''
+      grid: 0
+      grid_header: ''
+      grid_medium: 0
+      grid_small: 0
     third_party_settings: {  }
-    type: image
+    type: blazy
     region: content
 hidden:
   created: true

--- a/modules/openy_features/openy_node/modules/openy_node_program/config/install/field.field.node.program.field_meta_tags.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_program/config/install/field.field.node.program.field_meta_tags.yml
@@ -5,6 +5,7 @@ dependencies:
     - field.storage.node.field_meta_tags
     - node.type.program
   module:
+    - datalayer
     - metatag
 third_party_settings:
   datalayer:

--- a/modules/openy_features/openy_node/modules/openy_node_program/config/install/field.field.node.program.field_program_description.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_program/config/install/field.field.node.program.field_program_description.yml
@@ -5,6 +5,7 @@ dependencies:
     - field.storage.node.field_program_description
     - node.type.program
   module:
+    - datalayer
     - text
 third_party_settings:
   datalayer:

--- a/modules/openy_features/openy_node/modules/openy_node_program/openy_node_program.info.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_program/openy_node_program.info.yml
@@ -4,6 +4,8 @@ type: module
 core: 8.x
 package: OpenY
 dependencies:
+  - blazy
+  - datalayer
   - entity_browser
   - entity_reference_revisions
   - field

--- a/modules/openy_features/openy_node/modules/openy_node_program/openy_node_program.install
+++ b/modules/openy_features/openy_node/modules/openy_node_program/openy_node_program.install
@@ -236,3 +236,18 @@ function openy_node_program_update_8009() {
     }
   }
 }
+
+/**
+ * Update OpenY node program feature configs for Blazy support.
+ */
+function openy_node_program_update_8010() {
+  $config_dir = drupal_get_path('module', 'openy_node_program') . '/config/install/';
+  // Import configuration.
+  $config_importer = \Drupal::service('openy_upgrade_tool.importer');
+  $config_importer->setDirectory($config_dir);
+  $config_importer->importConfigs([
+    'core.entity_view_display.media.image.node_program_header',
+    'field.field.node.program.field_meta_tags',
+    'field.field.node.program.field_program_description',
+  ]);
+}

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_banner/config/install/core.entity_view_display.media.image.prgf_banner.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_banner/config/install/core.entity_view_display.media.image.prgf_banner.yml
@@ -7,10 +7,9 @@ dependencies:
     - field.field.media.image.field_media_image
     - field.field.media.image.field_media_in_library
     - field.field.media.image.field_media_tags
-    - image.style.prgf_banner
     - media_entity.bundle.image
   module:
-    - image
+    - blazy
 id: media.image.prgf_banner
 targetEntityType: media
 bundle: image
@@ -21,9 +20,55 @@ content:
     label: hidden
     settings:
       image_style: prgf_banner
-      image_link: ''
+      thumbnail_style: ''
+      media_switch: ''
+      ratio: enforced
+      sizes: ''
+      breakpoints:
+        xs:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        sm:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        md:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        lg:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        xl:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+      current_view_mode: prgf_banner
+      background: false
+      caption:
+        title: '0'
+        alt: '0'
+      iframe_lazy: true
+      icon: ''
+      layout: ''
+      view_mode: ''
+      cache: 0
+      optionset: default
+      skin: ''
+      style: ''
+      box_caption: ''
+      box_caption_custom: ''
+      box_style: ''
+      box_media_style: ''
+      responsive_image_style: ''
+      grid: 0
+      grid_header: ''
+      grid_medium: 0
+      grid_small: 0
     third_party_settings: {  }
-    type: image
+    type: blazy
     region: content
 hidden:
   created: true

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_banner/config/install/field.field.paragraph.banner.field_prgf_color.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_banner/config/install/field.field.paragraph.banner.field_prgf_color.yml
@@ -5,7 +5,8 @@ dependencies:
     - field.storage.paragraph.field_prgf_color
     - paragraphs.paragraphs_type.banner
     - taxonomy.vocabulary.color
-  module: {}
+  module:
+    - datalayer
 third_party_settings:
   datalayer:
     expose: 0

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_banner/openy_prgf_banner.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_banner/openy_prgf_banner.info.yml
@@ -4,6 +4,8 @@ type: module
 core: 8.x
 package: OpenY
 dependencies:
+  - blazy
+  - datalayer
   - entity_browser
   - field
   - image

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_banner/openy_prgf_banner.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_banner/openy_prgf_banner.install
@@ -156,3 +156,17 @@ function openy_prgf_banner_update_8005() {
     }
   }
 }
+
+/**
+ * Update OpenY paragraph banner feature configs for Blazy support.
+ */
+function openy_prgf_banner_update_8006() {
+  $config_dir = drupal_get_path('module', 'openy_prgf_banner') . '/config/install/';
+  // Import configuration.
+  $config_importer = \Drupal::service('openy_upgrade_tool.importer');
+  $config_importer->setDirectory($config_dir);
+  $config_importer->importConfigs([
+    'core.entity_view_display.media.image.prgf_banner',
+    'field.field.paragraph.banner.field_prgf_color.yml',
+  ]);
+}

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_gallery/config/install/core.entity_view_display.media.image.prgf_gallery.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_gallery/config/install/core.entity_view_display.media.image.prgf_gallery.yml
@@ -7,10 +7,9 @@ dependencies:
     - field.field.media.image.field_media_image
     - field.field.media.image.field_media_in_library
     - field.field.media.image.field_media_tags
-    - image.style.prgf_gallery
     - media_entity.bundle.image
   module:
-    - image
+    - blazy
 id: media.image.prgf_gallery
 targetEntityType: media
 bundle: image
@@ -21,9 +20,55 @@ content:
     label: hidden
     settings:
       image_style: prgf_gallery
-      image_link: ''
+      thumbnail_style: ''
+      media_switch: ''
+      ratio: enforced
+      sizes: ''
+      breakpoints:
+        xs:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        sm:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        md:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        lg:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        xl:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+      current_view_mode: prgf_gallery
+      background: false
+      caption:
+        title: '0'
+        alt: '0'
+      iframe_lazy: true
+      icon: ''
+      layout: ''
+      view_mode: ''
+      cache: 0
+      optionset: default
+      skin: ''
+      style: ''
+      box_caption: ''
+      box_caption_custom: ''
+      box_style: ''
+      box_media_style: ''
+      responsive_image_style: ''
+      grid: 0
+      grid_header: ''
+      grid_medium: 0
+      grid_small: 0
     third_party_settings: {  }
-    type: image
+    type: blazy
     region: content
 hidden:
   created: true

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_gallery/openy_prgf_gallery.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_gallery/openy_prgf_gallery.info.yml
@@ -4,6 +4,7 @@ type: module
 core: 8.x
 package: OpenY
 dependencies:
+  - blazy
   - entity_browser
   - field
   - image

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_gallery/openy_prgf_gallery.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_gallery/openy_prgf_gallery.install
@@ -63,3 +63,16 @@ function openy_prgf_gallery_update_8002() {
     }
   }
 }
+
+/**
+ * Update OpenY paragraph gallery feature configs for Blazy support.
+ */
+function openy_prgf_gallery_update_8003() {
+  $config_dir = drupal_get_path('module', 'openy_prgf_gallery') . '/config/install/';
+  // Import configuration.
+  $config_importer = \Drupal::service('openy_upgrade_tool.importer');
+  $config_importer->setDirectory($config_dir);
+  $config_importer->importConfigs([
+    'core.entity_view_display.media.image.prgf_gallery',
+  ]);
+}

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_mbrshp_calc/config/install/core.entity_view_display.media.image.calc_preview.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_mbrshp_calc/config/install/core.entity_view_display.media.image.calc_preview.yml
@@ -7,10 +7,9 @@ dependencies:
     - field.field.media.image.field_media_image
     - field.field.media.image.field_media_in_library
     - field.field.media.image.field_media_tags
-    - image.style.node_mbrshp_calc_preview
     - media_entity.bundle.image
   module:
-    - image
+    - blazy
 id: media.image.calc_preview
 targetEntityType: media
 bundle: image
@@ -21,9 +20,55 @@ content:
     label: hidden
     settings:
       image_style: node_mbrshp_calc_preview
-      image_link: ''
+      thumbnail_style: ''
+      media_switch: ''
+      ratio: enforced
+      sizes: ''
+      breakpoints:
+        xs:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        sm:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        md:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        lg:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        xl:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+      current_view_mode: calc_preview
+      background: false
+      caption:
+        title: '0'
+        alt: '0'
+      iframe_lazy: true
+      icon: ''
+      layout: ''
+      view_mode: ''
+      cache: 0
+      optionset: default
+      skin: ''
+      style: ''
+      box_caption: ''
+      box_caption_custom: ''
+      box_style: ''
+      box_media_style: ''
+      responsive_image_style: ''
+      grid: 0
+      grid_header: ''
+      grid_medium: 0
+      grid_small: 0
     third_party_settings: {  }
-    type: image
+    type: blazy
     region: content
 hidden:
   created: true

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_mbrshp_calc/config/install/core.entity_view_display.media.image.calc_summary.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_mbrshp_calc/config/install/core.entity_view_display.media.image.calc_summary.yml
@@ -7,10 +7,9 @@ dependencies:
     - field.field.media.image.field_media_image
     - field.field.media.image.field_media_in_library
     - field.field.media.image.field_media_tags
-    - image.style.node_mbrshp_calc_summary
     - media_entity.bundle.image
   module:
-    - image
+    - blazy
 id: media.image.calc_summary
 targetEntityType: media
 bundle: image
@@ -21,9 +20,55 @@ content:
     label: hidden
     settings:
       image_style: node_mbrshp_calc_summary
-      image_link: ''
+      thumbnail_style: ''
+      media_switch: ''
+      ratio: enforced
+      sizes: ''
+      breakpoints:
+        xs:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        sm:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        md:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        lg:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        xl:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+      current_view_mode: calc_summary
+      background: false
+      caption:
+        title: '0'
+        alt: '0'
+      iframe_lazy: true
+      icon: ''
+      layout: ''
+      view_mode: ''
+      cache: 0
+      optionset: default
+      skin: ''
+      style: ''
+      box_caption: ''
+      box_caption_custom: ''
+      box_style: ''
+      box_media_style: ''
+      responsive_image_style: ''
+      grid: 0
+      grid_header: ''
+      grid_medium: 0
+      grid_small: 0
     third_party_settings: {  }
-    type: image
+    type: blazy
     region: content
 hidden:
   created: true

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_mbrshp_calc/openy_prgf_mbrshp_calc.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_mbrshp_calc/openy_prgf_mbrshp_calc.info.yml
@@ -5,6 +5,7 @@ core: 8.x
 package: OpenY
 dependencies:
   - address
+  - blazy
   - entity_reference_revisions
   - field
   - image

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_mbrshp_calc/openy_prgf_mbrshp_calc.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_mbrshp_calc/openy_prgf_mbrshp_calc.install
@@ -71,3 +71,17 @@ function openy_prgf_mbrshp_calc_update_8003() {
     }
   }
 }
+
+/**
+ * Update OpenY paragraph membership calc feature configs for Blazy support.
+ */
+function openy_prgf_mbrshp_calc_update_8004() {
+  $config_dir = drupal_get_path('module', 'openy_prgf_mbrshp_calc') . '/config/install/';
+  // Import configuration.
+  $config_importer = \Drupal::service('openy_upgrade_tool.importer');
+  $config_importer->setDirectory($config_dir);
+  $config_importer->importConfigs([
+    'core.entity_view_display.media.image.calc_preview',
+    'core.entity_view_display.media.image.calc_summary',
+  ]);
+}

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_small_banner/config/install/core.entity_view_display.media.image.prgf_small_banner.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_small_banner/config/install/core.entity_view_display.media.image.prgf_small_banner.yml
@@ -7,10 +7,9 @@ dependencies:
     - field.field.media.image.field_media_image
     - field.field.media.image.field_media_in_library
     - field.field.media.image.field_media_tags
-    - image.style.prgf_small_banner
     - media_entity.bundle.image
   module:
-    - image
+    - blazy
 id: media.image.prgf_small_banner
 targetEntityType: media
 bundle: image
@@ -21,15 +20,62 @@ content:
     label: hidden
     settings:
       image_style: prgf_small_banner
-      image_link: ''
+      thumbnail_style: ''
+      media_switch: ''
+      ratio: enforced
+      sizes: ''
+      breakpoints:
+        xs:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        sm:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        md:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        lg:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        xl:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+      current_view_mode: prgf_small_banner
+      background: false
+      caption:
+        title: '0'
+        alt: '0'
+      iframe_lazy: true
+      icon: ''
+      layout: ''
+      view_mode: ''
+      cache: 0
+      optionset: default
+      skin: ''
+      style: ''
+      box_caption: ''
+      box_caption_custom: ''
+      box_style: ''
+      box_media_style: ''
+      responsive_image_style: ''
+      grid: 0
+      grid_header: ''
+      grid_medium: 0
+      grid_small: 0
     third_party_settings: {  }
-    type: image
+    type: blazy
     region: content
 hidden:
   created: true
   field_media_caption: true
   field_media_in_library: true
   field_media_tags: true
+  langcode: true
   name: true
   thumbnail: true
   uid: true

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_small_banner/config/install/field.field.paragraph.small_banner.field_prgf_description.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_small_banner/config/install/field.field.paragraph.small_banner.field_prgf_description.yml
@@ -5,6 +5,7 @@ dependencies:
     - field.storage.paragraph.field_prgf_description
     - paragraphs.paragraphs_type.small_banner
   module:
+    - datalayer
     - text
 third_party_settings:
   datalayer:

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_small_banner/config/install/paragraphs.paragraphs_type.small_banner.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_small_banner/config/install/paragraphs.paragraphs_type.small_banner.yml
@@ -3,3 +3,4 @@ status: true
 dependencies: {  }
 id: small_banner
 label: 'Small Banner'
+behavior_plugins: {  }

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_small_banner/openy_prgf_small_banner.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_small_banner/openy_prgf_small_banner.info.yml
@@ -4,6 +4,7 @@ type: module
 core: 8.x
 package: OpenY
 dependencies:
+  - blazy
   - datalayer
   - entity_browser
   - field

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_small_banner/openy_prgf_small_banner.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_small_banner/openy_prgf_small_banner.install
@@ -117,3 +117,18 @@ function openy_prgf_small_banner_update_8004() {
     'content'
   );
 }
+
+/**
+ * Update OpenY paragraph small banner feature configs for Blazy support.
+ */
+function openy_prgf_small_banner_update_8005() {
+  $config_dir = drupal_get_path('module', 'openy_prgf_small_banner') . '/config/install/';
+  // Import configuration.
+  $config_importer = \Drupal::service('openy_upgrade_tool.importer');
+  $config_importer->setDirectory($config_dir);
+  $config_importer->importConfigs([
+    'core.entity_view_display.media.image.prgf_small_banner',
+    'field.field.paragraph.small_banner.field_prgf_description',
+    'paragraphs.paragraphs_type.small_banner.yml',
+  ]);
+}

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_teaser/config/install/core.entity_view_display.media.image.prgf_teaser.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_teaser/config/install/core.entity_view_display.media.image.prgf_teaser.yml
@@ -7,10 +7,9 @@ dependencies:
     - field.field.media.image.field_media_image
     - field.field.media.image.field_media_in_library
     - field.field.media.image.field_media_tags
-    - image.style.prgf_teaser
     - media_entity.bundle.image
   module:
-    - image
+    - blazy
 id: media.image.prgf_teaser
 targetEntityType: media
 bundle: image
@@ -21,9 +20,55 @@ content:
     label: hidden
     settings:
       image_style: prgf_teaser
-      image_link: ''
+      thumbnail_style: ''
+      media_switch: ''
+      ratio: enforced
+      sizes: ''
+      breakpoints:
+        xs:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        sm:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        md:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        lg:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+        xl:
+          image_style: ''
+          width: ''
+          breakpoint: ''
+      current_view_mode: prgf_teaser
+      background: false
+      caption:
+        title: '0'
+        alt: '0'
+      iframe_lazy: true
+      icon: ''
+      layout: ''
+      view_mode: ''
+      cache: 0
+      optionset: default
+      skin: ''
+      style: ''
+      box_caption: ''
+      box_caption_custom: ''
+      box_style: ''
+      box_media_style: ''
+      responsive_image_style: ''
+      grid: 0
+      grid_header: ''
+      grid_medium: 0
+      grid_small: 0
     third_party_settings: {  }
-    type: image
+    type: blazy
     region: content
 hidden:
   created: true

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_teaser/openy_prgf_teaser.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_teaser/openy_prgf_teaser.info.yml
@@ -4,6 +4,7 @@ type: module
 core: 8.x
 package: OpenY
 dependencies:
+  - blazy
   - entity_browser
   - field
   - image

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_teaser/openy_prgf_teaser.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_teaser/openy_prgf_teaser.install
@@ -98,3 +98,16 @@ function openy_prgf_teaser_update_8003() {
     }
   }
 }
+
+/**
+ * Update OpenY paragraph teaser feature configs for Blazy support.
+ */
+function openy_prgf_teaser_update_8004() {
+  $config_dir = drupal_get_path('module', 'openy_prgf_teaser') . '/config/install/';
+  // Import configuration.
+  $config_importer = \Drupal::service('openy_upgrade_tool.importer');
+  $config_importer->setDirectory($config_dir);
+  $config_importer->importConfigs([
+    'core.entity_view_display.media.image.prgf_teaser',
+  ]);
+}


### PR DESCRIPTION
Make sure these boxes are checked before asking for review of your pull request - thank you!

## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/ci-errors.png" width="200" alt="CI code sniffer errors">
- [ ] All tests are running and there are no failed tests reported by CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/behat.png" width="200" alt="Behat test results">
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!

## Steps for review

- [ ] Check pages with the banner paragraph or node program subcategory teasers (the blog post tiles.) Images should lazy load. You should see both on the home page. See http://recordit.co/d0stPkwNsn

In this PR I didn't add anything for upgrade path yet. I wanted to get feedback on the solution first. I tested with two things that have images. (banner and program subcategory) What other things do we want to include? This is done per view mode on the image media type at /admin/structure/media/manage/image .
