### PR TITLE
[OPENY-17] Banner - component decoupling

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_banner/openy_prgf_banner.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_banner/openy_prgf_banner.info.yml
@@ -3,6 +3,7 @@ description: 'OpenY Paragraph Banner.'
 type: module
 core: 8.x
 package: OpenY
+version: '8.x-1.0'
 dependencies:
   - blazy
   - datalayer

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_banner/openy_prgf_banner.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_banner/openy_prgf_banner.install
@@ -6,6 +6,26 @@
  */
 
 /**
+ * Implements hook_uninstall().
+ */
+function openy_prgf_banner_uninstall() {
+  // Remove banner content and paragraph type.
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('paragraph', 'paragraphs_type', 'banner');
+
+  // Remove other module configs.
+  $config_factory = \Drupal::configFactory();
+  $configs_to_delete = [
+    'image.style.prgf_banner',
+    'core.entity_view_display.media.image.prgf_banner',
+    'core.entity_view_mode.media.prgf_banner',
+  ];
+  foreach ($configs_to_delete as $config) {
+    $config_factory->getEditable($config)->delete();
+  }
+}
+
+/**
  * Implements hook_update_dependencies().
  */
 function openy_prgf_banner_update_dependencies() {


### PR DESCRIPTION
## Steps for review

- [x] Login as admin
- [x] Go to /node/add/landing_page
- [x] Create landing_page with "Banner" (use "Add Banner in paragraphs")
- [x] go to /admin/modules/uninstall
- [x] uninstall "OpenY Paragraph Banner"
- [x] return to created landing_page, check that page works fine and not contain "Banner" content (try to edit this page, all must be fine)
- [x] go to /admin/config/media/image-styles
- [x] check that "Paragraph banner" not exist in this list
- [x] go to /admin/structure/display-modes/view
- [x] check that "Paragraph banner" not exist in Media section
- [x] go to /admin/modules
- [x] enable "OpenY Paragraph Banner"
- [x] check that after modules enabling all functional, related to this modules restored and works fine