### PR TITLE
[OPENY-62] Latest news posts (camp) decoupling

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_news_camp/openy_prgf_news_camp.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_news_camp/openy_prgf_news_camp.info.yml
@@ -3,6 +3,7 @@ description: 'OpenY Paragraph Latest News Posts (Camp).'
 package: 'OpenY (Experimental)'
 type: module
 core: 8.x
+version: '8.x-1.0'
 dependencies:
   - field
   - node

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_news_camp/openy_prgf_news_camp.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_news_camp/openy_prgf_news_camp.install
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @file
+ * Update hooks for module.
+ */
+
+/**
+ * Implements hook_uninstall().
+ */
+function openy_prgf_news_camp_uninstall() {
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('paragraph', 'paragraphs_type', 'latest_news_posts_camp');
+  \Drupal::configFactory()
+    ->getEditable('views.view.latest_news_posts_camp')
+    ->delete();
+}


### PR DESCRIPTION
## Steps for review

- [x] login as admin
- [x] go to /admin/content?title=&type=news&status=All&langcode=All
- [x] edit several nodes (select "Camp Colman" in Locations field and save)
- [x] go to /camps/camp-colman page
- [x] edit this page
- [x] Add "Latest news posts (camp)" paragraph to CONTENT AREA
- [x] Save node and check that you can see this paragraph on page
- [x] go to /admin/modules/uninstall
- [x] uninstall "OpenY Demo Node News" module
- [x] uninstall "OpenY Paragraph Latest News Posts (Camp)" module
- [x] return to /camps/camp-colman page
- [x] check that "Latest news posts (camp)" paragraph was removed
- [x] go to /admin/structure/paragraphs_type
- [x] check that "Latest news posts (camp)" paragraph not exist in this list
- [x] go to /admin/modules
- [x] install "OpenY Paragraph Latest News Posts (Camp)" module
- [x] return to /camps/camp-colman page
- [x] check that you can add "Latest news posts (camp)" paragraph
- [x] check that all components that related to "OpenY Paragraph Latest News Posts (Camp)" module was restored and works fine

