### PR TITLE
[OPENY-50] Featured Blog Posts paragraph decoupling

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_featured_blogs/openy_prgf_featured_blogs.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_featured_blogs/openy_prgf_featured_blogs.info.yml
@@ -3,6 +3,7 @@ description: 'OpenY Paragraph Featured Blog Posts.'
 type: module
 core: 8.x
 package: OpenY
+version: 8.x-1.0
 dependencies:
   - field
   - node

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_featured_blogs/openy_prgf_featured_blogs.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_featured_blogs/openy_prgf_featured_blogs.install
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @file
+ * OpenY Paragraph Featured Blog Posts install file.
+ */
+
+/**
+ * Implements hook_uninstall().
+ */
+function openy_prgf_featured_blogs_uninstall() {
+  // Remove featured_blogs content and paragraph type.
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('paragraph', 'paragraphs_type', 'featured_blogs');
+}


### PR DESCRIPTION
## Steps for review

- [x] login as admin
- [x] Go to "/blog"
- [x] Check that you can see here "Featured Blog Posts" paragraph in content area
- [x] go to "/admin/modules/uninstall"
- [x] uninstall "OpenY Paragraph Featured Blog Posts" module
- [x] return to "/blog" page
- [x] check that "Featured Blog Posts" paragraph was removed
- [x] edit this page
- [x] check that you can't add "Featured Blog Posts" paragraph
- [x] go to "/admin/modules"
- [x] install "OpenY Paragraph Featured Blog Posts"
- [x] return to "/blog" page and edit
- [x] add "Featured Blog Posts" paragraph  to content area with random list of blog posts
- [x] save node and check that all works fine

