### PR TITLE
Fix possible errors for theme alters functions

### DIFF
--- a/themes/openy_themes/openy_rose/openy_rose.theme
+++ b/themes/openy_themes/openy_rose/openy_rose.theme
@@ -42,7 +42,8 @@ function openy_rose_preprocess_paragraph(array &$variables) {
  */
 function openy_rose_theme_suggestions_page_alter(array &$suggestions, array $variables) {
   // Add content type suggestions for node types.
-  if ($node = \Drupal::request()->attributes->get('node')) {
+  $node = \Drupal::request()->attributes->get('node');
+  if ($node && is_object($node)) {
     $node_type = $node->getType();
     $page__node_pos = array_search('page__node', $suggestions);
     $page__node__type = 'page__node__' . $node_type;
@@ -235,7 +236,8 @@ function openy_rose_page_attachments_alter(array &$page) {
   // related to a camp, and the custom camp favicon has been set for the theme.
 
   // Exit if not a node page, or if the 'openy_loc_camp.camp_service' is not available.
-  if (!($node = \Drupal::request()->attributes->get('node')) || !($camp_service = \Drupal::service('openy_loc_camp.camp_service'))) {
+  $node = \Drupal::request()->attributes->get('node');
+  if (!$node || !is_object($node) || !($camp_service = \Drupal::service('openy_loc_camp.camp_service'))) {
     return;
   }
 


### PR DESCRIPTION
For some custom pages, that not related to openy we can get next errors in case request contain `node` attribute, but this attribute is not object (custom views page with context filter for example):
`Recoverable fatal error: Argument 1 passed to Drupal\openy_loc_camp\CampService::nodeHasOrIsCamp() must implement interface Drupal\node\NodeInterface, string given, called in /var/www/docroot/profiles/contrib/openy/themes/openy_themes/openy_rose/openy_rose.theme on line 243 and defined in Drupal\openy_loc_camp\CampService->nodeHasOrIsCamp() (line 64 of /var/www/docroot/profiles/contrib/openy/modules/openy_features/openy_location/modules/openy_loc_camp/src/CampService.php) `.


