### PR TITLE
[OPENY-62] Latest news posts (branch) decoupling

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_news_branch/openy_prgf_news_branch.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_news_branch/openy_prgf_news_branch.info.yml
@@ -3,6 +3,7 @@ description: 'OpenY Paragraph Latest News Posts (Branch).'
 package: 'OpenY (Experimental)'
 type: module
 core: 8.x
+version: '8.x-1.0'
 dependencies:
   - field
   - node

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_news_branch/openy_prgf_news_branch.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_news_branch/openy_prgf_news_branch.install
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @file
+ * Update hooks for module.
+ */
+
+/**
+ * Implements hook_uninstall().
+ */
+function openy_prgf_news_branch_uninstall() {
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('paragraph', 'paragraphs_type', 'latest_news_posts_branch');
+  \Drupal::configFactory()
+    ->getEditable('views.view.latest_news_posts_branch')
+    ->delete();
+}


### PR DESCRIPTION
## Steps for review

- [x] login as admin
- [x] go to /admin/content?title=&type=news&status=All&langcode=All
- [x] edit several nodes (select "Downtown YMCA" in Locations field and save)
- [x] go to /locations/downtown-ymca page
- [x] edit this page
- [x] Add "Latest news posts (branch)" paragraph to CONTENT AREA
- [x] Save node and check that you can see this paragraph on page
- [x] go to /admin/modules/uninstall
- [x] uninstall "OpenY Demo Node News" module
- [x] uninstall "OpenY Paragraph Latest News Posts (Branch)" module
- [x] return to /locations/downtown-ymca page
- [x] check that "Latest news posts (branch)" paragraph was removed
- [x] go to /admin/structure/paragraphs_type
- [x] check that "Latest news posts (branch)" paragraph not exist in this list
- [x] go to /admin/modules
- [x] install "OpenY Paragraph Latest News Posts (Branch)" module
- [x] return to /locations/downtown-ymca page
- [x] check that you can add "Latest news posts (branch)" paragraph
- [x] check that all components that related to "OpenY Paragraph Latest News Posts (Branch)" module was restored and works fine
