### PR TITLE
[OPENY-63] Latest blog posts (camp) paragraph decoupling

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_blog_camp/openy_prgf_blog_camp.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_blog_camp/openy_prgf_blog_camp.info.yml
@@ -3,6 +3,7 @@ description: 'OpenY Paragraph Latest Blog Posts (Camp).'
 type: module
 core: 8.x
 package: OpenY
+version: '8.x-1.0'
 dependencies:
   - field
   - node

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_blog_camp/openy_prgf_blog_camp.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_blog_camp/openy_prgf_blog_camp.install
@@ -6,6 +6,17 @@
  */
 
 /**
+ * Implements hook_uninstall().
+ */
+function openy_prgf_blog_camp_uninstall() {
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('paragraph', 'paragraphs_type', 'latest_blog_posts_camp');
+  \Drupal::configFactory()
+    ->getEditable('views.view.latest_blog_posts_camp')
+    ->delete();
+}
+
+/**
  * Update Paragraph Latest Blog Posts (Camp) field_prgf_block.
  */
 function openy_prgf_blog_camp_update_8001() {
@@ -27,7 +38,7 @@ function openy_prgf_blog_camp_update_8002() {
   $config_dir = drupal_get_path('module', 'openy_prgf_blog_camp');
   $config_dir .= '/config/install/';
 
-  // Import new configuration
+  // Import new configuration.
   $config_importer = \Drupal::service('openy_upgrade_tool.importer');
   $config_importer->setDirectory($config_dir);
   $config_importer->importConfigs([


### PR DESCRIPTION
## Steps for review

- [x] login as admin
- [x] go to /camps/camp-colman
- [x] check that you can see "What's New at Camp Colman?" block
- [x] edit this page
- [x] check that in CONTENT AREA you can see "Latest blog posts (camp)" paragraph
- [x] go to /admin/modules/uninstall
- [x] uninstall "OpenY Paragraph Latest Blog Posts (Camp)" module
- [x] return to edit /camps/camp-colman page 
- [x] check that "Latest blog posts (Camp)" paragraph was removed from  CONTENT AREA
- [x] view this page
- [x] check that now "Blog posts (branch)" block not shown
- [x] go to /admin/structure/paragraphs_type
- [x] check that "What's New at Camp Colman?" paragraph not exist in this list
- [x] go to /admin/modules
- [x] install "OpenY Paragraph Latest Blog Posts (Camp)" module
- [x] return to front page
- [x] check that you can add "Latest blog posts (camp)" paragraph
- [x] check that all components that related to "OpenY Paragraph Latest Blog Posts (Camp)" module was restored and works fine

