### PR TITLE
Add entity reference selection plugins

### DIFF
--- a/modules/custom/openy_er/README.md
+++ b/modules/custom/openy_er/README.md
@@ -1,0 +1,26 @@
+### OpenY Entity Reference Tweaks module.
+
+The idea of the module is to provide enhancements to the Core entity reference fields in OpenY installation profile purposes.
+
+#### Entity Reference Selection Handler plugins
+
+The plugins stored at `src/Plugin/EntityReferenceSelection` must be used in ER-fields if additional bundle filtering is setup and you export configuration of those fields into the profile.
+Default Selection Handlers put dependency for each single bundle setup there, because the core works the way, that 'target_bundles' field settings entries add dependencies. See [EntityReferenceItem::calculateDependencies()](https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Field%21Plugin%21Field%21FieldType%21EntityReferenceItem.php/function/EntityReferenceItem%3A%3AcalculateDependencies/8.5.x)
+
+`DefaultSelectionNoDependency` is basically needed to create a label for the group of OpenY selection handlers.
+
+`SelectionNoDependecyTrait` is useful for inheriting from existing entity type specific selection handlers (see NodeSelectionNoDependency implementation as example).
+See [Traits Precendence](http://php.net/manual/en/language.oop5.traits.php#language.oop5.traits.precedence) section to understand how PHP handles method overrides when traits are used.
+
+#### Migrating from core selection handlers to OpenY selection handlers
+
+- Go to the required entity refrence field configuration page that is provided by Field UI
+- Find "REFERENCE TYPE" section that contains "Reference method" field and a set of checkboxes for bundles limiting
+- Memorize the set of the selected bundles
+- Update "Reference method" value from 'Default' to 'Default (OpenY)'
+- Restore the state of the checkboxes (it can be named 'Content types' for nodes, or just 'Bundles' for other entity types)
+- Submit the form
+- Export the config (or the whole feature)
+- Verify field config doesn't contain dependencies to the bundle configs
+- Make sure the module now depends on `openy_er` module
+

--- a/modules/custom/openy_er/openy_er.info.yml
+++ b/modules/custom/openy_er/openy_er.info.yml
@@ -1,0 +1,9 @@
+name: 'OpenY Entity Reference Tweaks'
+description: 'Provides additional Entity Reference selection plugins.'
+type: module
+core: 8.x
+package: OpenY
+version: '8.x-1.0'
+dependencies:
+  - field
+  - plugin

--- a/modules/custom/openy_er/openy_er.module
+++ b/modules/custom/openy_er/openy_er.module
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @file
+ * OpenY Entity Reference Tweaks module file.
+ */
+
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Implements hook_field_widget_form_alter().
+ *
+ * Alters default entity reference widget in favor of openy_er.
+ */
+function openy_er_field_widget_form_alter(&$element, FormStateInterface $form_state, $context) {
+  $settings = $context['items']->getSettings();
+  // Entity reference fields contain handler in form 'handler:entity_type'.
+  if (!isset($settings['handler']) || !preg_match('/.*:.*/', $settings['handler'])) {
+    return;
+  }
+  list($type, $entity_type) = explode(':', $settings['handler']);
+  // We only massage form if the handler is derived from default_no_dep.
+  if ($type != 'default_no_dep') {
+    return;
+  }
+  // Reduce the list of options if 'bundle' field is presented.
+  if (!isset($element['actions']['bundle'])) {
+    return;
+  }
+
+  $target_bundles = $settings['handler_settings']['target_bundles_no_dep'];
+  $options = &$element['actions']['bundle']['#options'];
+  foreach ($options as $key => $option) {
+    if (isset($target_bundles[$key])) {
+      continue;
+    }
+    unset($options[$key]);
+  }
+}

--- a/modules/custom/openy_er/src/Plugin/EntityReferenceSelection/BlockSelectionNoDependency.php
+++ b/modules/custom/openy_er/src/Plugin/EntityReferenceSelection/BlockSelectionNoDependency.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\openy_er\Plugin\EntityReferenceSelection;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\node\Plugin\EntityReferenceSelection\NodeSelection;
+
+/**
+ * Provides block_content entity type specific selection handler.
+ *
+ * @EntityReferenceSelection(
+ *   id = "default_no_dep:block_content",
+ *   label = @Translation("Block selection (openy)"),
+ *   entity_types = {"block_content"},
+ *   group = "default_no_dep",
+ *   weight = 1
+ * )
+ */
+class BlockSelectionNoDependency extends NodeSelection {
+
+  use SelectionNoDependencyTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $form = parent::buildConfigurationForm($form, $form_state);
+    $form = $this->buildConfigurationFormAlter($form, $form_state);
+    return $form;
+  }
+
+}

--- a/modules/custom/openy_er/src/Plugin/EntityReferenceSelection/DefaultSelectionNoDependency.php
+++ b/modules/custom/openy_er/src/Plugin/EntityReferenceSelection/DefaultSelectionNoDependency.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Drupal\openy_er\Plugin\EntityReferenceSelection;
+
+use Drupal\Core\Entity\Plugin\EntityReferenceSelection\DefaultSelection;
+
+/**
+ * No dependency plugin implementation of the Entity Reference Selection plugin.
+ *
+ * Also serves as a base class for specific types of Entity Reference
+ * Selection plugins.
+ *
+ * @see \Drupal\Core\Entity\EntityReferenceSelection\SelectionPluginManager
+ * @see \Drupal\Core\Entity\Annotation\EntityReferenceSelection
+ * @see \Drupal\Core\Entity\EntityReferenceSelection\SelectionInterface
+ * @see \Drupal\Core\Entity\Plugin\Derivative\DefaultSelectionDeriver
+ * @see plugin_api
+ *
+ * @EntityReferenceSelection(
+ *   id = "default_no_dep",
+ *   label = @Translation("Default (openy)"),
+ *   group = "default (openy)",
+ *   weight = 0,
+ *   deriver = "Drupal\Core\Entity\Plugin\Derivative\DefaultSelectionDeriver"
+ * )
+ */
+class DefaultSelectionNoDependency extends DefaultSelection {
+
+  // Intentionally empty.
+
+}

--- a/modules/custom/openy_er/src/Plugin/EntityReferenceSelection/NodeSelectionNoDependency.php
+++ b/modules/custom/openy_er/src/Plugin/EntityReferenceSelection/NodeSelectionNoDependency.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\openy_er\Plugin\EntityReferenceSelection;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\node\Plugin\EntityReferenceSelection\NodeSelection;
+
+/**
+ * No dependency selection handler implementation for the node entity type.
+ *
+ * @EntityReferenceSelection(
+ *   id = "default_no_dep:node",
+ *   label = @Translation("Node selection (openy)"),
+ *   entity_types = {"node"},
+ *   group = "default_no_dep",
+ *   weight = 1
+ * )
+ */
+class NodeSelectionNoDependency extends NodeSelection {
+
+  use SelectionNoDependencyTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $form = parent::buildConfigurationForm($form, $form_state);
+    $form = $this->buildConfigurationFormAlter($form, $form_state);
+    $form['target_bundles_no_dep']['#title'] = $this->t('Content types');
+    return $form;
+  }
+
+}

--- a/modules/custom/openy_er/src/Plugin/EntityReferenceSelection/SelectionNoDependencyTrait.php
+++ b/modules/custom/openy_er/src/Plugin/EntityReferenceSelection/SelectionNoDependencyTrait.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Drupal\openy_er\Plugin\EntityReferenceSelection;
+
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * No dependency Entity Reference Selection plugin delta implementation.
+ */
+trait SelectionNoDependencyTrait {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return [
+      // For the 'target_bundles' setting, a NULL value is equivalent to "allow
+      // entities from any bundle to be referenced" and an empty array value is
+      // equivalent to "no entities from any bundle can be referenced".
+      'target_bundles' => NULL,
+      'sort' => [
+        'field' => '_none',
+        'direction' => 'ASC',
+      ],
+      'target_bundles_no_dep' => NULL,
+      'auto_create' => FALSE,
+      'auto_create_bundle' => NULL,
+    ] + parent::defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationFormAlter(array $form, FormStateInterface $form_state) {
+    $configuration = $this->getConfiguration();
+    $entity_type_id = $configuration['target_type'];
+    $entity_type = $this->entityManager->getDefinition($entity_type_id);
+    $bundles = $this->entityManager->getBundleInfo($entity_type_id);
+
+    if ($entity_type->hasKey('bundle')) {
+      $bundle_options = [];
+      foreach ($bundles as $bundle_name => $bundle_info) {
+        $bundle_options[$bundle_name] = $bundle_info['label'];
+      }
+      natsort($bundle_options);
+
+      $form['target_bundles_no_dep'] = [
+        '#type' => 'checkboxes',
+        '#title' => $form['target_bundles']['#title'],
+        '#options' => $bundle_options,
+        '#default_value' => (array) $configuration['target_bundles_no_dep'],
+        '#required' => TRUE,
+        '#size' => 6,
+        '#multiple' => TRUE,
+        '#element_validate' => [[get_class($this), 'elementValidateFilter']],
+        '#ajax' => TRUE,
+        '#limit_validation_errors' => [],
+      ];
+    }
+    $form['target_bundles'] = [
+      '#type' => 'value',
+      '#value' => [],
+    ];
+
+    if ($entity_type->hasKey('bundle')) {
+      $bundles = array_intersect_key($bundle_options, array_filter((array) $configuration['target_bundles_no_dep']));
+      $form['auto_create_bundle']['#options'] = $bundles;
+      $form['auto_create_bundle']['#access'] = count($bundles) > 1;
+    }
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateConfigurationForm(array &$form, FormStateInterface $form_state) {
+    parent::validateConfigurationForm($form, $form_state);
+
+    // If no checkboxes were checked for 'target_bundles_no_dep', store NULL ("all
+    // bundles are referenceable") rather than empty array ("no bundle is
+    // referenceable" - typically happens when all referenceable bundles have
+    // been deleted).
+    if ($form_state->getValue(['settings', 'handler_settings', 'target_bundles_no_dep']) === []) {
+      $form_state->setValue(['settings', 'handler_settings', 'target_bundles_no_dep'], NULL);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateReferenceableNewEntities(array $entities) {
+    return array_filter($entities, function ($entity) {
+      $target_bundles = $this->getConfiguration()['target_bundles_no_dep'];
+      if (isset($target_bundles)) {
+        return in_array($entity->bundle(), $target_bundles);
+      }
+      return TRUE;
+    });
+  }
+
+  /**
+   * Builds an EntityQuery to get referenceable entities.
+   *
+   * @param string|null $match
+   *   (Optional) Text to match the label against. Defaults to NULL.
+   * @param string $match_operator
+   *   (Optional) The operation the matching should be done with. Defaults
+   *   to "CONTAINS".
+   *
+   * @return \Drupal\Core\Entity\Query\QueryInterface
+   *   The EntityQuery object with the basic conditions and sorting applied to
+   *   it.
+   */
+  protected function buildEntityQuery($match = NULL, $match_operator = 'CONTAINS') {
+    $configuration = $this->getConfiguration();
+    $target_type = $configuration['target_type'];
+    $entity_type = $this->entityManager->getDefinition($target_type);
+
+    $query = $this->entityManager->getStorage($target_type)->getQuery();
+
+    // If 'target_bundles_no_dep' is NULL, all bundles are referenceable, no further
+    // conditions are needed.
+    if (is_array($configuration['target_bundles_no_dep'])) {
+      // If 'target_bundles_no_dep' is an empty array, no bundle is referenceable,
+      // force the query to never return anything and bail out early.
+      if ($configuration['target_bundles_no_dep'] === []) {
+        $query->condition($entity_type->getKey('id'), NULL, '=');
+        return $query;
+      }
+      else {
+        $query->condition($entity_type->getKey('bundle'), $configuration['target_bundles_no_dep'], 'IN');
+      }
+    }
+
+    if (isset($match) && $label_key = $entity_type->getKey('label')) {
+      $query->condition($label_key, $match, $match_operator);
+    }
+
+    // Add entity-access tag.
+    $query->addTag($target_type . '_access');
+
+    // Add the Selection handler for system_query_entity_reference_alter().
+    $query->addTag('entity_reference');
+    $query->addMetaData('entity_reference_selection_handler', $this);
+
+    // Add the sort option.
+    if ($configuration['sort']['field'] !== '_none') {
+      $query->sort($configuration['sort']['field'], $configuration['sort']['direction']);
+    }
+
+    return $query;
+  }
+
+}

--- a/openy.info.yml
+++ b/openy.info.yml
@@ -105,6 +105,7 @@ dependencies:
   - local_fonts
   - css_editor
   # OpenY features.
+  - openy_er
   - openy_svg_formatter
   - openy_media_image
   - openy_media_document

--- a/openy.install
+++ b/openy.install
@@ -889,3 +889,10 @@ function openy_update_8057() {
 function openy_update_8058() {
   \Drupal::service('module_installer')->uninstall(['location_finder']);
 }
+
+/**
+ * Enable OpenY Entity Reference Tweaks.
+ */
+function openy_update_8059() {
+  \Drupal::service('module_installer')->install(['openy_er']);
+}


### PR DESCRIPTION
## Info
In `ymcatwincities:decoupling` branch we have created` OpenY Entity Reference Tweaks` module, and some of openy custom modules depend on hook number where `openy_er` enabled. On every code back porting from `ymcatwincities:8.x-1.x` branch we have broken builds (due to the change in hook_update_N() number). To avoid this issue every time we decide to move this module with hook_update to `ymcatwincities:8.x-1.x` branch.

You can check this issue details this PR - https://github.com/ymcatwincities/openy/pull/1113 

## Steps for review

- [ ] Login as admin
- [ ] Go to /admin/modules
- [ ] Check that OpenY Entity Reference Tweaks module is enabled
