### PR TITLE
Updated fix for OYPD-626 to help with slogan length

### DIFF
--- a/openy.profile
+++ b/openy.profile
@@ -404,5 +404,5 @@ function openy_import_migration($migration_id) {
  * @param $form_id
  */
 function openy_form_system_site_information_settings_alter(&$form, \Drupal\Core\Form\FormStateInterface $form_state, $form_id) {
-  $form['site_information']['site_slogan']['#description'] = t("This will display your association name in the header as per Y USA brand guidelines.");
+  $form['site_information']['site_slogan']['#description'] = t("This will display your association name in the header as per Y USA brand guidelines. Try to use less than 27 characters. The text may get cut off on smaller devices.");
 }

--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -390,6 +390,7 @@ body {
 .page-head__logo .site-slogan {
   color: #ebebeb;
   display: block;
+  font-size: 13px;
   height: 0;
   left: 0;
   margin: auto;
@@ -401,6 +402,11 @@ body {
 }
 .page-head__logo .site-slogan:hover {
   text-decoration: none;
+}
+@media (min-width: 48em) {
+  .page-head__logo .site-slogan {
+    font-size: 14px;
+  }
 }
 @media (min-width: 62em) {
   .page-head__logo .site-slogan {

--- a/themes/openy_themes/openy_rose/scss/modules/_header.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_header.scss
@@ -46,6 +46,7 @@
     .site-slogan {
       color: $lighter-grey;
       display: block;
+      font-size: 13px;
       height: 0;
       left: 0;
       margin: auto;
@@ -56,6 +57,9 @@
       top: 20px;
       &:hover {
         text-decoration: none;
+      }
+      @include breakpoint($screen-tablet) {
+        font-size: 14px;
       }
       @include breakpoint($screen-desktop) {
         top: 10px;


### PR DESCRIPTION
A quick fix. AlexM noticed the text has problems on smaller sizes. We agreed on scrum to add warning text to the form. I also reduced the font size very slightly to help it fit. We are aiming for iphone6, no smaller. Max 27 characters.

![screen shot 2017-12-08 at 11 45 05 am](https://user-images.githubusercontent.com/1504038/33775867-b29d9f2e-dc0d-11e7-970e-6b8096f4d1ba.png)
