### PR TITLE
[OPENY-39] Blog Posts Listing paragraph decoupling

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_blog_listing/openy_prgf_blog_listing.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_blog_listing/openy_prgf_blog_listing.info.yml
@@ -3,6 +3,7 @@ description: 'OpenY Paragraph Blog Posts Listing.'
 type: module
 core: 8.x
 package: OpenY
+version: 8.x-1.0
 dependencies:
   - field
   - node

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_blog_listing/openy_prgf_blog_listing.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_blog_listing/openy_prgf_blog_listing.install
@@ -6,6 +6,20 @@
  */
 
 /**
+ * Implements hook_uninstall().
+ */
+function openy_prgf_blog_listing_uninstall() {
+  // Remove blog_posts_listing content and paragraph type.
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('paragraph', 'paragraphs_type', 'blog_posts_listing');
+
+  // Remove other module configs.
+  \Drupal::configFactory()
+    ->getEditable('views.view.listing_blog_posts')
+    ->delete();
+}
+
+/**
  * Update Paragraph Blog Listing filter labels.
  */
 function openy_prgf_blog_listing_update_8001() {


### PR DESCRIPTION
## Steps for review

- [x] login as admin
- [x] Go to "/blog"
- [x] Check that you can see here "Blog Posts Listing" paragraph in content area
- [x] go to "/admin/modules/uninstall"
- [x] uninstall "OpenY Paragraph Blog Posts Listing" module
- [x] return to "/blog" page
- [x] check that "Blog Posts Listing" paragraph was removed
- [x] edit this page
- [x] check that you can't add "Blog Posts Listing" paragraph
- [x] go to "/admin/modules"
- [x] install "OpenY Paragraph Blog Posts Listing"
- [x] return to "/blog" page and edit
- [x] add "Blog Posts Listing" paragraph  to content area
- [x] save node and check that all works fine
