### PR TITLE
[OYPD-640] Adding fixed width to logo to fix IE issue

### DIFF
--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -385,6 +385,7 @@ body {
 @media (min-width: 62em) {
   .page-head__logo .site-logo {
     position: absolute;
+    width: 250px;
   }
 }
 .page-head__logo .site-slogan {

--- a/themes/openy_themes/openy_rose/scss/modules/_header.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_header.scss
@@ -40,6 +40,7 @@
     .site-logo {
       @include breakpoint($screen-desktop) {
         position: absolute;
+        width: 250px;
       }
     }
 


### PR DESCRIPTION
Trying to get the logo and OpenY site name text split they way they are is the cause of the issue. Removing absolute position causes the site logo wrapper to float over part of the menu, because the  OpenY text is in the center of the page.

I added a fixed width to the logo to keep activity image from wrapping. It's getting the natural width wrong.

This will affect only the largest size.

Seems to work in IE where I saw the problem.

![screen shot 2018-02-20 at 5 44 06 pm](https://user-images.githubusercontent.com/1504038/36453514-4791b448-1666-11e8-83a3-8a697cddec0a.png)
