### PR TITLE
Refactor OpenY upgrade tool

### DIFF
--- a/modules/custom/openy_upgrade_tool/src/ConfigUpdater.php
+++ b/modules/custom/openy_upgrade_tool/src/ConfigUpdater.php
@@ -152,6 +152,7 @@ class ConfigUpdater extends ConfigImporterService {
    *   TRUE if config was changed.
    */
   public function isManuallyChanged($config_name) {
+    return FALSE;
     $configs = $this->loggerEntityStorage->loadByProperties([
       'type' => 'openy_config_upgrade_logs',
       'name' => $config_name,


### PR DESCRIPTION
There is a hard rule which can't be skipped, and should be rethinked from the foundation
OpenY upgrade tool stops config updates when there is a manual change detected.
Which is wrong in terms of maintenance and upgrade.
There are other issues we need to address https://github.com/ymcatwincities/openy/issues/675

User story
I'm an OpenY developer and I need to upgrade from 8.0.1 to 8.1.12
For that, because of large number of updates and impossibility to predict quality of upgrade path support for the contrib modules it is impossible to upgrade in one leap - from 8.0.1 to 8.1.12. 
For that I have to update from version to version, relying on some investigation from the OpenY community https://github.com/ymcatwincities/openy/wiki/%5BDraft%5D-OpenY-upgrade-how-to-for-Developers
Thus, after first detected manually changed config I'm blocked from upgradig to latest version of OpenY with a huge scope in front of me
As a better resolution I'd like to be able to update to latest version even if my configs and manual changes are overridden. 
And as a feature from OpenY upgrade tool would be cool to keep is to show the diff between latest config from updated OpenY version of my site and old config that was overridden during upgrade

Make sure these boxes are checked before asking for review of your pull request - thank you!

If there is a new feature, please create PR against 8.x-1.xx-dev branch.

If this is a bug fix - use 8.x-1.x branch. We'll tag for release if the bug is critical asap or tag for release next bug fix release until critical issue arrived.

## Steps for review

- [ ] Please provide steps for review here.
- [ ] Please provide steps for review here.
- [ ] Please provide steps for review here.
- [ ] Please provide steps for review here.

## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/ci-errors.png" width="200" alt="CI code sniffer errors">
- [ ] All tests are running and there are no failed tests reported by CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/behat.png" width="200" alt="Behat test results">
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
