### PR TITLE
Schedule: add AJAX throbber to Date filter

### DIFF
--- a/modules/custom/openy_schedules/js/openy_schedules.js
+++ b/modules/custom/openy_schedules/js/openy_schedules.js
@@ -69,15 +69,10 @@
           form.find('.js-form-type-select select').attr('readonly', true);
         });
 
-      $('.openy-schedules-search-form .js-form-item-date input').datepicker({
-        onSelect: function(dateText, ins) {
-          $(this)
-            .parents('.openy-schedules-search-form')
-            .each(function() {
-              var form = $(this);
-              form.find('.js-form-submit').trigger('click');
-              form.find('.js-form-type-select select').attr('readonly', true);
-            });
+      form.find(':input.openy-schedule-datepicker').datepicker({
+        onClose: function(dateText, inst) {
+          // Make all form elements readonly. AJAX will remove this attribute.
+          form.find(':input').attr('readonly', true);
         }
       });
 
@@ -87,6 +82,7 @@
           if (settings.data !== undefined && settings.data.match('form_id=openy_schedules_search_form')) {
             var form = $('.openy-schedules-search-form');
             form.find('.js-form-type-select select').removeAttr('readonly');
+            form.find(':input.openy-schedule-datepicker').removeAttr('readonly');
             form.find('.filters-container').addClass('hidden');
             if (form.find('.filter').length !== 0) {
               form.find('.filters-container').removeClass('hidden');

--- a/modules/custom/openy_schedules/src/Form/SchedulesSearchForm.php
+++ b/modules/custom/openy_schedules/src/Form/SchedulesSearchForm.php
@@ -444,15 +444,20 @@ class SchedulesSearchForm extends FormBase {
       '#type' => 'textfield',
       '#title' => $this->t('Date'),
       '#default_value' => isset($values['date']) ? $values['date'] : '',
+      '#attributes' => [
+        'class' => ['openy-schedule-datepicker'],
+      ],
       '#ajax' => [
         'callback' => [$this, 'rebuildAjaxCallback'],
         'wrapper' => 'schedules-search-form-wrapper',
-        'event' => 'keyup',
+        'event' => 'change',
         'method' => 'replace',
         'effect' => 'fade',
         'progress' => [
           'type' => 'throbber',
         ],
+        // Do not focus current input element after ajax finish.
+        'disable-refocus' => TRUE,
       ],
     ];
 
@@ -849,7 +854,7 @@ class SchedulesSearchForm extends FormBase {
       if ($ticket_required_items = $session->field_session_ticket->getValue()) {
         $ticket_required = (int) reset($ticket_required_items)['value'];
       }
-      if (isset($parameters['display']) && $parameters['display']) {
+      if ($parameters['display'] && !is_null($parameters['display'])) {
         $timestamp = DrupalDateTime::createFromTimestamp($session_instance->getTimestamp());
         $day = $timestamp->format('D n/j/Y');
         $time_from = $timestamp->format('g:i a');
@@ -911,7 +916,7 @@ class SchedulesSearchForm extends FormBase {
         ];
       }
 
-      $form['#cache']['tags'] = isset($form['#cache']['tags']) && is_array($form['#cache']['tags']) ? $form['#cache']['tags'] : [];
+      $form['#cache']['tags'] = is_array($form['#cache']['tags']) ? $form['#cache']['tags'] : [];
       $form['#cache']['tags'] = $form['#cache']['tags'] + $session_instance->getCacheTags();
     }
 

--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -4827,6 +4827,10 @@ html.js .branch__updates_queue__button {
     font-size: 16px;
   }
 }
+#schedules-search-form-wrapper .form-control[readonly], #schedules-search-form-wrapper .form-control[disabled] {
+  color: #4f4f4f;
+  background: #ebebeb;
+}
 
 #schedules-search-listing-wrapper .results {
   margin-bottom: 40px;

--- a/themes/openy_themes/openy_rose/scss/modules/_schedules.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_schedules.scss
@@ -241,6 +241,13 @@
       }
     }
   }
+
+  .form-control  {
+    &[readonly], &[disabled] {
+      color: $dark_grey;
+      background: $lighter-grey;
+    }
+  }
 }
 
 #schedules-search-listing-wrapper {


### PR DESCRIPTION
## Problem:
It can confuse user: filter was changed, the rest of form is inactive but no throbber appeared.
For now Schedule form's Date filter just clicks on Submit button using JS: https://github.com/ymcatwincities/openy/blob/8.x-1.x/modules/custom/openy_schedules/js/openy_schedules.js#L72-L82

## Solution:
Form field with date picker should have its own AJAX callback on change event that will show throbber in needed place.

Also please have a look to video demonstration how it improves UX:
- [Current state](https://www.drupal.org/files/issues/1.%20Before.mp4)
- [After PR merge](https://www.drupal.org/files/issues/2.%20After.mp4)

Issue on Drupal.org: https://www.drupal.org/project/openy/issues/2923773