### PR TITLE
[OPENY-63] Latest blog posts (branch) paragraph decoupling

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_blog_branch/openy_prgf_blog_branch.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_blog_branch/openy_prgf_blog_branch.info.yml
@@ -3,6 +3,7 @@ description: 'OpenY Paragraph Latest Blog Posts (Branch).'
 type: module
 core: 8.x
 package: OpenY
+version: '8.x-1.0'
 dependencies:
   - field
   - node

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_blog_branch/openy_prgf_blog_branch.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_blog_branch/openy_prgf_blog_branch.install
@@ -6,6 +6,17 @@
  */
 
 /**
+ * Implements hook_uninstall().
+ */
+function openy_prgf_blog_branch_uninstall() {
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('paragraph', 'paragraphs_type', 'latest_blog_posts_branch');
+  \Drupal::configFactory()
+    ->getEditable('views.view.latest_blog_posts_branch')
+    ->delete();
+}
+
+/**
  * Update Paragraph Latest Blog Posts (Branch) field_prgf_block.
  */
 function openy_prgf_blog_branch_update_8001() {
@@ -27,7 +38,7 @@ function openy_prgf_blog_branch_update_8002() {
   $config_dir = drupal_get_path('module', 'openy_prgf_blog_branch');
   $config_dir .= '/config/install/';
 
-  // Import new configuration
+  // Import new configuration.
   $config_importer = \Drupal::service('openy_upgrade_tool.importer');
   $config_importer->setDirectory($config_dir);
   $config_importer->importConfigs([


### PR DESCRIPTION
## Steps for review

- [x] login as admin
- [x] go to /locations/downtown-ymca
- [x] check that you can see "Blog posts (branch)" block
- [x] edit this page
- [x] check that in CONTENT AREA you can see "Latest blog posts (branch)" paragraph
- [x] go to /admin/modules/uninstall
- [x] uninstall "OpenY Paragraph Latest Blog Posts (Branch)" module
- [x] return to edit /locations/downtown-ymca page 
- [x] check that "Latest blog posts (branch)" paragraph was removed from  CONTENT AREA
- [x] view this page
- [x] check that now "Blog posts (branch)" block not shown
- [x] go to /admin/structure/paragraphs_type
- [x] check that "Latest blog posts (branch)" paragraph not exist in this list
- [x] go to /admin/modules
- [x] install "OpenY Paragraph Latest Blog Posts (Branch)" module
- [x] return to branch page
- [x] check that you can add "Latest blog posts (branch)" paragraph
- [x] check that all components that related to "OpenY Paragraph Latest Blog Posts (Branch)" module was restored and works fine

