### PR TITLE
OYPD-636 Removing programs from class filter if they are unpublished

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_classes_listing/openy_prgf_classes_listing.module
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_classes_listing/openy_prgf_classes_listing.module
@@ -34,6 +34,21 @@ function openy_prgf_classes_listing_form_views_exposed_form_alter(&$form, FormSt
       }
     }
 
+    /**
+     * Check status of the program nodes. The VERF module doesn't do this. :(
+     */
+    $program_ids = array_keys($form['program']['#options']);
+    foreach($program_ids as $id) {
+      if(is_numeric($id)) {
+        $query = \Drupal::entityQuery('node');
+        $query->condition('status', 1);
+        $query->condition('nid', $id);
+        if (!$result = $query->execute()) {
+          unset($form['program']['#options'][$id]);
+        }
+      }
+    }
+
     $form['#attributes']['class'][] = 'container';
     $form['#attached']['library'][] = 'openy_prgf_classes_listing/openy_classes_listing';
   }

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_classes_listing/openy_prgf_classes_listing.module
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_classes_listing/openy_prgf_classes_listing.module
@@ -32,19 +32,23 @@ function openy_prgf_classes_listing_form_views_exposed_form_alter(&$form, FormSt
       if ($selectField == 'location') {
         $form[$selectField]['#options'] = openy_prgf_classes_listing_get_location_options();
       }
-    }
 
-    /**
-     * Check status of the program nodes. The VERF module doesn't do this. :(
-     */
-    $program_ids = array_keys($form['program']['#options']);
-    foreach($program_ids as $id) {
-      if(is_numeric($id)) {
-        $query = \Drupal::entityQuery('node');
-        $query->condition('status', 1);
-        $query->condition('nid', $id);
-        if (!$result = $query->execute()) {
-          unset($form['program']['#options'][$id]);
+      /**
+       * Check status of the program nodes. The VERF module doesn't do this. :(
+       * This isn't needed for locations, because they are the base filter and
+       * update automatically already.
+       */
+      if ($selectField != 'locations') {
+        $filter_ids = array_keys($form[$selectField]['#options']);
+        foreach ($filter_ids as $id) {
+          if (is_numeric($id)) {
+            $query = \Drupal::entityQuery('node');
+            $query->condition('status', 1);
+            $query->condition('nid', $id);
+            if (!$result = $query->execute()) {
+              unset($form[$selectField]['#options'][$id]);
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Github issue: #913 

## Steps for review

- [x] Look at the options available for "Program" when visiting a program page with the class filter. Like /programs/child-care/after-school-child-care
- [x] Unpublish one of the programs, like "Swimming".
- [x] Go back to the filter and verify that Swimming is removed from the list of options.
