### PR TITLE
[OPENY-62] News Post decoupling

### DIFF
--- a/modules/openy_features/openy_node/modules/openy_node_news/openy_node_news.info.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_news/openy_node_news.info.yml
@@ -3,6 +3,7 @@ package: 'OpenY (Experimental)'
 description: 'OpenY Node News.'
 type: module
 core: 8.x
+version: '8.x-1.0'
 dependencies:
   - datalayer
   - entity_browser

--- a/modules/openy_features/openy_node/modules/openy_node_news/openy_node_news.install
+++ b/modules/openy_features/openy_node/modules/openy_node_news/openy_node_news.install
@@ -6,6 +6,28 @@
  */
 
 /**
+ * Implements hook_uninstall().
+ */
+function openy_node_news_uninstall() {
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('node', 'node_type', 'news');
+  $configFactory = \Drupal::configFactory();
+  $configs = [
+    'core.entity_view_display.media.image.node_news',
+    'core.entity_view_display.media.image.node_news_teaser',
+    'core.entity_view_mode.media.node_news',
+    'core.entity_view_mode.media.node_news_teaser',
+    'simple_sitemap.bundle_settings.node.news',
+    'pathauto.pattern.news',
+    'image.style.node_news',
+    'image.style.node_news_teaser',
+  ];
+  foreach ($configs as $config) {
+    $configFactory->getEditable($config)->delete();
+  }
+}
+
+/**
  * Update config for the image style after focal point support was added.
  */
 function openy_node_news_update_8001() {


### PR DESCRIPTION
## Note: Test and merge this after this PR's:
- https://github.com/ymcatwincities/openy/pull/1119
- https://github.com/ymcatwincities/openy/pull/1120
- https://github.com/ymcatwincities/openy/pull/1121
- https://github.com/ymcatwincities/openy/pull/1123
- https://github.com/ymcatwincities/openy/pull/1124

## Steps for review

- [x] login as admin
- [x] go to /admin/modules/uninstall
- [x] uninstall "OpenY Demo Node News", "OpenY Demo Taxonomy News Category" modules
- [x] uninstall all "OpenY News *" paragraphs modules
- [x] uninstall "OpenY Node News" module
- [x] go to /admin/structure/types
- [x] check that news not exist in this list
- [x] go to /admin/content
- [x] check that news content was removed
- [x] go to /admin/structure/media/manage/image/display
- [x] check that node_news and node_news_teaser not exist in this list
- [x] go to /admin/config/media/image-styles
- [x] check that node_news and node_news_teaser not exist in this list
- [x] install "OpenY Node News" module
- [x] check that the points above was restored
- [x] go to /node/add/news
- [x] check that all components that related to "OpenY Node News" module was restored and works fine
