### PR TITLE
[OPENY-63] Blog category decoupling

### DIFF
--- a/modules/openy_features/openy_taxonomy/modules/openy_txnm_blog_category/openy_txnm_blog_category.info.yml
+++ b/modules/openy_features/openy_taxonomy/modules/openy_txnm_blog_category/openy_txnm_blog_category.info.yml
@@ -3,6 +3,7 @@ description: 'OpenY Taxonomy Blog Category.'
 type: module
 core: 8.x
 package: OpenY
+version: '8.x-1.0'
 dependencies:
   - ctools
   - entity_reference_revisions

--- a/modules/openy_features/openy_taxonomy/modules/openy_txnm_blog_category/openy_txnm_blog_category.install
+++ b/modules/openy_features/openy_taxonomy/modules/openy_txnm_blog_category/openy_txnm_blog_category.install
@@ -6,6 +6,22 @@
  */
 
 /**
+ * Implements hook_uninstall().
+ */
+function openy_txnm_blog_category_uninstall() {
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('taxonomy_term', 'taxonomy_vocabulary', 'blog_category', 'vid');
+  $configFactory = \Drupal::configFactory();
+  $configs = [
+    'simple_sitemap.bundle_settings.taxonomy_term.blog_category',
+    'pathauto.pattern._blog_category_',
+  ];
+  foreach ($configs as $config) {
+    $configFactory->getEditable($config)->delete();
+  }
+}
+
+/**
  * Add Taxonomy content field.
  */
 function openy_txnm_blog_category_update_8001() {
@@ -16,7 +32,7 @@ function openy_txnm_blog_category_update_8001() {
     'core.entity_form_display.taxonomy_term.blog_category.default',
     'core.entity_view_display.taxonomy_term.blog_category.default',
     'field.field.taxonomy_term.blog_category.field_taxonomy_content',
-    'field.storage.taxonomy_term.field_taxonomy_content'
+    'field.storage.taxonomy_term.field_taxonomy_content',
   ]);
 }
 


### PR DESCRIPTION
Note: Test and merge this after this PR:
- https://github.com/ymcatwincities/openy/pull/1116

## Steps for review

- [x] login as admin
- [x] go to /admin/modules/uninstall
- [x] uninstall "OpenY Demo Node Camp", "OpenY Demo Taxonomy Blog Category" and "OpenY Demo Node Blog" modules
- [x] uninstall all "OpenY Blog *" paragraphs modules
- [x] uninstall "OpenY Node Blog" module
- [x] uninstall "OpenY Taxonomy Blog Category" module
- [x] go to /admin/structure/taxonomy
- [x] check that blog category not exist in this list
- [x] install "OpenY Taxonomy Blog Category" module
- [x] go to /admin/structure/taxonomy
- [x] check that blog category exist in this list
- [x] go to /admin/structure/taxonomy/manage/blog_category/add
- [x] check that all components that related to "OpenY Taxonomy Blog Category" module was restored and works fine
