### PR TITLE
[OPENY-42] Camp menu paragraph decoupling

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_camp_menu/openy_prgf_camp_menu.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_camp_menu/openy_prgf_camp_menu.info.yml
@@ -3,6 +3,7 @@ description: 'OpenY Paragraph Camp Menu.'
 type: module
 core: 8.x
 package: OpenY
+version: '8.x-1.0'
 dependencies:
   - field
   - openy_prgf

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_camp_menu/openy_prgf_camp_menu.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_camp_menu/openy_prgf_camp_menu.install
@@ -6,6 +6,14 @@
  */
 
 /**
+ * Implements hook_uninstall().
+ */
+function openy_prgf_camp_menu_uninstall() {
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('paragraph', 'paragraphs_type', 'camp_menu');
+}
+
+/**
  * Update Paragraph Camp Menu field_prgf_block.
  */
 function openy_prgf_camp_menu_update_8001() {
@@ -14,7 +22,7 @@ function openy_prgf_camp_menu_update_8001() {
 
   // Update multiple configurations.
   $configs = [
-    'core.entity_view_display.paragraph.camp_menu.default' =>[
+    'core.entity_view_display.paragraph.camp_menu.default' => [
       'content.field_prgf_block.region',
     ],
     'field.field.paragraph.camp_menu.field_prgf_block' => [


### PR DESCRIPTION
## Steps for review

- [x] login as admin
- [x] go to /camps/camp-terry/about
- [x] check that you can see camp menu
- [x] edit this page
- [x] check that in HEADER AREA you can see "Camp menu" paragraph
- [x] go to /admin/modules/uninstall
- [x] uninstall "OpenY Demo Node Camp" module
- [x] uninstall "OpenY Paragraph Camp Menu" module
- [x] return to edit page 
- [x] check that "Camp menu" paragraph was removed from HEADER AREA
- [x] view this page
- [x] check that now Camp menu not exist on page header
- [x] check that this page not have issues that related to the lack of "Camp menu" paragraph
- [x] go to /admin/structure/paragraphs_type
- [x] check that "Camp menu" paragraph not exist in this list
- [x] go to /admin/modules
- [x] install "OpenY Paragraph Camp Menu" module
- [x] return to camp landing page
- [x] check that you can add "Camp Menu" paragraph
- [x] check that all components that related to "OpenY Paragraph Camp Menu" module was restored and works fine

