### PR TITLE
[OPENY-49] Embedded GroupEx Pro Schedule paragraph decoupling

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_embedded_groupexpro_schedule/openy_prgf_embedded_groupexpro_schedule.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_embedded_groupexpro_schedule/openy_prgf_embedded_groupexpro_schedule.info.yml
@@ -3,6 +3,7 @@ description: 'OpenY Paragraph Embedded GroupEx Pro Schedule.'
 type: module
 core: 8.x
 package: OpenY
+version: '8.x-1.0'
 dependencies:
   - embedded_groupexpro_schedule
   - field

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_embedded_groupexpro_schedule/openy_prgf_embedded_groupexpro_schedule.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_embedded_groupexpro_schedule/openy_prgf_embedded_groupexpro_schedule.install
@@ -1,7 +1,17 @@
 <?php
+
 /**
- * @file OpenY Paragraph Embedded GroupEx Pro Schedule install file.
+ * @file
+ * OpenY Paragraph Embedded GroupEx Pro Schedule install file.
  */
+
+/**
+ * Implements hook_uninstall().
+ */
+function openy_prgf_embedded_groupexpro_schedule_uninstall() {
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('paragraph', 'paragraphs_type', 'embedded_groupexpro_schedule');
+}
 
 /**
  * Update Paragraph Embedded GroupEx Pro Schedule field_prgf_block.
@@ -17,7 +27,7 @@ function openy_prgf_embedded_groupexpro_schedule_update_8001() {
     ],
     'field.field.paragraph.embedded_groupexpro_schedule.field_prgf_block' => [
       'dependencies.module',
-    ]
+    ],
   ];
 
   $config_updater = \Drupal::service('openy_upgrade_tool.param_updater');


### PR DESCRIPTION
## Steps for review

- [x] login as admin
- [x] go to /node/add/landing_page
- [x] create landing page with "Embedded GroupEx Pro Schedule" paragraph in content area
- [x] go to /admin/modules/uninstall
- [x] uninstall "OpenY Paragraph Embedded GroupEx Pro Schedule" module
- [x] return to created page 
- [x] check that "Embedded GroupEx Pro Schedule" paragraph was removed from CONTENT AREA
- [x] go to /admin/structure/paragraphs_type
- [x] check that "Embedded GroupEx Pro Schedule" paragraph not exist in this list
- [x] go to /admin/modules
- [x] install "OpenY Paragraph Embedded GroupEx Pro Schedule" module
- [x] return to created page 
- [x] check that you can add "Embedded GroupEx Pro Schedule" paragraph
- [x] check that all components that related to "OpenY Paragraph Embedded GroupEx Pro Schedule" module was restored and works fine

