### PR TITLE
Daxko2 API integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -190,6 +190,7 @@
         "drupal/plugin": "2.5",
         "drupal/migrate_plus": "3.0-beta1",
         "drupal/migrate_tools": "3.0-beta1",
+        "drupal/migrate_source_csv": "2.0",
         "drupal/verf": "1.0-beta6",
         "drupal/simple_menu_icons": "1.x-dev",
         "drupal/views_infinite_scroll": "1.5",

--- a/modules/custom/openy_daxko2/README.txt
+++ b/modules/custom/openy_daxko2/README.txt
@@ -1,0 +1,14 @@
+OpenY Daxko integration. Uses APIv2 https://api.daxko.com/v3/docs/api/index.html
+
+Imports Daxko Categories into OpenY Classes.
+Imports Daxko Offerings into OpenY Sessions.
+
+See Settings page at admin/config/services/daxko2 that needs to be filled before running import.
+
+Import can be run at admin/content/daxko-import page.
+
+Module uses one API call to get all the Daxko offerings, saves it into two CSV files
+and then run Drupal migrations (migrate_plus.migration.daxko_categories_import and
+migrate_plus.migration.daxko_offerings_import).
+
+See openy_daxko2_example for more details on how you will implement this module for actual client.

--- a/modules/custom/openy_daxko2/config/install/migrate_plus.migration.daxko_categories_import.yml
+++ b/modules/custom/openy_daxko2/config/install/migrate_plus.migration.daxko_categories_import.yml
@@ -1,0 +1,75 @@
+langcode: en
+status: true
+dependencies: {  }
+id: daxko_categories_import
+migration_tags: null
+migration_group: daxko
+label: 'Import Daxko Categories'
+source:
+  plugin: csv
+  path: /tmp/categories.csv
+  delimiter: ','
+  enclosure: '"'
+  header_row_count: 0
+  keys:
+    - id
+  column_names:
+    -
+      id: Id
+    -
+      type: Type
+    -
+      title: Title
+    -
+      description: Description
+    -
+      activity: Activity
+process:
+  title: title
+  type:
+    plugin: default_value
+    default_value: class
+
+  langcode:
+    plugin: default_value
+    source: language
+    default_value: und
+  status:
+    plugin: default_value
+    default_value: 13
+  uid:
+    plugin: default_value
+    default_value: 1
+
+  field_class_activity/target_id: activity
+  field_class_activity/target_revision_id: activity
+
+  field_class_description/value: description
+  field_class_description/format:
+    plugin: default_value
+    default_value: full_html
+
+  field_content:
+    -
+      plugin: default_value
+      default_value: class_sessions,branches_popup_class
+    -
+      plugin: openy_daxko_paragraph
+
+  field_sidebar_content:
+    -
+      plugin: default_value
+      default_value: class_location
+    -
+      plugin: openy_daxko_paragraph
+
+destination:
+  plugin: 'entity:node'
+  default_bundle: class
+
+migration_dependencies:
+  required:
+    - daxko_activity_import
+    - openy_demo_paragraph_class_location_01
+    - openy_demo_paragraph_class_sessions_01
+    - openy_demo_paragraph_branches_popup_class_01

--- a/modules/custom/openy_daxko2/config/install/migrate_plus.migration.daxko_offerings_import.yml
+++ b/modules/custom/openy_daxko2/config/install/migrate_plus.migration.daxko_offerings_import.yml
@@ -1,0 +1,93 @@
+langcode: en
+status: true
+dependencies: {  }
+id: daxko_offerings_import
+migration_tags: null
+migration_group: daxko
+label: 'Import Daxko Offerings'
+source:
+  plugin: csv
+  path: /tmp/programs.csv
+  delimiter: ','
+  enclosure: '"'
+  header_row_count: 1
+  keys:
+    - id
+  column_names:
+    -
+      id: Id
+    -
+      title: Title
+    -
+      body: Description
+    -
+      date_start: 'Date start'
+    -
+      date_end: 'Date end'
+    -
+      category: Category
+    -
+      location: Location
+    -
+      something: Array
+    -
+      restrictions: Restrictions
+    -
+      times: 'Schedules (serialized times and dates when session runs)'
+    -
+      days_of_week: 'Days of week'
+    -
+      duration: 'Duration (human view)'
+    -
+      link: 'Registration link'
+    -
+      age_start: 'Start age'
+    -
+      age_end: 'End age'
+process:
+  title: title
+  field_session_description: body
+  field_session_class/target_id:
+    plugin: migration
+    migration: daxko_categories_import
+    source: category
+  type:
+    plugin: default_value
+    default_value: session
+  field_session_time:
+    plugin: openy_daxko_schedule
+    source: times
+  field_session_location/target_id:
+    plugin: get
+    source: location
+  field_session_location/target_revision_id:
+    plugin: get
+    source: location
+  langcode:
+    plugin: default_value
+    source: language
+    default_value: und
+  status:
+    plugin: default_value
+    default_value: 1
+  uid:
+    plugin: default_value
+    default_value: 1
+  field_session_reg_link/uri:
+    plugin: get
+    source: link
+  field_session_reg_link/title:
+    plugin: default_value
+    default_value: 'Register Now'
+  field_session_min_age/value:
+    plugin: get
+    source: age_start
+  field_session_max_age/value:
+    plugin: get
+    source: age_end
+
+destination:
+  plugin: 'entity:node'
+migration_dependencies:
+  required:
+    - daxko_categories_import

--- a/modules/custom/openy_daxko2/config/install/migrate_plus.migration_group.daxko.yml
+++ b/modules/custom/openy_daxko2/config/install/migrate_plus.migration_group.daxko.yml
@@ -6,5 +6,5 @@ id: daxko
 label: Daxko
 description: 'Daxko CRM system'
 source_type: 'Use APIv2 to save categories and offerings into CSV files and then migrate from them'
-module: null
+module: openy_daxko2
 shared_configuration: null

--- a/modules/custom/openy_daxko2/config/install/migrate_plus.migration_group.daxko.yml
+++ b/modules/custom/openy_daxko2/config/install/migrate_plus.migration_group.daxko.yml
@@ -1,0 +1,10 @@
+uuid: 8f09303f-c298-4b08-8bb2-512e9c4e6a06
+langcode: en
+status: true
+dependencies: {  }
+id: daxko
+label: Daxko
+description: 'Daxko CRM system'
+source_type: 'Use APIv2 to save categories and offerings into CSV files and then migrate from them'
+module: null
+shared_configuration: null

--- a/modules/custom/openy_daxko2/openy_daxko2.info.yml
+++ b/modules/custom/openy_daxko2/openy_daxko2.info.yml
@@ -1,0 +1,8 @@
+name: Daxko API v2 integration
+type: module
+description: Provide way to import classes and sessions.
+core: 8.x
+package: OpenY
+dependencies:
+  - migrate_tools
+  - migrate_source_csv

--- a/modules/custom/openy_daxko2/openy_daxko2.links.menu.yml
+++ b/modules/custom/openy_daxko2/openy_daxko2.links.menu.yml
@@ -1,0 +1,10 @@
+openy_daxko2.import:
+  title: 'Sync Daxko'
+  parent: system.admin_content
+  route_name: openy_daxko2.import
+
+openy_daxko2.admin:
+  title: 'Daxko2 settings'
+  parent: system.admin_config_services
+  route_name: openy_daxko2.settings
+  weight: 100

--- a/modules/custom/openy_daxko2/openy_daxko2.permissions.yml
+++ b/modules/custom/openy_daxko2/openy_daxko2.permissions.yml
@@ -1,0 +1,2 @@
+administer daxko2:
+  title: 'Administer Daxko2'

--- a/modules/custom/openy_daxko2/openy_daxko2.routing.yml
+++ b/modules/custom/openy_daxko2/openy_daxko2.routing.yml
@@ -1,0 +1,15 @@
+openy_daxko2.import:
+  path: '/admin/content/daxko-import'
+  defaults:
+    _form: '\Drupal\openy_daxko2\Form\ImportForm'
+    _title: 'Run Daxko Import'
+  requirements:
+    _permission: 'administer site configuration'
+
+openy_daxko2.settings:
+  path: '/admin/config/services/daxko2'
+  defaults:
+    _form: '\Drupal\openy_daxko2\Form\SettingsForm'
+    _title: 'Daxko settings'
+  requirements:
+    _permission: 'administer daxko2'

--- a/modules/custom/openy_daxko2/openy_daxko2_example/README.txt
+++ b/modules/custom/openy_daxko2/openy_daxko2_example/README.txt
@@ -1,0 +1,8 @@
+In order to implement migration you would need to do few things:
+1. Set links between classes and activities
+2. Set links between sessions and locations
+
+For these you have two hooks hook_openy_daxko2_programs_csv_row_alter() and
+openy_daxko2_example_openy_daxko2_categories_csv_row_alter()
+
+See example of the module where we pull random activities and locations.

--- a/modules/custom/openy_daxko2/openy_daxko2_example/openy_daxko2_example.info.yml
+++ b/modules/custom/openy_daxko2/openy_daxko2_example/openy_daxko2_example.info.yml
@@ -1,0 +1,7 @@
+name: Example of Daxko2 mapping
+type: module
+description: Example of session to activities and session to location mapping.
+core: 8.x
+package: OpenY
+dependencies:
+  - openy_daxko2

--- a/modules/custom/openy_daxko2/openy_daxko2_example/openy_daxko2_example.module
+++ b/modules/custom/openy_daxko2/openy_daxko2_example/openy_daxko2_example.module
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * Implements hook_openy_daxko2_programs_csv_row_alter().
+ */
+function openy_daxko2_example_openy_daxko2_programs_csv_row_alter(&$row) {
+  // Locations mapping. Ideally here should be mapping table of
+  // Daxko locations -> OpenY locations. Result should be id of the node.
+
+  // For demo purposes use random location.
+  static $locations;
+  if (empty($locations)) {
+    $query = \Drupal::entityQuery('node');
+    $query->condition('status', 1);
+    $query->condition('type', 'branch');
+    $locations = array_values($query->execute());
+  }
+
+  $row['locations'] = $locations[rand(0, count($locations) - 1)];
+}
+
+/**
+ * Implements hook_openy_daxko2_categories_csv_row_alter().
+ */
+function openy_daxko2_example_openy_daxko2_categories_csv_row_alter(&$row) {
+  // Here should be a mapping of classes to activities. As activities
+  // are created manually in Drupal and classes coming from Daxko
+  // there should be some kind of intelligent system of mapping or simple
+  // mapping table (if there are not too many classes).
+
+  // In example we do simple random pull of activities. And also mark
+  // classes with 'Daxko' so easy to spot on demo site.
+  static $activities;
+  if (empty($activities)) {
+    $query = \Drupal::entityQuery('node');
+    $query->condition('status', 1);
+    $query->condition('type', 'activity');
+    $activities = array_values($query->execute());
+  }
+  
+  $row['name'] = 'Daxko ' . $row['name'];
+  $row['description'] = 'Daxko ' . $row['description'];
+
+  $row['activity'] = $activities[rand(0, count($activities) - 1)];
+}

--- a/modules/custom/openy_daxko2/src/Form/ImportForm.php
+++ b/modules/custom/openy_daxko2/src/Form/ImportForm.php
@@ -101,7 +101,7 @@ class ImportForm extends FormBase {
     $after = TRUE;
     $i = 1;
 
-    $filenamePrograms = file_directory_temp() . '/programs.csv';
+    $filenamePrograms = '/tmp/programs.csv';
     unlink($filenamePrograms);
     $fp = fopen($filenamePrograms, 'w');
 
@@ -209,7 +209,7 @@ class ImportForm extends FormBase {
     fclose($fp);
 
     // Save categories CSV file.
-    $filenameCategories = file_directory_temp() . '/categories.csv';
+    $filenameCategories = '/tmp/categories.csv';
     unlink($filenameCategories);
     $fp = fopen($filenameCategories, 'w');
     foreach ($categories as $fields) {

--- a/modules/custom/openy_daxko2/src/Form/ImportForm.php
+++ b/modules/custom/openy_daxko2/src/Form/ImportForm.php
@@ -1,0 +1,247 @@
+<?php
+
+namespace Drupal\openy_daxko2\Form;
+
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+use Drupal\migrate\MigrateExecutable;
+use Drupal\migrate\MigrateMessage;
+
+use GuzzleHttp\Client;
+
+/**
+ * Settings Form for daxko.
+ */
+class ImportForm extends FormBase {
+
+  protected $client;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'openy_daxko2_import';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form['selects']['button'] = [
+      '#type' => 'submit',
+      '#attributes' => [
+        'class' => [
+          'btn',
+          'blue',
+        ]
+      ],
+      '#value' => $this->t('Run Daxko Import'),
+    ];
+
+    return $form;
+
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $config = \Drupal::configFactory()->get('openy_daxko2.settings');
+
+    $batch = array(
+      'title' => $this->t('Importing Programs from Daxko'),
+      'operations' => array(
+        // We will get Categories CSV file from Programs as ID's of categories
+        // do not match.
+        array('Drupal\openy_daxko2\Form\ImportForm::generateProgramsCSV', array($config)),
+        array('Drupal\openy_daxko2\Form\ImportForm::migrateCategories', array()),
+        array('Drupal\openy_daxko2\Form\ImportForm::migrateOfferings', array()),
+      ),
+      'finished' => 'Drupal\openy_daxko2\Form\ImportForm::batchFinished',
+    );
+
+    batch_set($batch);
+  }
+
+  protected static function getAccessToken(&$context, $config) {
+    if (isset($context['results']['access_token'])) {
+      return $context['results']['access_token'];
+    }
+    $client = new Client(['base_uri' => $config->get('base_uri')]);
+    $response = $client->request('POST', 'partners/oauth2/token',
+    [
+      'form_params' => [
+        'client_id' => $config->get('user'),
+        'client_secret' => $config->get('pass'),
+        'grant_type' => 'client_credentials',
+        'scope' => 'client:' . $config->get('client_id'),
+      ],
+      'headers' => [
+        'Authorization' => "Bearer " . $config->get('referesh_token')
+      ],
+    ]);
+
+    $context['results']['access_token'] = json_decode((string)$response->getBody())->access_token;
+
+    return $context['results']['access_token'];
+  }
+
+  public static function generateProgramsCSV($config, &$context) {
+    $base_uri = $config->get('base_uri');
+
+    $accessToken = self::getAccessToken($context, $config);
+
+    $client = new Client(['base_uri' => $base_uri]);
+
+    $after = TRUE;
+    $i = 1;
+
+    unlink('/tmp/programs.csv');
+    $fp = fopen('/tmp/programs.csv', 'w');
+
+    $categories = [];
+
+    while (!empty($after) && $i < 100) {
+      $get = [];
+
+      if (strlen($after) > 5) {
+        $get = [ 'after' => $after ];
+      }
+      $response = $client->request('GET', 'programs/offerings/search',
+        [
+          'query' => $get,
+          'headers' => [
+            'Authorization' => "Bearer " . $accessToken
+          ],
+        ]);
+
+      $programsResponse = json_decode((string)$response->getBody(), TRUE);
+
+//      drupal_set_message(json_encode($programsResponse));
+
+      foreach ($programsResponse['offerings'] as $row) {
+
+        $newRow = [];
+        foreach ($row as $key => $value) {
+          if (in_array($key, ['highlights', 'score', 'type'])) {
+            continue;
+          }
+
+          switch ($key) {
+            case 'start_date':
+            case 'end_date':
+              $value = substr($value, 0, 10);
+              break;
+
+            case 'locations':
+              // We expect 'locations' to be overidden with hook.
+              // @see openy_daxko2_example_openy_daxko2_categories_csv_row_alter().
+
+              break;
+
+            case 'program':
+              array_pop($value);
+              $value['description'] = $row['description'];
+
+              $categories[$value['id']] = $value;
+
+              $value = $value['id'];
+              break;
+
+            case 'days_offered':
+              $weekdays = [];
+              foreach ($value as $day) {
+                $weekdays[] = $day['name'];
+              }
+              $value = implode(', ', $weekdays);
+              break;
+
+            case 'registration':
+              $value = json_encode($value);
+              break;
+
+            case 'restrictions':
+              if (isset($value['age'])) {
+                $value = json_encode($value);
+              }
+              break;
+
+            case 'times':
+              $value = json_encode([
+                'times' => $row['times'],
+                'days' => $row['days_offered'],
+                'start_date' => $row['start_date'],
+                'end_date' => $row['end_date'],
+              ]);
+              break;
+          }
+
+          $newRow[$key] = $value;
+        }
+
+        $newRow['link'] = 'https://ops1.operations.daxko.com/Online/' . $config->get('client_id') . '/ProgramsV2/OfferingDetails.mvc?program_id=' . $row['program']['id'] . '&offering_id=' . $row['id'] . '&location_id=' . $row['locations'][0]['id'];
+        $newRow['ageFrom'] = isset($row['restrictions']['age']) ? $row['restrictions']['age']['start'] : null;
+        $newRow['ageTo'] = isset($row['restrictions']['age']) ? $row['restrictions']['age']['end'] : null;
+
+        // Allow custom implementations to set up the mappings.
+        \Drupal::moduleHandler()->alter('openy_daxko2_programs_csv_row', $newRow);
+
+        fputcsv($fp, $newRow);
+      }
+
+      $after = '';
+      if (isset($programsResponse['links'])) {
+        $link = reset($programsResponse['links']);
+        if (strpos($link['href'], 'after=')) {
+          list(, $after) = explode('after=', $link['href']);
+          $after = urldecode($after);
+        }
+      }
+
+      $i++;
+    }
+
+    fclose($fp);
+
+    // Save categories CSV file.
+    unlink('/tmp/categories.csv');
+    $fp = fopen('/tmp/categories.csv', 'w');
+    foreach ($categories as $fields) {
+      \Drupal::moduleHandler()->alter('openy_daxko2_categories_csv_row', $fields);
+
+      fputcsv($fp, $fields);
+    }
+    fclose($fp);
+  }
+
+  public static function batchFinished($success, $results, $operations) {
+    // For some reason imported sessions (offerings) got status 13 instead of 1.
+    // So update them manually or dive into the code and find the bug.
+    db_query('UPDATE {node_field_data} SET status=1 WHERE status=13');
+
+
+    if ($success) {
+      drupal_set_message(t('Great success!'));
+    }
+    else {
+      $error_operation = reset($operations);
+      drupal_set_message(t('An error occurred while processing @operation with arguments : @args', array('@operation' => $error_operation[0], '@args' => print_r($error_operation[0], TRUE))));
+    }
+  }
+
+  public static function migrateCategories() {
+    self::runMigration('daxko_categories_import');
+  }
+
+  public static function migrateOfferings() {
+    self::runMigration('daxko_offerings_import');
+  }
+
+  protected static function runMigration($migration_id) {
+    $migration = \Drupal::service('plugin.manager.migration')->createInstance($migration_id);
+    $executable = new MigrateExecutable($migration, new MigrateMessage());
+    $executable->import();
+  }
+
+}

--- a/modules/custom/openy_daxko2/src/Form/SettingsForm.php
+++ b/modules/custom/openy_daxko2/src/Form/SettingsForm.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Drupal\openy_daxko2\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Settings Form for daxko.
+ */
+class SettingsForm extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'openy_daxko2_admin_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      'openy_daxko2.settings',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->config('openy_daxko2.settings');
+
+    $form_state->setCached(FALSE);
+
+    /* @see \Drupal\daxko\DaxkoClientFactory::get */
+    
+    $form['base_uri'] = [
+      '#type' => 'url',
+      '#title' => $this->t('Daxko API Base URI v3'),
+      '#default_value' => $config->get('base_uri'),
+      '#description' => t('Add your Daxko API base uri here. It is most likely https://api.daxko.com/v3/.'),
+    ];
+
+    $form['client_id'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Client Id'),
+      '#default_value' => $config->get('client_id'),
+      '#description' => t('Your Daxko client id. Like 4032.'),
+    ];
+
+    $form['user'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Daxko account name'),
+      '#default_value' => $config->get('user'),
+      '#description' => t('Add your Daxko API user name here.'),
+    ];
+
+    $form['pass'] = [
+      '#type' => 'password',
+      '#title' => $this->t('Daxko password'),
+      '#description' => t('Add your Daxko API password.'),
+    ];
+
+    $form['referesh_token'] = [
+      '#type' => 'textarea',
+      '#title' => $this->t('Daxko refresh token'),
+      '#default_value' => $config->get('referesh_token'),
+      '#description' => t('Refresh token is a large string like 241 chars long.'),
+    ];
+
+    return parent::buildForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    /* @var $config \Drupal\Core\Config\Config */
+    $config = \Drupal::service('config.factory')->getEditable('openy_daxko2.settings');
+
+    $config->set('referesh_token', $form_state->getValue('referesh_token'))->save();
+
+    $config->set('client_id', $form_state->getValue('client_id'))->save();
+
+    if ($base_uri = $form_state->getValue('base_uri')) {
+      if (preg_match("#https?://#", $base_uri) === 0) {
+        $base_uri = 'https://' . $base_uri;
+      }
+      $config->set('base_uri', rtrim($base_uri, '/') . '/')->save();
+    }
+
+    $config->set('user', $form_state->getValue('user'))->save();
+
+    if (empty($pass = $form_state->getValue('pass'))) {
+      $pass = $config->get('pass');
+    }
+    $config->set('pass', $pass)->save();
+
+    parent::submitForm($form, $form_state);
+  }
+
+}

--- a/modules/custom/openy_daxko2/src/Plugin/migrate/process/OpenYDaxkoParagraph.php
+++ b/modules/custom/openy_daxko2/src/Plugin/migrate/process/OpenYDaxkoParagraph.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\openy_daxko2\Plugin\migrate\process;
+
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\Row;
+use Drupal\paragraphs\Entity\Paragraph;
+
+/**
+ * Fills in link options with icon information.
+ *
+ * @MigrateProcessPlugin(
+ *   id = "openy_daxko_paragraph"
+ * )
+ */
+class OpenYDaxkoParagraph extends ProcessPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    $types = explode(',', $value);
+    $paragraps = [];
+    foreach ($types as $type) {
+      $paragraph = Paragraph::create(['type' => $type ]);
+      $paragraph->isNew();
+      $paragraph->save();
+      $paragraps[] = [
+        'target_id' => $paragraph->id(),
+        'target_revision_id' => $paragraph->getRevisionId(),
+      ];
+    }
+
+    return $paragraps;
+  }
+
+  public function multiple() {
+    return TRUE;
+  }
+
+}

--- a/modules/custom/openy_daxko2/src/Plugin/migrate/process/OpenYDaxkoSchedule.php
+++ b/modules/custom/openy_daxko2/src/Plugin/migrate/process/OpenYDaxkoSchedule.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Drupal\openy_daxko2\Plugin\migrate\process;
+
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\Row;
+use Drupal\paragraphs\Entity\Paragraph;
+
+/**
+ * Fills in link options with icon information.
+ *
+ * @MigrateProcessPlugin(
+ *   id = "openy_daxko_schedule"
+ * )
+ */
+class OpenYDaxkoSchedule extends ProcessPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    $value = json_decode($value);
+//    {"times":[{"start":"18:00","end":"20:00"}],"days":[{"id":"5","name":"Friday"}],"start_date":"2018-02-16T00:00:00.0000000","end_date":"2018-02-16T00:00:00.0000000"}
+
+    $startDate = substr($value->start_date, 0, 11) . $value->times[0]->start . ':00';
+    $endDate = substr($value->end_date, 0, 11) . $value->times[0]->end . ':00';
+
+    $days = [];
+    foreach ($value->days as $day) {
+      $days[] = strtolower($day->name);
+    }
+
+    $paragraph = Paragraph::create(['type' => 'session_time' ]);
+    $paragraph->set('field_session_time_days', $days);
+    $paragraph->set('field_session_time_date', ['value' => $startDate, 'end_value' => $endDate]);
+    $paragraph->isNew();
+    $paragraph->save();
+
+    return [
+      'target_id' => $paragraph->id(),
+      'target_revision_id' => $paragraph->getRevisionId(),
+    ];
+  }
+
+}

--- a/modules/custom/openy_daxko2/src/README.txt
+++ b/modules/custom/openy_daxko2/src/README.txt
@@ -1,0 +1,1 @@
+Integration with Daxko API https://api.daxko.com/v3/docs/api/index.html


### PR DESCRIPTION
Module allows importing Categories (OpenY's classes) and Offerings (OpenY's sessions) into Drupal.

Depends on migrate_source_csv module. See site openy-daxko.ixm.ca for demo. Under programs you can see "Daxko ..." classes. These are the ones imported from CRM. Example http://openy-daxko.ixm.ca/programs/swimming/swim-lessons/daxko-preschool-stage-2-water-movement/class-times?location=all

I am not putting openy_daxko2 module into installation profile for now. Not sure if we should do that by default.