### PR TITLE
[OPENY-44] [OPENY-45] Classes Listing paragraph decoupling

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_classes_listing/openy_prgf_classes_listing.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_classes_listing/openy_prgf_classes_listing.info.yml
@@ -3,6 +3,7 @@ description: 'OpenY Paragraph Classes Listing.'
 type: module
 core: 8.x
 package: OpenY
+version: '8.x-1.0'
 dependencies:
   - field
   - node

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_classes_listing/openy_prgf_classes_listing.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_classes_listing/openy_prgf_classes_listing.install
@@ -1,7 +1,21 @@
 <?php
+
 /**
- * @file OpenY paragraph classes listing install.
+ * @file
+ * OpenY paragraph classes listing install.
  */
+
+/**
+ * Implements hook_uninstall().
+ */
+function openy_prgf_classes_listing_uninstall() {
+  $modules_manager = \Drupal::service('openy.modules_manager');
+  $modules_manager->removeEntityBundle('paragraph', 'paragraphs_type', 'classes_listing');
+  $modules_manager->removeEntityBundle('paragraph', 'paragraphs_type', 'classes_listing_filters');
+  \Drupal::configFactory()
+    ->getEditable('views.view.classes_listing')
+    ->delete();
+}
 
 /**
  * Update classes listing view.
@@ -11,7 +25,7 @@ function openy_prgf_classes_listing_update_8001() {
 
   // Update multiple configurations.
   $configs = [
-    'views.view.classes_listing' =>[
+    'views.view.classes_listing' => [
       'display.default.display_options.filters',
       'display.default.display_options.filter_groups',
     ],
@@ -54,7 +68,7 @@ function openy_prgf_classes_listing_update_8003() {
       'content.field_prgf_block',
     ],
     'core.entity_view_display.paragraph.classes_listing_filters.default' => [
-      'content.field_prgf_block'
+      'content.field_prgf_block',
     ],
     'views.view.classes_listing' => [
       'display.default.display_options.field.nid',


### PR DESCRIPTION
## Steps for review

- [x] login as admin
- [x] go to /admin/content?title=&type=program_subcategory&status=All&langcode=All
- [x] open any Program Subcategory page
- [x] go to /admin/modules/uninstall
- [x] uninstall "OpenY Paragraph Classes Listing" module
- [x] return to Program Subcategory page
- [x] check that "Classes Listing Filters" paragraph was removed from HEADER AREA and "Classes Listing" paragraph was removed from CONTENT AREA
- [x] go to /admin/structure/paragraphs_type
- [x] check that "Classes Listing Filters" and  "Classes Listing" paragraphs not exist in this list
- [x] go to /admin/structure/views
- [x] check that "Classes Listing" views not exist in this list
- [x] go to /admin/modules
- [x] install "OpenY Paragraph Classes Listing" module
- [x] return to Program Subcategory page
- [x] check that you can add "Classes Listing Filters" and  "Classes Listing" paragraphs
- [x] check that all components that related to "OpenY Paragraph Classes Listing" module was restored and works fine