### PR TITLE
[OPENY-25] OpenY Paragraph Teaser component decoupling

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_gallery/openy_prgf_gallery.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_gallery/openy_prgf_gallery.install
@@ -17,7 +17,7 @@ function openy_prgf_gallery_uninstall() {
   $config_factory = \Drupal::configFactory();
   $configs_to_delete = [
     'image.style.prgf_gallery',
-    'core.entity_view_display.media.image.prgf_gallery.yml',
+    'core.entity_view_display.media.image.prgf_gallery',
     'core.entity_view_mode.media.prgf_gallery',
   ];
   foreach ($configs_to_delete as $config) {

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_teaser/openy_prgf_teaser.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_teaser/openy_prgf_teaser.info.yml
@@ -3,6 +3,7 @@ description: 'OpenY Paragraph Teaser.'
 type: module
 core: 8.x
 package: OpenY
+version: '8.x-1.0'
 dependencies:
   - blazy
   - entity_browser

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_teaser/openy_prgf_teaser.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_teaser/openy_prgf_teaser.install
@@ -6,6 +6,26 @@
  */
 
 /**
+ * Implements hook_uninstall().
+ */
+function openy_prgf_teaser_uninstall() {
+  // Remove teaser content and paragraph type.
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('paragraph', 'paragraphs_type', 'teaser');
+
+  // Remove other module configs.
+  $config_factory = \Drupal::configFactory();
+  $configs_to_delete = [
+    'image.style.prgf_teaser',
+    'core.entity_view_display.media.image.prgf_teaser',
+    'core.entity_view_mode.media.prgf_teaser',
+  ];
+  foreach ($configs_to_delete as $config) {
+    $config_factory->getEditable($config)->delete();
+  }
+}
+
+/**
  * Implements hook_update_dependencies().
  */
 function openy_prgf_teaser_dependencies() {


### PR DESCRIPTION
## Steps for review

- [x] Login as admin
- [x] Go to /node/add/blog
- [x] Create blog post with "Teaser" in content area
- [x] go to /admin/modules/uninstall
- [x] uninstall "OpenY Paragraph Teaser"
- [x] return to created blog post, check that page works fine and not contain "Teaser" content (try to edit this page, all must be fine)
- [x] go to /admin/modules
- [x] enable "OpenY Paragraph Teaser"
- [x] check that after module enabling all functional, related to this module restored and works fine
