### PR TITLE
[OYPD-648] Update focal point support for News Post content type

### DIFF
--- a/modules/openy_features/openy_node/modules/openy_node_news/config/install/image.style.node_news.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_news/config/install/image.style.node_news.yml
@@ -1,13 +1,16 @@
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  module:
+    - focal_point
 name: node_news
 label: 'Node news'
 effects:
-  dd6b02aa-6378-4d42-a2b3-57eaa0c52019:
-    uuid: dd6b02aa-6378-4d42-a2b3-57eaa0c52019
-    id: image_scale_and_crop
-    weight: 1
+  c45d98ad-b676-42b9-b59b-12e671b55141:
+    uuid: c45d98ad-b676-42b9-b59b-12e671b55141
+    id: focal_point_scale_and_crop
+    weight: 2
     data:
       width: 762
       height: 451
+      crop_type: focal_point

--- a/modules/openy_features/openy_node/modules/openy_node_news/openy_node_news.info.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_news/openy_node_news.info.yml
@@ -9,6 +9,7 @@ dependencies:
   - entity_reference_revisions
   - field
   - field_group
+  - focal_point
   - image
   - media_entity
   - menu_ui

--- a/modules/openy_features/openy_node/modules/openy_node_news/openy_node_news.install
+++ b/modules/openy_features/openy_node/modules/openy_node_news/openy_node_news.install
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @file
+ * OpenY News Posts install file.
+ */
+
+/**
+ * Update config for the image style after pinpoint support was added.
+ */
+function openy_node_news_update_8001() {
+  $config_dir = drupal_get_path('module', 'openy_node_news') . '/config/install/';
+  // Update multiple configurations.
+  $configs = [
+    'image.style.node_news' => [
+      'dependencies',
+      'effects',
+    ],
+  ];
+  $config_updater = \Drupal::service('openy_upgrade_tool.param_updater');
+  foreach ($configs as $config_name => $params) {
+    $config = $config_dir . $config_name . '.yml';
+    foreach ($params as $param) {
+      $config_updater->update($config, $config_name, $param);
+    }
+  }
+}

--- a/modules/openy_features/openy_node/modules/openy_node_news/openy_node_news.install
+++ b/modules/openy_features/openy_node/modules/openy_node_news/openy_node_news.install
@@ -6,7 +6,7 @@
  */
 
 /**
- * Update config for the image style after pinpoint support was added.
+ * Update config for the image style after focal point support was added.
  */
 function openy_node_news_update_8001() {
   $config_dir = drupal_get_path('module', 'openy_node_news') . '/config/install/';

--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -4445,14 +4445,41 @@ html.js .branch__updates_queue__button {
 }
 .node--type-news.node--view-mode-teaser {
   margin: auto;
-  max-width: 373px;
-  width: 100%;
+}
+@media (min-width: 30em) {
+  .node--type-news.node--view-mode-teaser {
+    max-width: 373px;
+    width: 100%;
+  }
 }
 .node--type-news.node--view-mode-teaser .inner-wrapper {
-  margin: 15px 0;
+  height: 240px;
+  width: 288px;
+  margin: 15px auto;
   position: relative;
   overflow: hidden;
-  height: 250px;
+}
+@media (min-width: 30em) {
+  .node--type-news.node--view-mode-teaser .inner-wrapper {
+    height: 288px;
+    width: auto;
+  }
+}
+@media (min-width: 48em) {
+  .node--type-news.node--view-mode-teaser .inner-wrapper {
+    height: 288px;
+    width: auto;
+  }
+}
+@media (min-width: 62em) {
+  .node--type-news.node--view-mode-teaser .inner-wrapper {
+    height: 245px;
+  }
+}
+@media (min-width: 75em) {
+  .node--type-news.node--view-mode-teaser .inner-wrapper {
+    height: 300px;
+  }
 }
 .node--type-news.node--view-mode-teaser img {
   height: auto;

--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -2172,26 +2172,38 @@ body {
 .paragraph--type--news-posts-listing .views-exposed-form,
 .paragraph--type--latest-news-posts .views-exposed-form,
 .paragraph--type--latest-news-posts-camp .views-exposed-form,
-.paragraph--type--latest-news-posts-branch .views-exposed-form {
+.paragraph--type--latest-news-posts-branch .views-exposed-form,
+.paragraph--type--featured-news .views-exposed-form {
   margin-bottom: 30px;
 }
 @media (min-width: 48em) {
   .paragraph--type--blog-posts-listing .blog-more-teaser-results-wrapper,
   .paragraph--type--blog-posts-listing .news-more-teaser-results-wrapper,
+  .paragraph--type--blog-posts-listing .wrapper-field-fnews-posts,
   .paragraph--type--latest-blog-posts .blog-more-teaser-results-wrapper,
   .paragraph--type--latest-blog-posts .news-more-teaser-results-wrapper,
+  .paragraph--type--latest-blog-posts .wrapper-field-fnews-posts,
   .paragraph--type--latest-blog-posts-camp .blog-more-teaser-results-wrapper,
   .paragraph--type--latest-blog-posts-camp .news-more-teaser-results-wrapper,
+  .paragraph--type--latest-blog-posts-camp .wrapper-field-fnews-posts,
   .paragraph--type--latest-blog-posts-branch .blog-more-teaser-results-wrapper,
   .paragraph--type--latest-blog-posts-branch .news-more-teaser-results-wrapper,
+  .paragraph--type--latest-blog-posts-branch .wrapper-field-fnews-posts,
   .paragraph--type--news-posts-listing .blog-more-teaser-results-wrapper,
   .paragraph--type--news-posts-listing .news-more-teaser-results-wrapper,
+  .paragraph--type--news-posts-listing .wrapper-field-fnews-posts,
   .paragraph--type--latest-news-posts .blog-more-teaser-results-wrapper,
   .paragraph--type--latest-news-posts .news-more-teaser-results-wrapper,
+  .paragraph--type--latest-news-posts .wrapper-field-fnews-posts,
   .paragraph--type--latest-news-posts-camp .blog-more-teaser-results-wrapper,
   .paragraph--type--latest-news-posts-camp .news-more-teaser-results-wrapper,
+  .paragraph--type--latest-news-posts-camp .wrapper-field-fnews-posts,
   .paragraph--type--latest-news-posts-branch .blog-more-teaser-results-wrapper,
-  .paragraph--type--latest-news-posts-branch .news-more-teaser-results-wrapper {
+  .paragraph--type--latest-news-posts-branch .news-more-teaser-results-wrapper,
+  .paragraph--type--latest-news-posts-branch .wrapper-field-fnews-posts,
+  .paragraph--type--featured-news .blog-more-teaser-results-wrapper,
+  .paragraph--type--featured-news .news-more-teaser-results-wrapper,
+  .paragraph--type--featured-news .wrapper-field-fnews-posts {
     margin-left: -15px;
     margin-right: -15px;
   }

--- a/themes/openy_themes/openy_rose/scss/modules/_news.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_news.scss
@@ -30,14 +30,31 @@
 
   &.node--view-mode-teaser {
     margin: auto;
-    max-width: 373px;
-    width: 100%;
+    @include breakpoint($screen-xs) {
+      max-width: 373px;
+      width: 100%;
+    }
 
     .inner-wrapper {
-      margin: 15px 0;
+      height: 240px;
+      width: 288px;
+      margin: 15px auto;
       position: relative;
       overflow: hidden;
-      height: 250px;
+      @include breakpoint($screen-xs) {
+        height: 288px;
+        width: auto;
+      }
+      @include breakpoint($screen-sm) {
+        height: 288px;
+        width: auto;
+      }
+      @include breakpoint($screen-md) {
+        height: 245px;
+      }
+      @include breakpoint($screen-lg) {
+        height: 300px;
+      }
     }
 
     img {

--- a/themes/openy_themes/openy_rose/scss/modules/_paragraphs.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_paragraphs.scss
@@ -879,13 +879,15 @@
 .paragraph--type--news-posts-listing,
 .paragraph--type--latest-news-posts,
 .paragraph--type--latest-news-posts-camp,
-.paragraph--type--latest-news-posts-branch {
+.paragraph--type--latest-news-posts-branch,
+.paragraph--type--featured-news {
   .views-exposed-form {
     margin-bottom: 30px;
   }
   @include breakpoint($screen-sm) {
     .blog-more-teaser-results-wrapper,
-    .news-more-teaser-results-wrapper {
+    .news-more-teaser-results-wrapper,
+    .wrapper-field-fnews-posts {
       margin-left: -15px;
       margin-right: -15px;
     }


### PR DESCRIPTION
## Steps for review

- [x] Check the focal point support on the full page for a news post. The teaser was already using it.
- [x] Check the styling of the teaser tiles. I used the same styling as the blog posts so they would look the same. I don't know why they were different.
- [x] I left the teaser using the program teaser image style because blog posts were doing the same. I only want to fix the current bug, which was not displaying the full image correctly. We should inventory all of these in a follow up and correct them.