### PR TITLE
[OPENY-46] Class location paragraph decoupling

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_class_location/openy_prgf_class_location.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_class_location/openy_prgf_class_location.info.yml
@@ -3,6 +3,7 @@ description: 'OpenY Paragraph Class Location.'
 type: module
 core: 8.x
 package: OpenY
+version: '8.x-1.0'
 dependencies:
   - paragraphs
   - openy_location

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_class_location/openy_prgf_class_location.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_class_location/openy_prgf_class_location.install
@@ -5,6 +5,14 @@
  */
 
 /**
+ * Implements hook_uninstall().
+ */
+function openy_prgf_class_location_uninstall() {
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('paragraph', 'paragraphs_type', 'class_location');
+}
+
+/**
  * Update class location paragraph configuration.
  */
 function openy_prgf_class_location_update_8001() {


### PR DESCRIPTION
## Steps for review

- [x] login as admin
- [x] go to /admin/content?title=&type=class&status=All&langcode=All
- [x] open any class page
- [x] check that you can see location block in sidebar
- [x] edit this page
- [x] check that in SIDEBAR AREA you can see "Class location" paragraph
- [x] go to /admin/modules/uninstall
- [x] uninstall "OpenY Paragraph Class Location" module
- [x] return to edit page 
- [x] check that "Class location" paragraph was removed from SIDEBAR AREA
- [x] view this page
- [x] check that now "Class location" not exist in sidebar
- [x] check that this page not have issues that related to the lack of "Class location" paragraph
- [x] go to /admin/structure/paragraphs_type
- [x] check that "Class location" paragraph not exist in this list
- [x] go to /admin/modules
- [x] install "OpenY Paragraph Class Location" module
- [x] return to class page
- [x] check that you can add "Class Location" paragraph
- [x] check that all components that related to "OpenY Paragraph Class Location" module was restored and works fine
