### PR TITLE
[OPENY-28] XML sitemap - component decoupling

### DIFF
--- a/modules/custom/openy_upgrade_tool/src/ConfigUpdater.php
+++ b/modules/custom/openy_upgrade_tool/src/ConfigUpdater.php
@@ -108,15 +108,7 @@ class ConfigUpdater extends ConfigImporterService {
 
       if ($this->isManuallyChanged($config)) {
         // Skip config update and log this to logger entity.
-        $this->updateLoggerEntity($file, $config);
-        $dashboard_url = Url::fromRoute('view.openy_upgrade_dashboard.page_1');
-        $dashboard_link = Link::fromTextAndUrl(t('OpenY upgrade dashboard'), $dashboard_url);
-        $this->logger->error($this->t('Could not update config @name. Please add this changes manual. More info here - @link.',
-          [
-            '@name' => $config,
-            '@link' => $dashboard_link->toString(),
-          ]
-        ));
+        $this->logConfigImportError($file, $config);
         continue;
       }
 
@@ -140,6 +132,56 @@ class ConfigUpdater extends ConfigImporterService {
     $this->filter($tmp_storage);
     // Import changed, just overwritten items, into config storage.
     $this->import($tmp_storage);
+  }
+
+  /**
+   * Simplified version of importConfigs.
+   *
+   * Main difference between this functions that in simple version we
+   * skip export of all site configs to temp directory and just copy and import
+   * only listed config for import. Also here was skiped configs filter logic.
+   *
+   * @param string $config
+   *   Config name.
+   */
+  public function importConfigSimple($config) {
+    // Stream wrappers are not available during installation.
+    $tmp_dir = (defined('MAINTENANCE_MODE') ? '/tmp' : 'temporary:/') . '/confi_simple' . $this->uuid->generate();
+    if (!$this->fileSystem->mkdir($tmp_dir)) {
+      throw new ConfigImporterException('Failed to create temporary directory: ' . $tmp_dir);
+    }
+    $tmp_storage = new FileStorage($tmp_dir);
+    $file = "$this->directory/$config.yml";
+    if ($this->isManuallyChanged($config)) {
+      // Skip config update and log this to logger entity.
+      $this->logConfigImportError($file, $config);
+    }
+    if (file_exists($file)) {
+      file_unmanaged_copy($file, $tmp_dir, FILE_EXISTS_REPLACE);
+      // Add openy_upgrade param to config.
+      file_put_contents($tmp_dir . "/$config.yml", 'openy_upgrade: true', FILE_APPEND);
+      $this->configStorage->write($config, $tmp_storage->read($config));
+    }
+  }
+
+  /**
+   * Helper function for config import error log.
+   *
+   * @param string $file
+   *   Full path to file including file name.
+   * @param string $config
+   *   Config name.
+   */
+  private function logConfigImportError($file, $config) {
+    $this->updateLoggerEntity($file, $config);
+    $dashboard_url = Url::fromRoute('view.openy_upgrade_dashboard.page_1');
+    $dashboard_link = Link::fromTextAndUrl(t('OpenY upgrade dashboard'), $dashboard_url);
+    $this->logger->error($this->t('Could not update config @name. Please add this changes manual. More info here - @link.',
+      [
+        '@name' => $config,
+        '@link' => $dashboard_link->toString(),
+      ]
+    ));
   }
 
   /**

--- a/modules/openy_features/openy_node/modules/openy_node_alert/openy_node_alert.install
+++ b/modules/openy_features/openy_node/modules/openy_node_alert/openy_node_alert.install
@@ -10,7 +10,7 @@
  */
 function openy_node_alert_update_8001() {
   $config_dir = drupal_get_path('module', 'openy_node_alert') . '/config/install/';
-  // Import new configuration
+  // Import new configuration.
   $config_importer = \Drupal::service('openy_upgrade_tool.importer');
   $config_importer->setDirectory($config_dir);
   $config_importer->importConfigs([
@@ -52,7 +52,7 @@ function openy_node_alert_update_8003() {
   $config_dir = drupal_get_path('module', 'openy_node_alert') . '/config/install/';
   // Update multiple configurations.
   $configs = [
-    'field.field.node.alert.field_alert_color' =>[
+    'field.field.node.alert.field_alert_color' => [
       'description',
     ],
     'field.field.node.alert.field_alert_description' => [
@@ -164,4 +164,14 @@ function openy_node_alert_update_8006() {
       $config_updater->update($config, $config_name, $param);
     }
   }
+
+  // Import new configuration.
+  $config_importer = \Drupal::service('openy_upgrade_tool.importer');
+  $config_importer->setDirectory($config_dir);
+  $config_importer->importConfigs([
+    'field.storage.node.field_alert_visibility_pages',
+    'field.storage.node.field_alert_visibility_state',
+    'field.field.node.alert.field_alert_visibility_pages',
+    'field.field.node.alert.field_alert_visibility_state',
+  ]);
 }

--- a/modules/openy_features/openy_node/modules/openy_node_news/config/install/simple_sitemap.bundle_settings.node.news.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_news/config/install/simple_sitemap.bundle_settings.node.news.yml
@@ -1,0 +1,2 @@
+index: 1
+priority: '0.5'

--- a/modules/openy_features/openy_node/modules/openy_node_news/openy_node_news.install
+++ b/modules/openy_features/openy_node/modules/openy_node_news/openy_node_news.install
@@ -25,3 +25,15 @@ function openy_node_news_update_8001() {
     }
   }
 }
+
+/**
+ * Add sitemap settings for news node type.
+ */
+function openy_node_news_update_8002() {
+  $config_dir = drupal_get_path('module', 'openy_node_news') . '/config/install';
+  $config_importer = \Drupal::service('openy_upgrade_tool.importer');
+  $config_importer->setDirectory($config_dir);
+  $config_importer->importConfigs([
+    'simple_sitemap.bundle_settings.node.news',
+  ]);
+}

--- a/modules/openy_features/openy_node/openy_node.module
+++ b/modules/openy_features/openy_node/openy_node.module
@@ -30,7 +30,7 @@ function openy_node_modules_installed($modules) {
       if ($module_handler->moduleExists($module)) {
         $config_dir = drupal_get_path('module', $module) . '/config/install';
         $config_importer->setDirectory($config_dir);
-        $config_importer->importConfigs([$config]);
+        $config_importer->importConfigSimple($config);
       }
     }
   }

--- a/modules/openy_features/openy_node/openy_node.module
+++ b/modules/openy_features/openy_node/openy_node.module
@@ -22,7 +22,11 @@ function openy_node_modules_installed($modules) {
       'openy_node_class' => 'simple_sitemap.bundle_settings.node.class',
       'openy_node_event' => 'simple_sitemap.bundle_settings.node.event',
       'openy_node_landing' => 'simple_sitemap.bundle_settings.node.landing_page',
+      'openy_node_news' => 'simple_sitemap.bundle_settings.node.news',
       'openy_node_program' => 'simple_sitemap.bundle_settings.node.program',
+      'openy_loc_branch' => 'simple_sitemap.bundle_settings.node.branch',
+      'openy_loc_camp' => 'simple_sitemap.bundle_settings.node.camp',
+      'openy_loc_facility' => 'simple_sitemap.bundle_settings.node.facility',
     ];
     $module_handler = \Drupal::service('module_handler');
     $config_importer = \Drupal::service('openy_upgrade_tool.importer');

--- a/modules/openy_features/openy_node/openy_node.module
+++ b/modules/openy_features/openy_node/openy_node.module
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @file
+ * OpenY Node module file.
+ */
+
+/**
+ * Implements hook_modules_installed().
+ *
+ * Perform necessary actions after modules are installed.
+ * This function differs from hook_install() in that it gives all other modules
+ * a chance to perform actions when a module is installed, whereas
+ * hook_install() is only called on the module actually being installed.
+ */
+function openy_node_modules_installed($modules) {
+  if (in_array('simple_sitemap', $modules)) {
+    // Import simple_sitemap settings for nodes bundles on module install.
+    $config_list = [
+      'openy_node_blog' => 'simple_sitemap.bundle_settings.node.blog',
+      'openy_node_category' => 'simple_sitemap.bundle_settings.node.program_subcategory',
+      'openy_node_class' => 'simple_sitemap.bundle_settings.node.class',
+      'openy_node_event' => 'simple_sitemap.bundle_settings.node.event',
+      'openy_node_landing' => 'simple_sitemap.bundle_settings.node.landing_page',
+      'openy_node_program' => 'simple_sitemap.bundle_settings.node.program',
+    ];
+    $module_handler = \Drupal::service('module_handler');
+    $config_importer = \Drupal::service('openy_upgrade_tool.importer');
+    foreach ($config_list as $module => $config) {
+      if ($module_handler->moduleExists($module)) {
+        $config_dir = drupal_get_path('module', $module) . '/config/install';
+        $config_importer->setDirectory($config_dir);
+        $config_importer->importConfigs([$config]);
+      }
+    }
+  }
+}

--- a/modules/openy_features/openy_taxonomy/modules/openy_txnm_blog_category/openy_txnm_blog_category.module
+++ b/modules/openy_features/openy_taxonomy/modules/openy_txnm_blog_category/openy_txnm_blog_category.module
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @file
+ * OpenY Taxonomy Blog Category module file.
+ */
+
+/**
+ * Implements hook_modules_installed().
+ */
+function openy_txnm_blog_category_modules_installed($modules) {
+  if (in_array('simple_sitemap', $modules)) {
+    // Import simple_sitemap settings for blog_category on module install.
+    $config_importer = \Drupal::service('openy_upgrade_tool.importer');
+    $config_dir = drupal_get_path('module', 'openy_txnm_blog_category') . '/config/install';
+    $config_importer->setDirectory($config_dir);
+    $config_importer->importConfigs(['simple_sitemap.bundle_settings.taxonomy_term.blog_category']);
+  }
+}


### PR DESCRIPTION
## Steps for review

- [x] login as admin
- [x] go to /admin/modules/uninstall
- [x] uninstall "Simple XML Sitemap" module
- [x] go to /admin/structure/types/manage/landing_page
- [x] check that sitemap settings were removed
- [x] go to /admin/modules
- [x] install "Simple XML Sitemap" module
- [x] go to /admin/structure/types/manage/landing_page
- [x] check that sitemap configs was restored
- [x] check other node types with sitemap support (blog, category, class, event, program)
- [x] go to /admin/structure/taxonomy/manage/blog_category
- [x] check that sitemap configs was restored
- [x] you can also check "/admin/config/search/simplesitemap" (anyway openy used default simple sitemap settings)
