### PR TITLE
Replace select list widget with autocomplete widget for Group schedules paragraph

### DIFF
--- a/modules/custom/openy_group_schedules/openy_group_schedules.routing.yml
+++ b/modules/custom/openy_group_schedules/openy_group_schedules.routing.yml
@@ -26,3 +26,11 @@ openy_group_schedules.settings:
     _title: GroupEx settings
   requirements:
     _permission: 'administer site configuration'
+
+openy_group_schedules.autocomplete:
+  path: /openy-group-schedules-autocomplete
+  defaults:
+    _controller: '\Drupal\openy_group_schedules\Controller\AutocompleteController::handleAutocomplete'
+    _format: json
+  requirements:
+    _access: 'TRUE'

--- a/modules/custom/openy_group_schedules/src/Controller/AutocompleteController.php
+++ b/modules/custom/openy_group_schedules/src/Controller/AutocompleteController.php
@@ -39,8 +39,8 @@ class AutocompleteController extends ControllerBase {
         $option_lower = Unicode::strtolower($option);
         if (strpos($option_lower, $typed_string)) {
           $results[] = [
-            'value' => $machine_name,
-            //'label' => $option . ' (' . $machine_name . ')',
+            // 'value' => $machine_name,
+            'value' => $option . ' (' . $machine_name . ')',
             'label' => $option,
           ];
         }

--- a/modules/custom/openy_group_schedules/src/Controller/AutocompleteController.php
+++ b/modules/custom/openy_group_schedules/src/Controller/AutocompleteController.php
@@ -40,6 +40,7 @@ class AutocompleteController extends ControllerBase {
         if (strpos($option_lower, $typed_string)) {
           $results[] = [
             'value' => $machine_name,
+            //'label' => $option . ' (' . $machine_name . ')',
             'label' => $option,
           ];
         }

--- a/modules/custom/openy_group_schedules/src/Controller/AutocompleteController.php
+++ b/modules/custom/openy_group_schedules/src/Controller/AutocompleteController.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Drupal\openy_group_schedules\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Drupal\Component\Utility\Tags;
+use Drupal\Component\Utility\Unicode;
+
+/**
+ * Defines a route controller for entity autocomplete form elements.
+ */
+class AutocompleteController extends ControllerBase {
+
+  /**
+   * Handler for autocomplete request.
+   */
+  public function handleAutocomplete(Request $request) {
+    $results = [];
+    // Get the typed string from the URL, if it exists.
+    if ($input = $request->query->get('q')) {
+      $blockManager = \Drupal::service('plugin.manager.block');
+      $contextRepository = \Drupal::service('context.repository');
+
+      // Get blocks definition
+      $definitions = $blockManager->getDefinitionsForContexts($contextRepository->getAvailableContexts());
+      $options = [];
+      foreach ($definitions as $machine_name => $definition) {
+        $options[$machine_name] = $definition['admin_label'];
+      }
+
+      $typed_string = Tags::explode($input);
+      $typed_string = Unicode::strtolower(array_pop($typed_string));
+      // @todo: Apply logic for generating results based on typed_string and other
+      // arguments passed.
+
+      foreach ($options as $machine_name => $option) {
+        $option_lower = Unicode::strtolower($option);
+        if (strpos($option_lower, $typed_string)) {
+          $results[] = [
+            'value' => $machine_name,
+            'label' => $option,
+          ];
+        }
+      }
+    }
+
+    return new JsonResponse($results);
+  }
+
+}

--- a/modules/custom/openy_group_schedules/src/Controller/AutocompleteController.php
+++ b/modules/custom/openy_group_schedules/src/Controller/AutocompleteController.php
@@ -23,7 +23,7 @@ class AutocompleteController extends ControllerBase {
       $blockManager = \Drupal::service('plugin.manager.block');
       $contextRepository = \Drupal::service('context.repository');
 
-      // Get blocks definition
+      // Get blocks definition.
       $definitions = $blockManager->getDefinitionsForContexts($contextRepository->getAvailableContexts());
       $options = [];
       foreach ($definitions as $machine_name => $definition) {
@@ -34,12 +34,10 @@ class AutocompleteController extends ControllerBase {
       $typed_string = Unicode::strtolower(array_pop($typed_string));
       // @todo: Apply logic for generating results based on typed_string and other
       // arguments passed.
-
       foreach ($options as $machine_name => $option) {
         $option_lower = Unicode::strtolower($option);
         if (strpos($option_lower, $typed_string)) {
           $results[] = [
-            // 'value' => $machine_name,
             'value' => $option . ' (' . $machine_name . ')',
             'label' => $option,
           ];

--- a/modules/custom/openy_group_schedules/src/Controller/AutocompleteController.php
+++ b/modules/custom/openy_group_schedules/src/Controller/AutocompleteController.php
@@ -39,6 +39,7 @@ class AutocompleteController extends ControllerBase {
         if (strpos($option_lower, $typed_string)) {
           $results[] = [
             'value' => $option . ' (' . $machine_name . ')',
+            // 'value' => $machine_name,
             'label' => $option,
           ];
         }

--- a/modules/custom/openy_group_schedules/src/Controller/AutocompleteController.php
+++ b/modules/custom/openy_group_schedules/src/Controller/AutocompleteController.php
@@ -39,7 +39,6 @@ class AutocompleteController extends ControllerBase {
         if (strpos($option_lower, $typed_string)) {
           $results[] = [
             'value' => $option . ' (' . $machine_name . ')',
-            // 'value' => $machine_name,
             'label' => $option,
           ];
         }

--- a/modules/custom/openy_group_schedules/src/Plugin/Plugin/PluginSelector/AutocompleteList.php
+++ b/modules/custom/openy_group_schedules/src/Plugin/Plugin/PluginSelector/AutocompleteList.php
@@ -43,7 +43,7 @@ class AutocompleteList extends AdvancedPluginSelectorBase {
           'name' => $element['container']['change']['#name'],
         ],
       ],
-      '#default_value' => $this->getSelectedPlugin() ? $this->getSelectedPlugin()->getPluginId() : NULL,
+      '#default_value' => $this->getSelectedPlugin() ? $options[$this->getSelectedPlugin()->getPluginId()] : NULL,
       //'#options' => $options,
       '#required' => $this->isRequired(),
       '#title' => $this->getLabel(),
@@ -61,7 +61,7 @@ class AutocompleteList extends AdvancedPluginSelectorBase {
           'name' => $element['container']['plugin_id']['#name'],
         ],*/
       ],
-      '#default_value' => $this->getSelectedPlugin() ? $options[$this->getSelectedPlugin()->getPluginId()] : NULL,
+      '#default_value' => $this->getSelectedPlugin() ? $this->getSelectedPlugin()->getPluginDefinition()['admin_label']->render() . ' (' . $this->getSelectedPlugin()->getPluginId() . ')' : NULL,
       //'#options' => $options,
       '#required' => $this->isRequired(),
       '#title' => $this->getLabel(),
@@ -154,5 +154,17 @@ class AutocompleteList extends AdvancedPluginSelectorBase {
     }
 
     return $options;
+  }
+
+  /**
+   * Builds the form elements for multiple plugins.
+   */
+  protected function buildMultipleAvailablePlugins(array $plugin_selector_form, FormStateInterface $plugin_selector_form_state) {
+    $plugins = $plugin_selector_form['#available_plugins'];
+
+    $plugin_selector_form['select'] = $this->buildSelector($plugin_selector_form, $plugin_selector_form_state, $plugins);
+    $plugin_selector_form['plugin_form'] = $this->buildPluginForm($plugin_selector_form, $plugin_selector_form_state);
+
+    return $plugin_selector_form;
   }
 }

--- a/modules/custom/openy_group_schedules/src/Plugin/Plugin/PluginSelector/AutocompleteList.php
+++ b/modules/custom/openy_group_schedules/src/Plugin/Plugin/PluginSelector/AutocompleteList.php
@@ -2,17 +2,9 @@
 
 namespace Drupal\openy_group_schedules\Plugin\Plugin\PluginSelector;
 
-use Drupal\Component\Utility\NestedArray;
-use Drupal\Core\Ajax\AjaxResponse;
-use Drupal\Core\Ajax\AlertCommand;
-use Drupal\Core\Ajax\ChangedCommand;
-use Drupal\Core\Ajax\DataCommand;
-use Drupal\Core\Ajax\ReplaceCommand;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\plugin\PluginDefinition\PluginLabelDefinitionInterface;
 use Drupal\plugin\PluginHierarchyTrait;
 use Drupal\plugin\Plugin\Plugin\PluginSelector\AdvancedPluginSelectorBase;
-use Drupal\Component\Utility\Html;
 
 /**
  * Provides a plugin selector using a <autocomplete> element.
@@ -44,7 +36,6 @@ class AutocompleteList extends AdvancedPluginSelectorBase {
         '#submit' => [[$this, 'rebuildForm']],
       ],
       '#default_value' => $this->getSelectedPlugin() ? $this->getSelectedPlugin()->getPluginDefinition()['admin_label'] . ' (' . $this->getSelectedPlugin()->getPluginId() . ')' : NULL,
-      // '#default_value' => $this->getSelectedPlugin() ? $this->getSelectedPlugin()->getPluginId() : NULL,
       '#required' => $this->isRequired(),
       '#title' => $this->getLabel(),
       '#description' => $this->getDescription(),
@@ -67,17 +58,12 @@ class AutocompleteList extends AdvancedPluginSelectorBase {
   /**
    * {@inheritdoc}
    */
-  public function submitSelectorForm(array &$plugin_selector_form, FormStateInterface $plugin_selector_form_state) {
-    $this->setPluginId($plugin_selector_form_state);
-    parent::submitSelectorForm($plugin_selector_form, $plugin_selector_form_state);
-  }
-
   public function setPluginId(FormStateInterface &$plugin_selector_form_state) {
     $this->assertSubformState($plugin_selector_form_state);
     $plugin_id = $plugin_selector_form_state
       ->getValue(['container', 'select', 'container', 'plugin_id']);
-    $match = preg_match('/\s\(([a-zA-Z0-9\:\-\_]+)\)$/', $plugin_id, $matches);
-    if ($match && isset($matches[1])) {
+    $match_plugin_id = preg_match('/\s\(([a-zA-Z0-9\:\-\_]+)\)$/', $plugin_id, $matches);
+    if ($match_plugin_id && isset($matches[1])) {
       $plugin_id = $matches[1];
       $plugin_selector_form_state
         ->setValue(['container', 'select', 'container', 'plugin_id'], $plugin_id);

--- a/modules/custom/openy_group_schedules/src/Plugin/Plugin/PluginSelector/AutocompleteList.php
+++ b/modules/custom/openy_group_schedules/src/Plugin/Plugin/PluginSelector/AutocompleteList.php
@@ -2,13 +2,19 @@
 
 namespace Drupal\openy_group_schedules\Plugin\Plugin\PluginSelector;
 
+use Drupal\Component\Utility\NestedArray;
+use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\Ajax\AlertCommand;
+use Drupal\Core\Ajax\ChangedCommand;
+use Drupal\Core\Ajax\DataCommand;
+use Drupal\Core\Ajax\ReplaceCommand;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\plugin\PluginDefinition\PluginLabelDefinitionInterface;
 use Drupal\plugin\PluginHierarchyTrait;
 use Drupal\plugin\Plugin\Plugin\PluginSelector\AdvancedPluginSelectorBase;
 
 /**
- * Provides a plugin selector using a <select> element.
+ * Provides a plugin selector using a <autocomplete> element.
  *
  * @PluginSelector(
  *   id = "plugin_autocomplete_list",
@@ -28,27 +34,100 @@ class AutocompleteList extends AdvancedPluginSelectorBase {
     /** @var \Drupal\Component\Plugin\PluginInspectionInterface[] $plugins */
 
     $options = $this->buildOptionsLevel($this->buildPluginHierarchy($this->selectablePluginDiscovery));
-
-    $element['container']['plugin_id'] = array(
-      '#ajax' => array(
-        'callback' => array(get_class(), 'ajaxRebuildForm'),
+    $element['container']['plugin_id'] = [
+      '#ajax' => [
+        'callback' => [$this, 'ajaxRebuildForm'],
         'effect' => 'fade',
         'event' => 'change',
-        'trigger_as' => array(
-          'name' => $options[$element['container']['change']['#name']],
-        ),
-      ),
+        'trigger_as' => [
+          'name' => $element['container']['change']['#name'],
+        ],
+      ],
+      '#default_value' => $this->getSelectedPlugin() ? $this->getSelectedPlugin()->getPluginId() : NULL,
+      //'#options' => $options,
+      '#required' => $this->isRequired(),
+      '#title' => $this->getLabel(),
+      '#description' => $this->getDescription(),
+      '#type' => 'textfield',
+      //'#autocomplete_route_name' => 'openy_group_schedules.autocomplete',
+      //'#autocomplete_route_parameters' => [],
+    ];
+    $element['container']['plugin_name'] = [
+      '#ajax' => [
+        'callback' => [$this, 'ajaxChangeHiddenFields'],
+        'effect' => 'fade',
+        'event' => 'change',
+        /*'trigger_as' => [
+          'name' => $element['container']['plugin_id']['#name'],
+        ],*/
+      ],
       '#default_value' => $this->getSelectedPlugin() ? $options[$this->getSelectedPlugin()->getPluginId()] : NULL,
-      '#options' => $options,
+      //'#options' => $options,
       '#required' => $this->isRequired(),
       '#title' => $this->getLabel(),
       '#description' => $this->getDescription(),
       '#type' => 'textfield',
       '#autocomplete_route_name' => 'openy_group_schedules.autocomplete',
-      #'#autocomplete_route_parameters' => array('field_name' => $this->getSelectedPlugin()->getPluginId()),
-    );
+      '#autocomplete_route_parameters' => [],
+    ];
 
     return $element;
+  }
+
+  /**
+   * Implements form AJAX callback.
+   */
+  public function ajaxChangeHiddenFields(array &$complete_form, FormStateInterface $complete_form_state) {
+
+    $triggering_element = $complete_form_state->getTriggeringElement();
+    $triggered_value = $triggering_element['#value'];
+
+    $form_parents = array_slice($triggering_element['#array_parents'], 0, -1);
+    $form_parents[] = 'plugin_id';
+
+    $element = NestedArray::getValue($complete_form, $form_parents);
+    $element->setValue($triggered_value);
+
+    $response = new AjaxResponse();
+    $response->addCommand(new DataCommand('input[data-drupal-selector="edit-field-header-content-0-subform-field-prgf-schedules-ref-0-plugin-selector-container-select-container-plugin-id"]', 'value', $triggered_value));
+    $response->addCommand(new ChangedCommand('input[data-drupal-selector="edit-field-header-content-0-subform-field-prgf-schedules-ref-0-plugin-selector-container-select-container-plugin-id"]'));
+
+
+    $response->addCommand(new AlertCommand('input[data-drupal-selector="edit-field-header-content-0-subform-field-prgf-schedules-ref-0-plugin-selector-container-select-container-plugin-id"]'));
+    return $response;
+    //print '<pre>' . print_r($root_element, 1) . '</pre>' ;
+
+    /** @var AjaxResponse $response */
+    $response = new AjaxResponse();
+    $response->addCommand(new AlertCommand(t($triggered_value)));
+
+
+    return $response;
+  }
+
+  /**
+   * Implements form AJAX callback.
+   */
+  public static function ajaxRebuildForm(array &$complete_form, FormStateInterface $complete_form_state) {
+    $blockManager = \Drupal::service('plugin.manager.block');
+    $contextRepository = \Drupal::service('context.repository');
+
+    // Get blocks definition
+    $definitions = $blockManager->getDefinitionsForContexts($contextRepository->getAvailableContexts());
+    $options = [];
+    foreach ($definitions as $machine_name => $definition) {
+      $options[$definition['admin_label']] = $machine_name;
+    }
+
+    $triggering_element = $complete_form_state->getTriggeringElement();
+
+    $form_parents = array_slice($triggering_element['#array_parents'], 0, -3);
+    $root_element = NestedArray::getValue($complete_form, $form_parents);
+
+    $response = new AjaxResponse();
+    $response->addCommand(new ReplaceCommand(sprintf('[data-drupal-selector="%s"]', $root_element['plugin_form']['#attributes']['data-drupal-selector']), $root_element['plugin_form']));
+
+    return $response;
   }
 
   /**

--- a/modules/custom/openy_group_schedules/src/Plugin/Plugin/PluginSelector/AutocompleteList.php
+++ b/modules/custom/openy_group_schedules/src/Plugin/Plugin/PluginSelector/AutocompleteList.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Drupal\openy_group_schedules\Plugin\Plugin\PluginSelector;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\plugin\PluginDefinition\PluginLabelDefinitionInterface;
+use Drupal\plugin\PluginHierarchyTrait;
+use Drupal\plugin\Plugin\Plugin\PluginSelector\AdvancedPluginSelectorBase;
+
+/**
+ * Provides a plugin selector using a <select> element.
+ *
+ * @PluginSelector(
+ *   id = "plugin_autocomplete_list",
+ *   label = @Translation("Autocomplete selection list")
+ * )
+ */
+class AutocompleteList extends AdvancedPluginSelectorBase {
+
+  use PluginHierarchyTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function buildSelector(array $root_element, FormStateInterface $form_state, array $plugins) {
+    $element = parent::buildSelector($root_element, $form_state, $plugins);
+
+    /** @var \Drupal\Component\Plugin\PluginInspectionInterface[] $plugins */
+
+    $options = $this->buildOptionsLevel($this->buildPluginHierarchy($this->selectablePluginDiscovery));
+
+    $element['container']['plugin_id'] = array(
+      '#ajax' => array(
+        'callback' => array(get_class(), 'ajaxRebuildForm'),
+        'effect' => 'fade',
+        'event' => 'change',
+        'trigger_as' => array(
+          'name' => $options[$element['container']['change']['#name']],
+        ),
+      ),
+      '#default_value' => $this->getSelectedPlugin() ? $options[$this->getSelectedPlugin()->getPluginId()] : NULL,
+      '#options' => $options,
+      '#required' => $this->isRequired(),
+      '#title' => $this->getLabel(),
+      '#description' => $this->getDescription(),
+      '#type' => 'textfield',
+      '#autocomplete_route_name' => 'openy_group_schedules.autocomplete',
+      #'#autocomplete_route_parameters' => array('field_name' => $this->getSelectedPlugin()->getPluginId()),
+    );
+
+    return $element;
+  }
+
+  /**
+   * Helper function for self::options().
+   *
+   * @param array $hierarchy
+   *   A plugin ID hierarchy as returned by self::hierarchy().
+   * @param integer $depth
+   *   The depth of $hierarchy's top-level items as seen from the original
+   *   hierarchy's root (this function is recursive), starting with 0.
+   *
+   * @return string[]
+   *   Keys are plugin IDs.
+   */
+  protected function buildOptionsLevel(array $hierarchy, $depth = 0) {
+    $plugin_definitions = $this->selectablePluginDiscovery->getDefinitions();
+    $options = [];
+    $prefix = $depth ? str_repeat('-', $depth) . ' ' : '';
+    foreach ($hierarchy as $plugin_id => $child_plugin_ids) {
+      $plugin_definition = $plugin_definitions[$plugin_id];
+      $label = $plugin_definition instanceof PluginLabelDefinitionInterface ? $plugin_definition->getLabel() : $plugin_definition->getId();
+      $options[$plugin_id] = $prefix . $label;
+      $options += $this->buildOptionsLevel($child_plugin_ids, $depth + 1);
+    }
+
+    return $options;
+  }
+}

--- a/modules/custom/openy_group_schedules/src/Plugin/Plugin/PluginSelector/AutocompleteList.php
+++ b/modules/custom/openy_group_schedules/src/Plugin/Plugin/PluginSelector/AutocompleteList.php
@@ -30,14 +30,6 @@ class AutocompleteList extends AdvancedPluginSelectorBase {
    */
   protected function buildSelector(array $root_element, FormStateInterface $form_state, array $plugins) {
     $element = parent::buildSelector($root_element, $form_state, $plugins);
-    // $element['container']['plugin_id'] = [
-    //   '#default_value' => $this->getSelectedPlugin() ? $this->getSelectedPlugin()->getPluginId() : NULL,
-    //   '#value' => $this->getSelectedPlugin() ? $this->getSelectedPlugin()->getPluginId() : NULL,
-    //   '#required' => $this->isRequired(),
-    //   '#title' => $this->getLabel(),
-    //   '#description' => $this->getDescription(),
-    //   '#type' => 'textfield',
-    // ];
     $element['container']['plugin_id'] = [
       '#ajax' => [
         'callback' => [$this, 'ajaxRebuildForm'],
@@ -61,19 +53,6 @@ class AutocompleteList extends AdvancedPluginSelectorBase {
 
     return $element;
   }
-
-  /**
-   * Implements form AJAX callback.
-   */
-  // public static function ajaxRebuildForm(array &$complete_form, FormStateInterface $complete_form_state) {
-  //   $response = parent::ajaxRebuildForm($complete_form, $complete_form_state);
-  //   $triggering_element = $complete_form_state->getTriggeringElement();
-  //   $form_parents = array_slice($triggering_element['#array_parents'], 0, -1);
-  //   $root_element = NestedArray::getValue($complete_form, $form_parents);
-  //   $response->addCommand(new ReplaceCommand(sprintf('[data-drupal-selector="%s"]', $root_element['#attributes']['data-drupal-selector']), $root_element));
-
-  //   return $response;
-  // }
 
   /**
    * Helper function for self::options().

--- a/modules/custom/openy_group_schedules/src/Plugin/Plugin/PluginSelector/AutocompleteList.php
+++ b/modules/custom/openy_group_schedules/src/Plugin/Plugin/PluginSelector/AutocompleteList.php
@@ -12,6 +12,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\plugin\PluginDefinition\PluginLabelDefinitionInterface;
 use Drupal\plugin\PluginHierarchyTrait;
 use Drupal\plugin\Plugin\Plugin\PluginSelector\AdvancedPluginSelectorBase;
+use Drupal\Component\Utility\Html;
 
 /**
  * Provides a plugin selector using a <autocomplete> element.
@@ -40,9 +41,10 @@ class AutocompleteList extends AdvancedPluginSelectorBase {
             $root_element['#parents'], ['select', 'plugin_id'],
           ],
         ],
-        '#submit' => [[get_class(), 'rebuildForm']],
+        '#submit' => [[$this, 'rebuildForm']],
       ],
       '#default_value' => $this->getSelectedPlugin() ? $this->getSelectedPlugin()->getPluginDefinition()['admin_label'] . ' (' . $this->getSelectedPlugin()->getPluginId() . ')' : NULL,
+      // '#default_value' => $this->getSelectedPlugin() ? $this->getSelectedPlugin()->getPluginId() : NULL,
       '#required' => $this->isRequired(),
       '#title' => $this->getLabel(),
       '#description' => $this->getDescription(),
@@ -55,67 +57,30 @@ class AutocompleteList extends AdvancedPluginSelectorBase {
   }
 
   /**
-   * Helper function for self::options().
-   *
-   * @param array $hierarchy
-   *   A plugin ID hierarchy as returned by self::hierarchy().
-   * @param integer $depth
-   *   The depth of $hierarchy's top-level items as seen from the original
-   *   hierarchy's root (this function is recursive), starting with 0.
-   *
-   * @return string[]
-   *   Keys are plugin IDs.
+   * {@inheritdoc}
    */
-  protected function buildOptionsLevel(array $hierarchy, $depth = 0) {
-    $plugin_definitions = $this->selectablePluginDiscovery->getDefinitions();
-    $options = [];
-    $prefix = $depth ? str_repeat('-', $depth) . ' ' : '';
-    foreach ($hierarchy as $plugin_id => $child_plugin_ids) {
-      $plugin_definition = $plugin_definitions[$plugin_id];
-      $label = $plugin_definition instanceof PluginLabelDefinitionInterface ? $plugin_definition->getLabel() : $plugin_definition->getId();
-      $options[$plugin_id] = $prefix . $label;
-      $options += $this->buildOptionsLevel($child_plugin_ids, $depth + 1);
-    }
-
-    return $options;
+  public function validateSelectorForm(array &$plugin_selector_form, FormStateInterface $plugin_selector_form_state) {
+    $this->setPluginId($plugin_selector_form_state);
+    parent::validateSelectorForm($plugin_selector_form, $plugin_selector_form_state);
   }
 
   /**
    * {@inheritdoc}
    */
-  public function validateSelectorForm(array &$plugin_selector_form, FormStateInterface $plugin_selector_form_state) {
+  public function submitSelectorForm(array &$plugin_selector_form, FormStateInterface $plugin_selector_form_state) {
+    $this->setPluginId($plugin_selector_form_state);
+    parent::submitSelectorForm($plugin_selector_form, $plugin_selector_form_state);
+  }
+
+  public function setPluginId(FormStateInterface &$plugin_selector_form_state) {
     $this->assertSubformState($plugin_selector_form_state);
     $plugin_id = $plugin_selector_form_state
       ->getValue(['container', 'select', 'container', 'plugin_id']);
     $match = preg_match('/\s\(([a-zA-Z0-9\:\-\_]+)\)$/', $plugin_id, $matches);
     if ($match && isset($matches[1])) {
       $plugin_id = $matches[1];
-    }
-    $selected_plugin = $this->getSelectedPlugin();
-    if (!$selected_plugin && $plugin_id || $selected_plugin && $plugin_id != $selected_plugin->getPluginId()) {
-      // Keep track of all previously selected plugins so their configuration
-      // does not get lost.
-      if (isset($this->getPreviouslySelectedPlugins()[$plugin_id])) {
-        $this->setSelectedPlugin($this->getPreviouslySelectedPlugins()[$plugin_id]);
-      }
-      elseif ($plugin_id) {
-        $this->setSelectedPlugin($this->selectablePluginFactory->createInstance($plugin_id));
-      }
-      else {
-        $this->resetSelectedPlugin();
-      }
-
-      // If a (different) plugin was chosen and its form must be displayed,
-      // rebuild the form.
-      if ($this->getCollectPluginConfiguration() && $this->getSelectedPlugin() instanceof PluginFormInterface) {
-        $plugin_selector_form_state->setRebuild();
-      }
-    }
-    // If no (different) plugin was chosen, delegate validation to the plugin.
-    elseif ($this->getCollectPluginConfiguration() && $selected_plugin instanceof PluginFormInterface) {
-      $selected_plugin_form = &$plugin_selector_form['container']['plugin_form'];
-      $selected_plugin_form_state = SubformState::createForSubform($selected_plugin_form, $plugin_selector_form, $plugin_selector_form_state);
-      $selected_plugin->validateConfigurationForm($selected_plugin_form, $selected_plugin_form_state);
+      $plugin_selector_form_state
+        ->setValue(['container', 'select', 'container', 'plugin_id'], $plugin_id);
     }
   }
 

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_group_schedules/config/install/core.entity_form_display.paragraph.group_schedules.default.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_group_schedules/config/install/core.entity_form_display.paragraph.group_schedules.default.yml
@@ -12,7 +12,7 @@ bundle: group_schedules
 mode: default
 content:
   field_prgf_schedules_ref:
-    type: 'plugin_selector:plugin_select_list'
+    type: 'plugin_selector:plugin_autocomplete_list'
     weight: 0
     settings: {  }
     third_party_settings: {  }

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_group_schedules/openy_prgf_group_schedules.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_group_schedules/openy_prgf_group_schedules.install
@@ -17,3 +17,15 @@ function openy_prgf_group_schedules_install() {
     }
   }
 }
+
+/**
+ * Update group schedule field display form from select to autocomplete.
+ */
+function openy_prgf_group_schedules_update_8001() {
+  $view_display = \Drupal::entityTypeManager()
+    ->getStorage('entity_form_display')
+    ->load('paragraph.group_schedules.default');
+  $settings = $view_display->getComponent('field_prgf_schedules_ref');
+  $settings['type'] = 'plugin_selector:plugin_autocomplete_list';
+  $view_display->setComponent('field_prgf_schedules_ref', $settings)->save();
+}


### PR DESCRIPTION
Provide ability to change widget to autocomplete for Schedules Block.

## Steps for review

- Install/update from profile 
- Login to system 
- visit /admin/structure/paragraphs_type/group_schedules/form-display
  Schedules Block widget should be set to Autocomplete selection list
- Edit home page 
- add Group Schedules (GroupEx Pro) paragraph  to CONTENT AREA Content field
  Autocomplete selection should be used as select plugin 

