### PR TITLE
 Fix 'results' is an invalid render array key error

### DIFF
--- a/modules/custom/openy_group_schedules/src/Form/GroupexFormFull.php
+++ b/modules/custom/openy_group_schedules/src/Form/GroupexFormFull.php
@@ -155,6 +155,7 @@ class GroupexFormFull extends GroupexFormBase {
     $formatted_results = NULL;
     $conf = $this->configFactory->get('openy_group_schedules.settings');
     $max_age = is_numeric($conf->get('cache_max_age')) ? $conf->get('cache_max_age') : 3600;
+    $instructors_options = [];
 
     // Get location options.
     $this->locationOptions = $this->getOptions($this->request(['query' => ['locations' => TRUE]]), 'id', 'name');

--- a/modules/custom/openy_group_schedules/src/Form/GroupexFormFull.php
+++ b/modules/custom/openy_group_schedules/src/Form/GroupexFormFull.php
@@ -426,7 +426,7 @@ class GroupexFormFull extends GroupexFormBase {
 
     $form['result'] = [
       '#prefix' => '</div><div class="groupex-results">',
-      'results' => $formatted_results,
+      '#results' => $formatted_results,
       '#suffix' => '</div>',
       '#weight' => 10,
     ];


### PR DESCRIPTION
Make sure these boxes are checked before asking for review of your pull request - thank you!

## General checks
- [x] All coding styles are fulfilled and there are no any issues reported by CodeSniffer CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/ci-errors.png" width="200" alt="CI code sniffer errors">
- [x] All tests are running and there are no failed tests reported by CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/behat.png" width="200" alt="Behat test results">
- [x] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [x] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [x] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [x] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [x] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!

## Steps for review

- [x] open path /locations/south-ymca.
- [x] Make sure no errors in log like 
User error: "results" is an invalid render array key in Drupal\Core\Render\Element::children() (line 97 of core/lib/Drupal/Core/Render/Element.php).
