### PR TITLE
[OPENY-13] Secondary Description and Sidebar component decoupling.

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_secondary_description_sidebar/openy_prgf_secondary_description_sidebar.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_secondary_description_sidebar/openy_prgf_secondary_description_sidebar.info.yml
@@ -3,6 +3,7 @@ description: 'OpenY Paragraph Secondary Description and Sidebar.'
 type: module
 core: 8.x
 package: OpenY
+version: '8.x-1.0'
 dependencies:
   - datalayer
   - field

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_secondary_description_sidebar/openy_prgf_secondary_description_sidebar.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_secondary_description_sidebar/openy_prgf_secondary_description_sidebar.install
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @file
+ * Installation file for OpenY "secondary description sidebar" module.
+ */
+
+/**
+ * Implements hook_uninstall().
+ */
+function openy_prgf_secondary_description_sidebar_uninstall() {
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('paragraph', 'paragraphs_type', 'secondary_description_sidebar');
+}


### PR DESCRIPTION
Make sure these boxes are checked before asking for review of your pull request - thank you!

## General checks
- [x] All coding styles are fulfilled and there are no any issues reported by CodeSniffer CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/ci-errors.png" width="200" alt="CI code sniffer errors">
- [ ] All tests are running and there are no failed tests reported by CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/behat.png" width="200" alt="Behat test results">
- [x] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [x] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [x] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [x] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [x] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!

## Steps for review

- [x] Login as admin
- [x] Go to /node/add/landing_page
- [x] Create landing_page with "Secondary Description and Sidebar" (use "Add Secondary Description and Sidebar in paragraphs")
- [x] go to /admin/modules/uninstall
- [x] uninstall "OpenY Paragraph Secondary Description and Sidebar"
- [x] return to created landing_page, check that page works fine and not contain "Secondary Description and Sidebar" content (try to edit this page, all must be fine)
- [x] go to /admin/modules
- [x] enable "OpenY Paragraph Secondary Description and Sidebar"
- [x] check that after modules enabling all functional, related to this modules works fine
