### PR TITLE
[OPENY-47] Class Sessions paragraph decoupling

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_class_sessions/openy_prgf_class_sessions.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_class_sessions/openy_prgf_class_sessions.info.yml
@@ -3,8 +3,10 @@ description: 'OpenY Paragraph Class Sessions.'
 type: module
 core: 8.x
 package: OpenY
+version: '8.x-1.0'
 dependencies:
   - field
   - openy_prgf
   - paragraphs
   - plugin
+  - openy_session_instance

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_class_sessions/openy_prgf_class_sessions.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_class_sessions/openy_prgf_class_sessions.install
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @file
+ * OpenY class sessions paragraph.
+ */
+
+/**
+ * Implements hook_uninstall().
+ */
+function openy_prgf_class_sessions_uninstall() {
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('paragraph', 'paragraphs_type', 'class_sessions');
+}


### PR DESCRIPTION
## Steps for review

- [x] login as admin
- [x] go to /admin/content?title=&type=class&status=All&langcode=All
- [x] open any class page
- [x] check that you can see "Class Times" block in content area
- [x] edit this page
- [x] check that in CONTENT AREA you can see "Class Sessions" paragraph
- [x] go to /admin/modules/uninstall
- [x] uninstall "OpenY Paragraph Class Sessions" module
- [x] return to edit page 
- [x] check that "Class Sessions" paragraph was removed from CONTENT AREA
- [x] view this page
- [x] check that now "Class Times" not exist in sidebar
- [x] check that this page not have issues that related to the lack of "Class Sessions" paragraph
- [x] go to /admin/structure/paragraphs_type
- [x] check that "Class Sessions" paragraph not exist in this list
- [x] go to /admin/modules
- [x] install "OpenY Paragraph Class Sessions" module
- [x] return to class page
- [x] check that you can add "Class Sessions" paragraph
- [x] check that all components that related to "OpenY Paragraph Class Sessions" module was restored and works fine

