### PR TITLE
Revert "[OYPD-523] changing focus style so it will work better with form elemen…"

### DIFF
--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -7044,9 +7044,7 @@ textarea:focus,
 .form-control:focus,
 .slick-arrow:focus:before,
 .navbar-toggle:focus {
-  border-color: #69ff00;
-  box-shadow: 0 0 0 5px #69ff00;
-  outline: none !important;
+  outline: 5px auto #69ff00;
 }
 
 .focusable.skip-link:focus {

--- a/themes/openy_themes/openy_rose/scss/state/_state.scss
+++ b/themes/openy_themes/openy_rose/scss/state/_state.scss
@@ -13,9 +13,7 @@ textarea:focus,
 .form-control:focus,
 .slick-arrow:focus:before,
 .navbar-toggle:focus {
-  border-color: $bright-green;
-  box-shadow: 0 0 0 5px $bright-green;
-  outline: none !important;
+  outline: 5px auto $bright-green;
 }
 
 .focusable.skip-link:focus {


### PR DESCRIPTION
Reverts ymcatwincities/openy#841

After this change post-click effect appeared for most of those elements
For example: 
When I click on menu link
![image](https://user-images.githubusercontent.com/4558228/32659144-519bc2ea-c62e-11e7-9ed5-da735c32c8cf.png)
Click on Blog title
![image](https://user-images.githubusercontent.com/4558228/32659164-7486af90-c62e-11e7-82cb-8c4b15e22fd0.png)
Click on link in Footer
![image](https://user-images.githubusercontent.com/4558228/32659191-93049414-c62e-11e7-8dff-96a34843b42c.png)


Seems this spoils design a lot
So until we found another approach
We can revert this
(no obvious way to improve this so far)

