### PR TITLE
[OYPD-599] Fix for bug related to viewing revisions, see https://www.…

### DIFF
--- a/modules/openy_features/openy_node/openy_node.services.yml
+++ b/modules/openy_features/openy_node/openy_node.services.yml
@@ -1,0 +1,6 @@
+services:
+  openy_node.route_subscriber:
+    class: Drupal\openy_node\Routing\RouteSubscriber
+    arguments: ['@module_handler']
+    tags:
+      - { name: event_subscriber }

--- a/modules/openy_features/openy_node/src/Routing/RouteSubscriber.php
+++ b/modules/openy_features/openy_node/src/Routing/RouteSubscriber.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Drupal\openy_node\Routing;
+
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Listens to the dynamic route events.
+ */
+class RouteSubscriber extends RouteSubscriberBase {
+  /**
+   * The module handler service.
+   *
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
+   */
+  protected $moduleHandler;
+
+  /**
+   * Constructs a route subscriber.
+   *
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler service.
+   */
+  public function __construct(ModuleHandlerInterface $module_handler) {
+    $this->moduleHandler = $module_handler;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterRoutes(RouteCollection $collection) {
+    // Node revision routes parameter {node} is not converted into its entity.
+    // @see https://www.drupal.org/node/2730631
+    // @todo Remove this alter once https://www.drupal.org/node/2730631 is in.
+    if ($this->moduleHandler->moduleExists('node')) {
+      $node_revision_routes = [
+        'entity.node.version_history',
+        'entity.node.revision',
+        'node.revision_revert_confirm',
+        'node.revision_revert_translation_confirm',
+        'node.revision_delete_confirm',
+      ];
+      foreach ($node_revision_routes as $route) {
+        $parameters = $collection->get($route)->getOption('parameters');
+        $parameters = $parameters ?: [];
+        $parameters['node']['type'] = 'entity:node';
+        $collection->get($route)->setOption('parameters', $parameters);
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
…drupal.org/node/2730631
#739 

Thank you for your contribution!

## Steps for review

- [ ] Before the fix, go to an old node revision and try to view it. You will get an error like `TypeError: Argument 1 passed to Drupal\openy_loc_camp\CampService::nodeHasOrIsCamp() must implement interface Drupal\node\NodeInterface, string given,...`
- [ ] After fix you should be able to view the revisions. The fix comes from the d.o issue and seems to work ok.

![screen shot 2017-11-09 at 2 17 53 pm](https://user-images.githubusercontent.com/1504038/32625073-3fcc84da-c559-11e7-82d9-72d36caf4798.png)

![screen shot 2017-11-09 at 2 18 01 pm](https://user-images.githubusercontent.com/1504038/32625074-41bc976c-c559-11e7-9367-4ed37a889c28.png)

![screen shot 2017-11-09 at 2 18 10 pm](https://user-images.githubusercontent.com/1504038/32625075-43d6efe8-c559-11e7-9742-01b27ef737ce.png)

I put this in openy_node because it is node related, but I don't know if that is the best place. I chose to do this over the using the patch since that is a core patch, and not done, so this seems like it would be easier to manage/remove later.
