### PR TITLE
[OPENY-62] News Posts Listing decoupling

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_news_listing/openy_prgf_news_listing.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_news_listing/openy_prgf_news_listing.info.yml
@@ -3,6 +3,7 @@ package: 'OpenY (Experimental)'
 description: 'OpenY News Posts listing.'
 type: module
 core: 8.x
+version: '8.x-1.0'
 dependencies:
   - field
   - node

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_news_listing/openy_prgf_news_listing.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_news_listing/openy_prgf_news_listing.install
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @file
+ * Update hooks for module.
+ */
+
+/**
+ * Implements hook_uninstall().
+ */
+function openy_prgf_news_listing_uninstall() {
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('paragraph', 'paragraphs_type', 'news_posts_listing');
+  \Drupal::configFactory()
+    ->getEditable('views.view.listing_news_posts')
+    ->delete();
+}


### PR DESCRIPTION
## Steps for review

- [x] login as admin
- [x] go to /news
- [x] check that you can see "Latest News & Updates" block
- [x] edit this page
- [x] check that you can see "News Posts Listing" paragraph in CONTENT AREA
- [x] go to /admin/modules/uninstall
- [x] uninstall "OpenY Demo Node News" module
- [x] uninstall "OpenY News Posts listing" module
- [x] return to /news page
- [x] check that "News Posts Listing" paragraph was removed
- [x] go to /admin/structure/paragraphs_type
- [x] check that "News Posts Listing" paragraph not exist in this list
- [x] go to /admin/modules
- [x] install "OpenY News Posts listing" module
- [x] return to /news page
- [x] check that you can add "News Posts Listing" paragraph
- [x] check that all components that related to "OpenY News Posts listing" module was restored and works fine

