### PR TITLE
[OPENY-63] Latest blog posts paragraph decoupling

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_1c/openy_prgf_1c.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_1c/openy_prgf_1c.install
@@ -22,7 +22,7 @@ function openy_prgf_1c_uninstall() {
 function openy_prgf_1c_update_dependencies() {
   $dependencies['openy_prgf_1c'] = [
     8003 => [
-      'openy' => 8057,
+      'openy' => 8059,
     ],
   ];
 

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_2c/openy_prgf_2c.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_2c/openy_prgf_2c.install
@@ -22,7 +22,7 @@ function openy_prgf_2c_uninstall() {
 function openy_prgf_2c_update_dependencies() {
   $dependencies['openy_prgf_2c'] = [
     8004 => [
-      'openy' => 8057,
+      'openy' => 8059,
     ],
   ];
 

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_3c/openy_prgf_3c.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_3c/openy_prgf_3c.install
@@ -22,7 +22,7 @@ function openy_prgf_3c_uninstall() {
 function openy_prgf_3c_update_dependencies() {
   $dependencies['openy_prgf_3c'] = [
     8003 => [
-      'openy' => 8057,
+      'openy' => 8059,
     ],
   ];
 

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_4c/openy_prgf_4c.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_4c/openy_prgf_4c.install
@@ -22,7 +22,7 @@ function openy_prgf_4c_uninstall() {
 function openy_prgf_4c_update_dependencies() {
   $dependencies['openy_prgf_4c'] = [
     8005 => [
-      'openy' => 8057,
+      'openy' => 8059,
     ],
   ];
 

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_blog_latest/openy_prgf_blog_latest.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_blog_latest/openy_prgf_blog_latest.info.yml
@@ -3,6 +3,7 @@ description: 'OpenY Paragraph Latest Blog Posts.'
 type: module
 core: 8.x
 package: OpenY
+version: '8.x-1.0'
 dependencies:
   - field
   - node

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_blog_latest/openy_prgf_blog_latest.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_blog_latest/openy_prgf_blog_latest.install
@@ -6,6 +6,17 @@
  */
 
 /**
+ * Implements hook_uninstall().
+ */
+function openy_prgf_blog_latest_uninstall() {
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('paragraph', 'paragraphs_type', 'latest_blog_posts');
+  \Drupal::configFactory()
+    ->getEditable('views.view.latest_blog_posts')
+    ->delete();
+}
+
+/**
  * Update OpenY Paragraph Latest Blog Posts field_prgf_block.
  */
 function openy_prgf_blog_latest_update_8001() {
@@ -27,7 +38,7 @@ function openy_prgf_blog_latest_update_8002() {
   $config_dir = drupal_get_path('module', 'openy_prgf_blog_latest');
   $config_dir .= '/config/install/';
 
-  // Import new configuration
+  // Import new configuration.
   $config_importer = \Drupal::service('openy_upgrade_tool.importer');
   $config_importer->setDirectory($config_dir);
   $config_importer->importConfigs([

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_featured_highlights/openy_prgf_featured_highlights.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_featured_highlights/openy_prgf_featured_highlights.install
@@ -19,7 +19,7 @@ function openy_prgf_featured_highlights_uninstall() {
 function openy_prgf_featured_highlights_update_dependencies() {
   $dependencies['openy_prgf_featured_highlights'] = [
     8001 => [
-      'openy' => 8057,
+      'openy' => 8059,
     ],
   ];
 

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_secondary_description_sidebar/openy_prgf_secondary_description_sidebar.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_secondary_description_sidebar/openy_prgf_secondary_description_sidebar.install
@@ -19,7 +19,7 @@ function openy_prgf_secondary_description_sidebar_uninstall() {
 function openy_prgf_secondary_description_sidebar_update_dependencies() {
   $dependencies['openy_prgf_secondary_description_sidebar'] = [
     8001 => [
-      'openy' => 8057,
+      'openy' => 8059,
     ],
   ];
 


### PR DESCRIPTION
## Steps for review

- [x] login as admin
- [x] go to front page
- [x] check that you can see "What's happening at the Y?" block
- [x] edit this page
- [x] check that in CONTENT AREA you can see "Latest blog posts" paragraph
- [x] go to /admin/modules/uninstall
- [x] uninstall "OpenY Paragraph Latest Blog Posts" module
- [x] return to edit front page 
- [x] check that "Latest blog posts" paragraph was removed from  CONTENT AREA
- [x] view this page
- [x] check that now "What's happening at the Y?" block not shown
- [x] go to /admin/structure/paragraphs_type
- [x] check that "Latest blog posts" paragraph not exist in this list
- [x] go to /admin/modules
- [x] install "OpenY Paragraph Latest Blog Posts" module
- [x] return to front page
- [x] check that you can add "Latest blog posts" paragraph
- [x] check that all components that related to "OpenY Paragraph Latest Blog Posts" module was restored and works fine

