### PR TITLE
Fix for dropdown styles of location finder

### DIFF
--- a/modules/custom/openy_map/templates/openy-map.html.twig
+++ b/modules/custom/openy_map/templates/openy-map.html.twig
@@ -22,7 +22,7 @@
                 <div class="col-sm-4 col-md-2 distance">
                   <div class="form-group">
                     <label class="sr-only">{{ 'Distance'|t }}</label>
-                    <select class="distance_limit_value distance_limit form-control">
+                    <select class="distance_limit_value distance_limit form-control form-select">
                       <option class="all_locations" value="">{{ 'All locations'|t }}</option>
                       <option value="5">{{ '5 miles'|t }}</option>
                       <option value="10" selected>{{ '10 miles'|t }}</option>


### PR DESCRIPTION

URL: /locations

Before:
![image](https://user-images.githubusercontent.com/4558228/35286622-92e5b9f4-0071-11e8-8b26-5bdf43941463.png)

After:
![image](https://user-images.githubusercontent.com/4558228/35286674-b0ce63d0-0071-11e8-8902-5eda38e8897e.png)

Github issue #929 

