### PR TITLE
[OYPD-605] Adjust schema for column size in logger_entity

### DIFF
--- a/modules/custom/logger_entity/logger_entity.install
+++ b/modules/custom/logger_entity/logger_entity.install
@@ -39,8 +39,7 @@ function logger_entity_update_8001() {
   $storage_definition = $manager->getFieldStorageDefinition('name', 'logger_entity');
   $storage_definition->setSetting('max_length', '250');
   $manager->updateFieldStorageDefinition($storage_definition);
-
-  \Drupal::service('entity.last_installed_schema.repository')->setLastInstalledFieldStorageDefinition($storage_definition);
+  $manager->applyUpdates();
 
   // Put the old records back.
   foreach ($results as $result) {

--- a/modules/custom/logger_entity/logger_entity.install
+++ b/modules/custom/logger_entity/logger_entity.install
@@ -20,7 +20,7 @@ function logger_entity_update_8001() {
   $results = $query->execute()->fetchAll();
 
   // Delete the data.
-  $query = \Drupal::database()->delete('logger_entity')->execute();
+  $query = \Drupal::database()->truncate('logger_entity')->execute();
 
   /**
    * Update the table.
@@ -34,6 +34,13 @@ function logger_entity_update_8001() {
   ];
   $schema = Database::getConnection()->schema();
   $schema->changeField('logger_entity', 'name', 'name', $spec);
+
+  $manager = \Drupal::entityDefinitionUpdateManager();
+  $storage_definition = $manager->getFieldStorageDefinition('name', 'logger_entity');
+  $storage_definition->setSetting('max_length', '250');
+  $manager->updateFieldStorageDefinition($storage_definition);
+
+  \Drupal::service('entity.last_installed_schema.repository')->setLastInstalledFieldStorageDefinition($storage_definition);
 
   // Put the old records back.
   foreach ($results as $result) {

--- a/modules/custom/logger_entity/logger_entity.install
+++ b/modules/custom/logger_entity/logger_entity.install
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @file
+ * Install file for Logger Entity module.
+ */
+
+use Drupal\Core\Database\Database;
+
+/**
+ * Implements hook_update_N().
+ *
+ * Fix logger_entity name length.
+ */
+function logger_entity_update_8001() {
+  /**
+   * See https://www.drupal.org/node/2227275
+   * A config file name can be as long as 250 characters.
+   */
+  $spec = [
+    'type' => 'varchar',
+    'length' => 250,
+  ];
+  $schema = Database::getConnection()->schema();
+  $schema->changeField('logger_entity', 'name', 'name', $spec);
+}

--- a/modules/custom/logger_entity/logger_entity.install
+++ b/modules/custom/logger_entity/logger_entity.install
@@ -13,6 +13,18 @@ use Drupal\Core\Database\Database;
  */
 function logger_entity_update_8001() {
   /**
+   * Entity does not like you trying to alter tables with data, so this will
+   * retrieve the data, updte the table, then put it back.
+   */
+  $query = \Drupal::database()->select('logger_entity')->fields('logger_entity');
+  $results = $query->execute()->fetchAll();
+
+  // Delete the data.
+  $query = \Drupal::database()->delete('logger_entity')->execute();
+
+  /**
+   * Update the table.
+   *
    * See https://www.drupal.org/node/2227275
    * A config file name can be as long as 250 characters.
    */
@@ -22,4 +34,13 @@ function logger_entity_update_8001() {
   ];
   $schema = Database::getConnection()->schema();
   $schema->changeField('logger_entity', 'name', 'name', $spec);
+
+  // Put the old records back.
+  foreach ($results as $result) {
+    $query = \Drupal::database()->insert('logger_entity');
+    $query->fields(array_keys((array)$result));
+    $query->values((array)$result);
+    $query->execute();
+  }
+
 }

--- a/modules/custom/logger_entity/src/Entity/LoggerEntity.php
+++ b/modules/custom/logger_entity/src/Entity/LoggerEntity.php
@@ -204,7 +204,7 @@ class LoggerEntity extends ContentEntityBase implements LoggerEntityInterface {
       ->setLabel(t('Name'))
       ->setDescription(t('The name of the Logger Entity entity.'))
       ->setSettings(array(
-        'max_length' => 50,
+        'max_length' => 250,
         'text_processing' => 0,
       ))
       ->setDefaultValue('')


### PR DESCRIPTION
Make sure these boxes are checked before asking for review of your pull request - thank you!

## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/ci-errors.png" width="200" alt="CI code sniffer errors">
- [ ] All tests are running and there are no failed tests reported by CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/behat.png" width="200" alt="Behat test results">
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!

## Steps for review

- [x] To reproduce, change a setting that results in a config name that is more than 50 characters. For example, /admin/structure/media/manage/image/display/node_program_subcategory_teaser. In the error log you should see. `Failed to save logger entity. Message: SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'name' at row 1: INSERT INTO {logger_entity} (type, uuid, langcode, user_id, name, status, created, changed, data) VALUES (:db_insert_placeholder_0, :db_insert_placeholder_1, :db_insert_placeholder_2, :db_insert_placeholder_3, :db_insert_placeholder_4, :db_insert_placeholder_5, :db_insert_placeholder_6, :db_insert_placeholder_7, :db_insert_placeholder_8); Array ( [:db_insert_placeholder_0] => openy_config_upgrade_logs [:db_insert_placeholder_1] => bae2b9b3-5152-43ae-9239-4e94e8601ffc [:db_insert_placeholder_2] => en [:db_insert_placeholder_3] => 1 [:db_insert_placeholder_4] => core.entity_view_display.media.image.node_program_subcategory_teaser [:db_insert_placeholder_5] => 1 [:db_insert_placeholder_6] => 1509461715 [:db_insert_placeholder_7] => 1509461715 [:db_insert_placeholder_8] => a:1:{i:0;s:68:"core.entity_view_display.media.image.node_program_subcategory_teaser";} ) `
- [x] With the fix you should be able to change the setting and see it get stored by logger_entity.  See screenshots.

![screen shot 2017-10-31 at 11 54 03 am](https://user-images.githubusercontent.com/1504038/32253127-ae8bb242-be6f-11e7-910b-31bb0dcd2539.png)
![screen shot 2017-10-31 at 12 35 29 pm](https://user-images.githubusercontent.com/1504038/32253126-ae7f6f64-be6f-11e7-9df1-88df41edfade.png)

