### PR TITLE
Fix upgrade path for new alert fields

### DIFF
--- a/modules/openy_features/openy_node/modules/openy_node_alert/openy_node_alert.install
+++ b/modules/openy_features/openy_node/modules/openy_node_alert/openy_node_alert.install
@@ -10,7 +10,7 @@
  */
 function openy_node_alert_update_8001() {
   $config_dir = drupal_get_path('module', 'openy_node_alert') . '/config/install/';
-  // Import new configuration
+  // Import new configuration.
   $config_importer = \Drupal::service('openy_upgrade_tool.importer');
   $config_importer->setDirectory($config_dir);
   $config_importer->importConfigs([
@@ -52,7 +52,7 @@ function openy_node_alert_update_8003() {
   $config_dir = drupal_get_path('module', 'openy_node_alert') . '/config/install/';
   // Update multiple configurations.
   $configs = [
-    'field.field.node.alert.field_alert_color' =>[
+    'field.field.node.alert.field_alert_color' => [
       'description',
     ],
     'field.field.node.alert.field_alert_description' => [
@@ -164,4 +164,14 @@ function openy_node_alert_update_8006() {
       $config_updater->update($config, $config_name, $param);
     }
   }
+
+  // Import new configuration.
+  $config_importer = \Drupal::service('openy_upgrade_tool.importer');
+  $config_importer->setDirectory($config_dir);
+  $config_importer->importConfigs([
+    'field.storage.node.field_alert_visibility_pages',
+    'field.storage.node.field_alert_visibility_state',
+    'field.field.node.alert.field_alert_visibility_pages',
+    'field.field.node.alert.field_alert_visibility_state',
+  ]);
 }

--- a/openy.install
+++ b/openy.install
@@ -882,3 +882,22 @@ function openy_update_8057() {
     drupal_set_message($message, 'warning');
   }
 }
+
+/**
+ * Upgrade path for new alert fields.
+ */
+function openy_update_8058() {
+  if (!\Drupal::service('module_handler')->moduleExists('openy_node_alert')) {
+    // Skip this update if module disabled.
+    return;
+  }
+  $config_dir = drupal_get_path('module', 'openy_node_alert') . '/config/install/';
+  $config_importer = \Drupal::service('openy_upgrade_tool.importer');
+  $config_importer->setDirectory($config_dir);
+  $config_importer->importConfigs([
+    'field.storage.node.field_alert_visibility_pages',
+    'field.storage.node.field_alert_visibility_state',
+    'field.field.node.alert.field_alert_visibility_pages',
+    'field.field.node.alert.field_alert_visibility_state',
+  ]);
+}


### PR DESCRIPTION
In this PR - https://github.com/ymcatwincities/openy/pull/1079 I got some errors on builds that related to alerts. 

```
Drupal\Core\Config\ConfigImporterException: Configuration <em class="placeholder">core.entity_form_display.node.alert.default</em> depends on configuration (<em class="placeholder">field.field.node.alert.field_alert_visibility_pages, field.field.node.alert.field_alert_visibility_state</em>) that will not exist after import. Configuration <em class="placeholder">core.entity_view_display.node.alert.default</em> depends on configuration (<em class="placeholder">field.field.node.alert.field_alert_visibility_pages, field.field.node.alert.field_alert_visibility_state</em>) that will not exist after import. in Drupal\config_import\ConfigImporterService->import() (line 328 of /var/lib/jenkins/jobs/PR_BUILDER_COMPOSER/workspace/build479/openy-project/docroot/modules/contrib/confi/src/ConfigImporterService.php).
```

This problem can be reproduced only on upgrade build. After investigation I found that in this PR - https://github.com/ymcatwincities/openy/pull/1012 was skipped import of new field configs, but imported `core.entity_view_display.node.alert.default` and `core.entity_form_display.node.alert.default` with dependency to new fields, which causes the error.

I have fixed this in `openy_node_alert_update_8001` but this not fix issue for all sites that already updated to [OpenY 1.11 Release](https://github.com/ymcatwincities/openy/releases/tag/8.1.11). In this case we need additional update in openy profile, that run before all modules updates.