### PR TITLE
[OPENY-12] Code block and Code block paragraph components decoupling

### DIFF
--- a/modules/openy_features/openy_block/modules/openy_block_date/openy_block_date.info.yml
+++ b/modules/openy_features/openy_block/modules/openy_block_date/openy_block_date.info.yml
@@ -1,5 +1,6 @@
 name: 'OpenY Date Block'
 description: 'Implements OpenY Date Block.'
+package: OpenY
 type: module
 core: 8.x
 dependencies:

--- a/modules/openy_features/openy_block/modules/openy_code_block/openy_code_block.info.yml
+++ b/modules/openy_features/openy_block/modules/openy_code_block/openy_code_block.info.yml
@@ -1,5 +1,6 @@
 name: 'OpenY Code Block'
 description: 'OpenY Code Block'
+package: OpenY
 type: module
 core: 8.x
 dependencies:

--- a/modules/openy_features/openy_block/modules/openy_code_block/openy_code_block.install
+++ b/modules/openy_features/openy_block/modules/openy_code_block/openy_code_block.install
@@ -6,6 +6,32 @@
  */
 
 /**
+ * Implements hook_install().
+ */
+function openy_code_block_install() {
+  if (\Drupal::service('module_handler')->moduleExists('openy_prgf_secondary_description_sidebar')) {
+    // Add code_block to secondary_description_sidebar target bundles.
+    $config_factory = \Drupal::configFactory();
+    $configs_to_update = [
+      'field.field.paragraph.secondary_description_sidebar.field_prgf_left_column_block',
+      'field.field.paragraph.secondary_description_sidebar.field_prgf_right_column_block',
+    ];
+    foreach ($configs_to_update as $config_name) {
+      $config = $config_factory->getEditable($config_name);
+      $dependencies = $config->get('dependencies.config');
+      if (!in_array('block_content.type.code_block', $dependencies)) {
+        $dependencies[] = 'block_content.type.code_block';
+        $config->set('dependencies.config', $dependencies);
+        $target_bundles = $config->get('settings.handler_settings.target_bundles');
+        $target_bundles['code_block'] = 'code_block';
+        $config->set('settings.handler_settings.target_bundles', $target_bundles);
+        $config->save(TRUE);
+      }
+    }
+  }
+}
+
+/**
  * Implements hook_uninstall().
  */
 function openy_code_block_uninstall() {

--- a/modules/openy_features/openy_block/modules/openy_code_block/openy_code_block.install
+++ b/modules/openy_features/openy_block/modules/openy_code_block/openy_code_block.install
@@ -6,6 +6,15 @@
  */
 
 /**
+ * Implements hook_uninstall().
+ */
+function openy_code_block_uninstall() {
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('block_content', 'block_content_type', 'code_block');
+  Drupal::configFactory()->getEditable('filter.format.code')->delete();
+}
+
+/**
  * Update configs for Drupal Core upgrade.
  */
 function openy_code_block_update_8001() {

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_block_date/openy_prgf_block_date.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_block_date/openy_prgf_block_date.info.yml
@@ -1,5 +1,6 @@
 name: 'OpenY Paragraph for Date Block'
 description: 'OpenY Paragraph shows content based on date and time (before, between, after).'
+package: OpenY
 type: module
 core: 8.x
 dependencies:

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_code_block/openy_prgf_code_block.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_code_block/openy_prgf_code_block.info.yml
@@ -1,5 +1,6 @@
 name: 'OpenY paragraph code block'
 description: 'Code block paragraph'
+package: OpenY
 type: module
 core: 8.x
 dependencies:

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_code_block/openy_prgf_code_block.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_code_block/openy_prgf_code_block.install
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @file
+ * Installation file for OpenY prgf_code_block module.
+ */
+
+/**
+ * Implements hook_uninstall().
+ */
+function openy_prgf_code_block_uninstall() {
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('paragraph', 'paragraphs_type', 'code');
+}

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_location_by_amenities/openy_prgf_location_by_amenities.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_location_by_amenities/openy_prgf_location_by_amenities.info.yml
@@ -1,4 +1,5 @@
 name: 'OpenY Paragraph Location By Amenities'
+package: OpenY
 type: module
 core: 8.x
 dependencies:

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_lto/openy_prgf_lto.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_lto/openy_prgf_lto.info.yml
@@ -1,5 +1,6 @@
 name: 'OpenY Paragraph Limited Time Offer'
 description: 'Limited Time Offer Paragraph for Home Page based on Landing Page CT.'
+package: OpenY
 type: module
 core: 8.x
 dependencies:

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_secondary_description_sidebar/openy_prgf_secondary_description_sidebar.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_secondary_description_sidebar/openy_prgf_secondary_description_sidebar.info.yml
@@ -9,6 +9,5 @@ dependencies:
   - openy_block_basic
   - openy_block_custom_simple
   - openy_block_date
-  - openy_code_block
   - paragraphs
   - text

--- a/modules/openy_features/openy_taxonomy/modules/openy_txnm_amenities/openy_txnm_amenities.info.yml
+++ b/modules/openy_features/openy_taxonomy/modules/openy_txnm_amenities/openy_txnm_amenities.info.yml
@@ -1,5 +1,6 @@
 name: 'OpenY Taxonomy Amenities'
 description: 'OpenY Taxonomy Amenities.'
+package: OpenY
 type: module
 core: 8.x
 dependencies:

--- a/openy.services.yml
+++ b/openy.services.yml
@@ -5,3 +5,6 @@ services:
     class: Drupal\openy\Routing\RouteSubscriber
     tags:
       - { name: event_subscriber }
+  openy.modules_manager:
+    class: Drupal\openy\OpenyModulesManager
+    arguments: ['@entity_type.manager']

--- a/src/OpenyModulesManager.php
+++ b/src/OpenyModulesManager.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Drupal\openy;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+
+/**
+ * Openy modules manager.
+ */
+class OpenyModulesManager {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs a OpenyModulesManager object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * Remove Entity bundle.
+   *
+   * This is helper function for modules uninstall with correct bundle
+   * deleting and content cleanup.
+   *
+   * @param string $content_entity_type
+   *   Content entity type (node, block_content, paragraph, etc.)
+   * @param string $config_entity_type
+   *   Config entity type (node_type, block_content_type, paragraphs_type, etc.)
+   * @param string $bundle
+   *   Entity bundle machine name.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function removeEntityBundle($content_entity_type, $config_entity_type, $bundle) {
+    // Remove existing data of content entity.
+    $query = $this->entityTypeManager
+      ->getStorage($content_entity_type)
+      ->getQuery('AND')
+      ->condition('type', $bundle);
+
+    $ids = $query->execute();
+    $storage_handler = $this->entityTypeManager->getStorage($content_entity_type);
+    $entities = $storage_handler->loadMultiple($ids);
+    $storage_handler->delete($entities);
+
+    // Remove bundle.
+    $config_entity_type_bundle = $this->entityTypeManager
+      ->getStorage($config_entity_type)
+      ->load($bundle);
+    if ($config_entity_type_bundle) {
+      $config_entity_type_bundle->delete();
+    }
+  }
+
+}

--- a/themes/openy_themes/openy_lily/openy_lily.theme
+++ b/themes/openy_themes/openy_lily/openy_lily.theme
@@ -538,7 +538,7 @@ function openy_lily_preprocess_html(&$variables) {
           ->load($p['target_id'])
         ) {
           // Take action for microsites_menu paragraph.
-          if ($paragraph->bundle() == 'microsites_menu') {
+          if ($paragraph && $paragraph->bundle() == 'microsites_menu') {
             // Add class to the body.
             $variables['attributes']['class'][] = 'microsites-menu';
             if ($paragraph->field_prgf_ms_menu_hide_menu->value) {

--- a/themes/openy_themes/openy_rose/openy_rose.theme
+++ b/themes/openy_themes/openy_rose/openy_rose.theme
@@ -375,7 +375,7 @@ function openy_rose_preprocess_html(&$variables) {
           ->load($p['target_id']);
 
         // Take action for microsites_menu paragraph.
-        if ($paragraph->bundle() == 'microsites_menu') {
+        if ($paragraph && $paragraph->bundle() == 'microsites_menu') {
           // Add class to the body.
           $variables['attributes']['class'][] = 'microsites-menu';
           if ($paragraph->field_prgf_ms_menu_hide_menu->value) {


### PR DESCRIPTION
Make sure these boxes are checked before asking for review of your pull request - thank you!

## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/ci-errors.png" width="200" alt="CI code sniffer errors">
- [ ] All tests are running and there are no failed tests reported by CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/behat.png" width="200" alt="Behat test results">
- [x] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [x] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [x] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [x] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [x] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!

## Steps for review

- [x] Login as admin
- [x] Go to /node/add/landing_page
- [x] Create landing_page with "OpenY paragraph code block" (use "Add code in paragraphs")
- [x] go to /admin/structure/block/block-content
- [x] check that you can see here created code block
- [x] go to /admin/modules/uninstall
- [x] uninstall "OpenY paragraph code block"
- [x] uninstall "OpenY Code Block" 
- [x] return to created landing_page, check that page works fine and not contain code block content (try to edit this page, all must be fine)
- [x] go to /admin/structure/block/block-content/types
- [x] check that "Code Block" not exist here
- [x] go to /admin/structure/block/block-content
- [x] check that you can't see here created code block
- [x] go to /admin/config/content/formats
- [x] check that "Code" text format not exist here
- [x] go to /admin/modules
- [x] enable "OpenY Code Block"  and "OpenY paragraph code block"
- [x] check that after modules enabling all functional, related to this modules works fine
- [x] check "Secondary Description and Sidebar" - after modules install it must contain "Code Block" in select list