### PR TITLE
[OPENY-41] Branches popup (Class) paragraph decoupling

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_branches_popup_class/openy_prgf_branches_popup_class.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_branches_popup_class/openy_prgf_branches_popup_class.info.yml
@@ -3,8 +3,10 @@ description: 'OpenY Paragraph Branches Popup (Class).'
 type: module
 core: 8.x
 package: OpenY
+version: '8.x-1.0'
 dependencies:
   - field
   - openy_prgf
   - paragraphs
   - plugin
+  - openy_popups

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_branches_popup_class/openy_prgf_branches_popup_class.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_branches_popup_class/openy_prgf_branches_popup_class.install
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @file
+ * Implement install hooks for module.
+ */
+
+/**
+ * Implements hook_uninstall().
+ */
+function openy_prgf_branches_popup_class_uninstall() {
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('paragraph', 'paragraphs_type', 'branches_popup_class');
+}


### PR DESCRIPTION
## Steps for review

- [x] login as admin
- [x] go to /admin/content?title=&type=class&status=All&langcode=All
- [x] open any class page, check that you can see "Please select a location" modal (not select location)
- [x] edit this class
- [x] check that in CONTENT AREA you can see "Branches popup (Class)" paragraph
- [x] go to /admin/modules/uninstall
- [x] uninstall "OpenY Paragraph Branches Popup (Class)" module
- [x] return to class edit page 
- [x] check that "Branches popup (Class)" paragraph was removed from  CONTENT AREA
- [x] view this class
- [x] check that now modal "Please select a location" not shown
- [x] check that this page not have issues that related to the lack of "Please select a location" modal
- [x] go to /admin/structure/paragraphs_type
- [x] check that "Branches popup (Class)" paragraph not exist in this list
- [x] go to /admin/modules
- [x] install "OpenY Paragraph Branches Popup (Class)" module
- [x] return to class page
- [x] check that you can add "Branches popup (Class)" paragraph
- [x] check that all components that related to "OpenY Paragraph Branches Popup (Class)" module was restored and works fine

