### PR TITLE
[OPENY-38] Amenities paragraphs decoupling

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_amenities/openy_prgf_amenities.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_amenities/openy_prgf_amenities.install
@@ -6,6 +6,20 @@
  */
 
 /**
+ * Implements hook_uninstall().
+ */
+function openy_prgf_amenities_uninstall() {
+  // Remove all_amenities content and paragraph type.
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('paragraph', 'paragraphs_type', 'all_amenities');
+
+  // Remove other module configs.
+  \Drupal::configFactory()
+    ->getEditable('views.view.branches')
+    ->delete();
+}
+
+/**
  * Update All amenities view.
  */
 function openy_prgf_amenities_update_8001() {

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_location_by_amenities/openy_prgf_location_by_amenities.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_location_by_amenities/openy_prgf_location_by_amenities.info.yml
@@ -2,6 +2,7 @@ name: 'OpenY Paragraph Location By Amenities'
 package: OpenY
 type: module
 core: 8.x
+version: 8.x-1.0
 dependencies:
   - content_moderation
   - datalayer

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_location_by_amenities/openy_prgf_location_by_amenities.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_location_by_amenities/openy_prgf_location_by_amenities.install
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @file
+ * Install, update/uninstall functions for the openy_prgf_location_by_amenities.
+ */
+
+/**
+ * Implements hook_uninstall().
+ */
+function openy_prgf_location_by_amenities_uninstall() {
+  // Remove location_filter_by_amenities content and paragraph type.
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('paragraph', 'paragraphs_type', 'location_filter_by_amenities');
+
+  // Remove other module configs.
+  \Drupal::configFactory()
+    ->getEditable('views.view.location_by_amenities')
+    ->delete();
+}


### PR DESCRIPTION
## Steps for review

- [x] login as admin
- [x] go to "/locations"
- [x] check that you can see location filter by amenities
- [x] go to "/admin/modules/uninstall"
- [x] uninstall "OpenY Paragraph Location By Amenities" module
- [x] go to "/locations"
- [x] check that location filter by amenities was removed
- [x] go to "/admin/modules/uninstall"
- [x] uninstall "OpenY Paragraph Amenities" module
- [x] go to "/amenities"
- [x] check that amenities paragraph was removed
- [x] go to "/admin/modules"
- [x] install "OpenY Paragraph Amenities" module
- [x] go to "/amenities" and edit node
- [x] add "All Amenities" paragraph to content section and save
- [x] check that you can see paragraph content and all works fine
- [x] go to "/admin/modules"
- [x] install "OpenY Paragraph Location By Amenities" module
- [x] go to "/locations" and edit node
- [x] Add to sidebar section "Location filter by amenities" paragraph and save
- [x] check that you can see paragraph content and all works fine