### PR TITLE
[OPENY-63] Blogs decoupling

### DIFF
--- a/modules/openy_features/openy_node/modules/openy_node_blog/openy_node_blog.info.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_blog/openy_node_blog.info.yml
@@ -3,6 +3,7 @@ description: 'OpenY Node Blog.'
 type: module
 core: 8.x
 package: OpenY
+version: '8.x-1.0'
 dependencies:
   - entity_browser
   - entity_reference_revisions

--- a/modules/openy_features/openy_node/modules/openy_node_blog/openy_node_blog.install
+++ b/modules/openy_features/openy_node/modules/openy_node_blog/openy_node_blog.install
@@ -6,6 +6,29 @@
  */
 
 /**
+ * Implements hook_uninstall().
+ */
+function openy_node_blog_uninstall() {
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('node', 'node_type', 'blog');
+  $configFactory = \Drupal::configFactory();
+  $configs = [
+    'core.entity_view_display.media.image.node_blog',
+    'core.entity_view_display.media.image.node_blog_teaser',
+    'core.entity_view_mode.media.node_blog',
+    'core.entity_view_mode.media.node_blog_teaser',
+    'simple_sitemap.bundle_settings.node.blog',
+    'pathauto.pattern.blog',
+    'image.style.node_blog',
+    'image.style.node_blog_teaser',
+    'metatag.metatag_defaults.node__blog',
+  ];
+  foreach ($configs as $config) {
+    $configFactory->getEditable($config)->delete();
+  }
+}
+
+/**
  * Implements hook_update_dependencies().
  */
 function openy_node_blog_update_dependencies() {


### PR DESCRIPTION
## Note: Test and merge this after this PR's:
- https://github.com/ymcatwincities/openy/pull/1113
- https://github.com/ymcatwincities/openy/pull/1114
- https://github.com/ymcatwincities/openy/pull/1115

## Steps for review

- [x] login as admin
- [x] go to /admin/modules/uninstall
- [x] uninstall "OpenY Demo Node Camp", "OpenY Demo Taxonomy Blog Category" and "OpenY Demo Node Blog" modules
- [x] uninstall all "OpenY Blog *" paragraphs modules
- [x] uninstall "OpenY Node Blog" module
- [x] go to /admin/structure/types
- [x] check that blogs not exist in this list
- [x] go to /admin/structure/media/manage/image/display
- [x] check that node_blog and node_blog_teaser not exist in this list
- [x] go to /admin/config/media/image-styles
- [x] check that node_blog and node_blog_teaser not exist in this list
- [x] install "OpenY Node Blog" module
- [x] check that the points above was restored
- [x] go to /node/add/blog
- [x] check that all components that related to "OpenY Node Blog" module was restored and works fine
