### PR TITLE
[OPENY-48] Date Block paragraph decoupling

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_block_date/openy_prgf_block_date.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_block_date/openy_prgf_block_date.info.yml
@@ -3,6 +3,7 @@ description: 'OpenY Paragraph shows content based on date and time (before, betw
 package: OpenY
 type: module
 core: 8.x
+version: '8.x-1.0'
 dependencies:
   - block_content
   - entity_browser_entity_form

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_block_date/openy_prgf_block_date.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_block_date/openy_prgf_block_date.install
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @file
+ * Implement install hooks for module.
+ */
+
+/**
+ * Implements hook_uninstall().
+ */
+function openy_prgf_block_date_uninstall() {
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('paragraph', 'paragraphs_type', 'block_date');
+}


### PR DESCRIPTION
## Steps for review

- [x] login as admin
- [x] go to /node/add/landing_page
- [x] create landing page with "Date Block" paragraph in content area
- [x] go to /admin/modules/uninstall
- [x] uninstall "OpenY Paragraph for Date Block" module
- [x] return to created page 
- [x] check that "Date Block" paragraph was removed from CONTENT AREA
- [x] go to /admin/structure/paragraphs_type
- [x] check that "Date Block" paragraph not exist in this list
- [x] go to /admin/modules
- [x] install "OpenY Paragraph for Date Block" module
- [x] return to created page 
- [x] check that you can add "Date Block" paragraph
- [x] check that all components that related to "OpenY Paragraph for Date Block" module was restored and works fine

