### PR TITLE
OYPD-592 adding scroll up on membership calc steps so users see the t…

### DIFF
--- a/modules/custom/openy_calc/js/openy_calc_submit.js
+++ b/modules/custom/openy_calc/js/openy_calc_submit.js
@@ -1,0 +1,20 @@
+/**
+ * Functions for after the form has been submitted.
+ */
+(function ($) {
+  "use strict";
+
+  /**
+   * This will scroll the page up after the first step.
+   */
+  Drupal.behaviors.openy_calc_scroll = {
+    attach: function (context, settings) {
+      $('#membership-calc-wrapper').once().each(function () {
+        var divPosition = $(this).offset();
+        $('html, body').animate({scrollTop: divPosition.top - 100}, "slow");
+        $(this).focus();
+      });
+    }
+  };
+
+})(jQuery);

--- a/modules/custom/openy_calc/openy_calc.libraries.yml
+++ b/modules/custom/openy_calc/openy_calc.libraries.yml
@@ -6,3 +6,13 @@ scripts:
     - core/jquery
     - core/drupal
     - core/drupalSettings
+
+submit:
+  version: 1.0
+  js:
+    js/openy_calc_submit.js: {}
+  dependencies:
+    - core/jquery
+    - core/jquery.once
+    - core/drupal
+    - core/drupalSettings

--- a/modules/custom/openy_calc/src/Form/CalcBlockForm.php
+++ b/modules/custom/openy_calc/src/Form/CalcBlockForm.php
@@ -186,6 +186,7 @@ class CalcBlockForm extends FormBase {
           'class' => ['btn', 'blue', 'pull-left'],
         ],
       ];
+      $form['#attached']['library'][] = 'openy_calc/submit';
     }
 
     if ($step < 3) {
@@ -213,8 +214,7 @@ class CalcBlockForm extends FormBase {
         ],
       ];
     }
-
-    $form['#attached']['library'] = 'openy_calc/scripts';
+    $form['#attached']['library'][] = 'openy_calc/scripts';
     return $form;
   }
 


### PR DESCRIPTION
…op of the form after advancing

Make sure these boxes are checked before asking for review of your pull request - thank you!

## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/ci-errors.png" width="200" alt="CI code sniffer errors">
- [ ] All tests are running and there are no failed tests reported by CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/behat.png" width="200" alt="Behat test results">
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!

## Steps for review

- [x] Go to join page.
- [x] Choose a membership type and click Next.
- [x] On each next section the page should scroll up so you see the top of the form with 1 > 2 > 3.
