### PR TITLE
[OPENY-62] Featured News Posts decoupling

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_featured_news/openy_prgf_featured_news.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_featured_news/openy_prgf_featured_news.info.yml
@@ -3,6 +3,7 @@ description: 'OpenY Paragraph Featured News Posts'
 package: 'OpenY (Experimental)'
 type: module
 core: 8.x
+version: '8.x-1.0'
 dependencies:
   - field
   - node

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_featured_news/openy_prgf_featured_news.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_featured_news/openy_prgf_featured_news.install
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @file
+ * Update hooks for module.
+ */
+
+/**
+ * Implements hook_uninstall().
+ */
+function openy_prgf_featured_news_uninstall() {
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('paragraph', 'paragraphs_type', 'featured_news');
+}


### PR DESCRIPTION
## Steps for review

- [x] login as admin
- [x] go to /news page or create new landing page
- [x] edit this page
- [x] Add "Featured News Posts" paragraph with several references to news
- [x] Save node and check that you can see this paragraph on page
- [x] go to /admin/modules/uninstall
- [x] uninstall "OpenY Demo Node News" module
- [x] uninstall "OpenY Paragraph Featured News Posts" module
- [x] return to landing page 
- [x] check that "Featured News Posts" paragraph was removed
- [x] go to /admin/structure/paragraphs_type
- [x] check that "Featured News Posts" paragraph not exist in this list
- [x] go to /admin/modules
- [x] install "OpenY Paragraph Featured News Posts" module
- [x] return to landing page
- [x] check that you can add "Featured News Posts" paragraph
- [x] check that all components that related to "OpenY Paragraph Featured News Posts" module was restored and works fine