### PR TITLE
[OPENY-62] Latest news posts decoupling

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_news_latest/openy_prgf_news_latest.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_news_latest/openy_prgf_news_latest.info.yml
@@ -3,6 +3,7 @@ package: 'OpenY (Experimental)'
 description: 'OpenY Latest News Posts.'
 type: module
 core: 8.x
+version: '8.x-1.0'
 dependencies:
   - field
   - node

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_news_latest/openy_prgf_news_latest.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_news_latest/openy_prgf_news_latest.install
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @file
+ * Update hooks for module.
+ */
+
+/**
+ * Implements hook_uninstall().
+ */
+function openy_prgf_news_latest_uninstall() {
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('paragraph', 'paragraphs_type', 'latest_news_posts');
+  \Drupal::configFactory()
+    ->getEditable('views.view.latest_news_posts')
+    ->delete();
+}


### PR DESCRIPTION
## Steps for review

- [x] login as admin
- [x] go to /news page or create new landing page
- [x] edit this page
- [x] Add "Latest news posts" paragraph
- [x] Save node and check that you can see this paragraph on page
- [x] go to /admin/modules/uninstall
- [x] uninstall "OpenY Demo Node News" module
- [x] uninstall "OpenY Latest News Posts" module
- [x] return to landing page 
- [x] check that "Latest news posts" paragraph was removed
- [x] go to /admin/structure/paragraphs_type
- [x] check that "Latest news posts" paragraph not exist in this list
- [x] go to /admin/modules
- [x] install "OpenY Latest News Posts" module
- [x] return to landing page
- [x] check that you can add "Latest News Posts" paragraph
- [x] check that all components that related to "OpenY Latest News Posts" module was restored and works fine

