### PR TITLE
[OPENY-52] [OPENY-19] Alert and Landing page - content types decoupling

### DIFF
--- a/modules/openy_features/openy_node/modules/openy_node_alert/openy_node_alert.info.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_alert/openy_node_alert.info.yml
@@ -3,6 +3,7 @@ description: 'OpenY Node Alert.'
 type: module
 core: 8.x
 package: OpenY
+version: 8.x-1.0
 dependencies:
   - block
   - field
@@ -10,17 +11,6 @@ dependencies:
   - link
   - menu_ui
   - node
-  - openy_loc_branch
-  - openy_loc_camp
-  - openy_loc_facility
-  - openy_node_activity
-  - openy_node_blog
-  - openy_node_category
-  - openy_node_class
-  - openy_node_landing
-  - openy_node_mbrshp
-  - openy_node_program
-  - openy_node_session
   - openy_txnm_color
   - options
   - path

--- a/modules/openy_features/openy_node/modules/openy_node_alert/openy_node_alert.install
+++ b/modules/openy_features/openy_node/modules/openy_node_alert/openy_node_alert.install
@@ -6,11 +6,33 @@
  */
 
 /**
+ * Implements hook_uninstall().
+ */
+function openy_node_alert_uninstall() {
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('node', 'node_type', 'alert');
+  $config_factory = Drupal::configFactory();
+  $configs_to_delete = [
+    'block.block.views_block__alerts_footer_alerts',
+    'block.block.views_block__alerts_footer_alerts_local',
+    'block.block.views_block__alerts_header_alerts',
+    'block.block.views_block__alerts_header_alerts_local',
+    'pathauto.pattern.alert',
+    'rabbit_hole.behavior_settings.node_type_alert',
+    'views.view.alert_belongs_reference',
+    'views.view.alerts',
+  ];
+  foreach ($configs_to_delete as $config) {
+    $config_factory->getEditable($config)->delete();
+  }
+}
+
+/**
  * Update Alert for rabbit hole, hiding pages from anonymous users.
  */
 function openy_node_alert_update_8001() {
   $config_dir = drupal_get_path('module', 'openy_node_alert') . '/config/install/';
-  // Import new configuration
+  // Import new configuration.
   $config_importer = \Drupal::service('openy_upgrade_tool.importer');
   $config_importer->setDirectory($config_dir);
   $config_importer->importConfigs([
@@ -52,7 +74,7 @@ function openy_node_alert_update_8003() {
   $config_dir = drupal_get_path('module', 'openy_node_alert') . '/config/install/';
   // Update multiple configurations.
   $configs = [
-    'field.field.node.alert.field_alert_color' =>[
+    'field.field.node.alert.field_alert_color' => [
       'description',
     ],
     'field.field.node.alert.field_alert_description' => [

--- a/modules/openy_features/openy_node/modules/openy_node_landing/openy_node_landing.info.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_landing/openy_node_landing.info.yml
@@ -3,6 +3,7 @@ description: 'OpenY Landing.'
 type: module
 core: 8.x
 package: OpenY
+version: 8.x-1.0
 dependencies:
   - entity_reference_revisions
   - field

--- a/modules/openy_features/openy_node/modules/openy_node_landing/openy_node_landing.install
+++ b/modules/openy_features/openy_node/modules/openy_node_landing/openy_node_landing.install
@@ -18,10 +18,26 @@ function openy_node_landing_update_dependencies() {
     ],
     8003 => [
       'openy' => 8015,
-    ]
+    ],
   ];
 
   return $dependencies;
+}
+
+/**
+ * Implements hook_uninstall().
+ */
+function openy_node_landing_uninstall() {
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('node', 'node_type', 'landing_page');
+  $config_factory = Drupal::configFactory();
+  $configs_to_delete = [
+    'pathauto.pattern.landing_page',
+    'simple_sitemap.bundle_settings.node.landing_page',
+  ];
+  foreach ($configs_to_delete as $config) {
+    $config_factory->getEditable($config)->delete();
+  }
 }
 
 /**
@@ -29,7 +45,7 @@ function openy_node_landing_update_dependencies() {
  */
 function openy_node_landing_update_8001() {
   $config_dir = drupal_get_path('module', 'openy_node_landing') . '/config/install/';
-  // Import new configuration
+  // Import new configuration.
   $config_importer = \Drupal::service('openy_upgrade_tool.importer');
   $config_importer->setDirectory($config_dir);
   $config_importer->importConfigs([
@@ -38,7 +54,7 @@ function openy_node_landing_update_8001() {
 
   // Update multiple configurations.
   $configs = [
-    'core.entity_form_display.node.landing_page.default' =>[
+    'core.entity_form_display.node.landing_page.default' => [
       'dependencies.config',
       'third_party_settings.field_group.group_bottom_area',
       'content.field_bottom_content',
@@ -73,7 +89,7 @@ function openy_node_landing_update_8001() {
 function openy_node_landing_update_8002() {
   $module = 'openy_node_landing';
   $bundle = 'landing_page';
-  // Field definitions
+  // Field definitions.
   $config_dir = drupal_get_path('module', $module) . '/config/install';
   $config_importer = \Drupal::service('openy_upgrade_tool.importer');
   $config_importer->setDirectory($config_dir);
@@ -81,17 +97,17 @@ function openy_node_landing_update_8002() {
     'field.field.node.' . $bundle . '.field_meta_tags',
     'simple_sitemap.bundle_settings.' . $bundle . '.landing_page',
   ]);
-  // Dependencies
+  // Dependencies.
   $config = drupal_get_path('module', $module) . $module . '.info.yml';
   $config_importer = \Drupal::service('openy_upgrade_tool.param_updater');
   $config_importer->update($config, $module . '.info', 'dependencies');
-  // Entity form
+  // Entity form.
   $config = drupal_get_path('module', $module) . '/config/install/core.entity_form_display.node.' . $bundle . '.default.yml';
   $config_importer = \Drupal::service('openy_upgrade_tool.param_updater');
   $config_importer->update($config, 'core.entity_form_display.node.' . $bundle . '.default', 'dependencies.config');
   $config_importer->update($config, 'core.entity_form_display.node.' . $bundle . '.default', 'dependencies.module');
   $config_importer->update($config, 'core.entity_form_display.node.' . $bundle . '.default', 'content.field_meta_tags');
-  // Entity view display
+  // Entity view display.
   $config = drupal_get_path('module', $module) . '/config/install/core.entity_view_display.node.' . $bundle . '.default.yml';
   $config_importer = \Drupal::service('openy_upgrade_tool.param_updater');
   $config_importer->update($config, 'core.entity_view_display.node.' . $bundle . '.default', 'dependencies.config');
@@ -239,7 +255,7 @@ function openy_node_landing_update_8009() {
 }
 
 /**
-* Update feature configs for Drupal Core upgrade.
+ * Update feature configs for Drupal Core upgrade.
  */
 function openy_node_landing_update_8010() {
   $config_dir = drupal_get_path('module', 'openy_node_landing') . '/config/install/';


### PR DESCRIPTION
## Steps for review

- [x] login as admin
- [x] go to /admin/modules/uninstall
- [x] uninstall OpenY Demo Node Alert
- [x] uninstall OpenY Demo Node Landing Page
- [x] check that you can uninstall OpenY Node Alert and OpenY Landing, than uninstall both modules
- [x] check that alerts and landing pages was fully removed from site
- [x] go to /admin/modules
- [x] install OpenY Node Alert module
- [x] go to /node/add/alert
- [x] create test alert with visibility pages "/locations/*"
- [x] clear cache
- [x] open any location page (/locations/west-ymca for example)
- [x] check that you can see crated alert
- [x] go to /admin/modules
- [x] install OpenY Landing module
- [x] go to /node/add/landing_page
- [x] create test landing page with any content
- [x] check that all works fine