### PR TITLE
[OPENY-43] Categories Listing paragraph decoupling

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_categories_listing/openy_prgf_categories_listing.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_categories_listing/openy_prgf_categories_listing.info.yml
@@ -3,6 +3,7 @@ description: 'OpenY Paragraph Categories Listing.'
 type: module
 core: 8.x
 package: OpenY
+version: '8.x-1.0'
 dependencies:
   - field
   - node

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_categories_listing/openy_prgf_categories_listing.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_categories_listing/openy_prgf_categories_listing.install
@@ -6,6 +6,17 @@
  */
 
 /**
+ * Implements hook_uninstall().
+ */
+function openy_prgf_categories_listing_uninstall() {
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('paragraph', 'paragraphs_type', 'categories_listing');
+  \Drupal::configFactory()
+    ->getEditable('views.view.categories_listing')
+    ->delete();
+}
+
+/**
  * Update Paragraph Categories Listing field_prgf_block.
  */
 function openy_prgf_categories_listing_update_8001() {


### PR DESCRIPTION
## Steps for review

- [x] login as admin
- [x] go to /admin/content?title=&type=program&status=All&langcode=All
- [x] open any program page
- [x] go to /admin/modules/uninstall
- [x] uninstall "OpenY Paragraph Categories Listing" module
- [x] return to program page
- [x] check that "Categories Listing" paragraph was removed from content section
- [x] go to /admin/structure/paragraphs_type
- [x] check that "Categories Listing" paragraph not exist in this list
- [x] go to /admin/structure/views
- [x] check that "Categories Listing" views not exist in this list
- [x] go to /admin/modules
- [x] install "OpenY Paragraph Categories Listing" module
- [x] return to program page
- [x] check that you can add "Categories Listing" paragraph
- [x] check that all components that related to "OpenY Paragraph Categories Listing" module was restored and works fine

