### PR TITLE
Fix for schedules page undefined index errors

### DIFF
--- a/modules/custom/openy_schedules/src/Form/SchedulesSearchForm.php
+++ b/modules/custom/openy_schedules/src/Form/SchedulesSearchForm.php
@@ -849,7 +849,7 @@ class SchedulesSearchForm extends FormBase {
       if ($ticket_required_items = $session->field_session_ticket->getValue()) {
         $ticket_required = (int) reset($ticket_required_items)['value'];
       }
-      if ($parameters['display'] && !is_null($parameters['display'])) {
+      if (isset($parameters['display']) && $parameters['display']) {
         $timestamp = DrupalDateTime::createFromTimestamp($session_instance->getTimestamp());
         $day = $timestamp->format('D n/j/Y');
         $time_from = $timestamp->format('g:i a');
@@ -911,7 +911,7 @@ class SchedulesSearchForm extends FormBase {
         ];
       }
 
-      $form['#cache']['tags'] = is_array($form['#cache']['tags']) ? $form['#cache']['tags'] : [];
+      $form['#cache']['tags'] = isset($form['#cache']['tags']) && is_array($form['#cache']['tags']) ? $form['#cache']['tags'] : [];
       $form['#cache']['tags'] = $form['#cache']['tags'] + $session_instance->getCacheTags();
     }
 


### PR DESCRIPTION
Hotfix. Getting lots of repeated undefined index errors coming from the schedule form.

```
Notice: Undefined index: tags in Drupal\openy_schedules\Form\SchedulesSearchForm->buildResults() (line 914 of /var/www/docroot/profiles/contrib/openy/modules/custom/openy_schedules/src/Form/SchedulesSearchForm.php) #0 /var/www/docroot/core/includes/bootstrap.inc(566): _drupal_error_handler_real(8, 'Undefined index...', '/var/www/docroo...', 914, Array) #1 /var/www/docroot/profiles/contrib/openy/modules/custom/openy_schedules/src/Form/SchedulesSearchForm.php(914): _drupal_error_handler(8, 'Undefined index...', '/var/www/docroo...', 914, Array) #2 /var/www/docroot/profiles/contrib/openy/modules/custom/openy_schedules/src/Form/SchedulesSearchForm.php(939): Drupal\openy_schedules\Form\SchedulesSearchForm->buildResults(Array, Array
...
```