### PR TITLE
[OPENY-23] Promo Card component decoupling

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_promo_card/openy_prgf_promo_card.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_promo_card/openy_prgf_promo_card.info.yml
@@ -3,6 +3,7 @@ description: 'OpenY Paragraph Promo Card.'
 type: module
 core: 8.x
 package: OpenY
+version: '8.x-1.0'
 dependencies:
   - field
   - link

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_promo_card/openy_prgf_promo_card.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_promo_card/openy_prgf_promo_card.install
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @file
+ * OpenY Paragraph Promo card install file.
+ */
+
+/**
+ * Implements hook_uninstall().
+ */
+function openy_prgf_promo_card_uninstall() {
+  // Remove Promo card content and paragraph type.
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('paragraph', 'paragraphs_type', 'promo_card');
+}


### PR DESCRIPTION
## Steps for review

- [x] Login as admin
- [x] Go to /node/add/blog
- [x] Create blog post with "Promo Card" in sidebar
- [x] go to /admin/modules/uninstall
- [x] uninstall "OpenY Paragraph Promo Card"
- [x] return to created blog post, check that page works fine and not contain "Promo Card" content in sidebar (try to edit this page, all must be fine)
- [x] go to /admin/modules
- [x] enable "OpenY Paragraph Promo Card"
- [x] check that after module enabling all functional, related to this module restored and works fine
