### PR TITLE
[OPENY-62] News category decoupling

### DIFF
--- a/modules/openy_features/openy_taxonomy/modules/openy_txnm_news_category/openy_txnm_news_category.info.yml
+++ b/modules/openy_features/openy_taxonomy/modules/openy_txnm_news_category/openy_txnm_news_category.info.yml
@@ -3,6 +3,7 @@ description: 'OpenY Taxonomy News Category.'
 package: 'OpenY (Experimental)'
 type: module
 core: 8.x
+version: '8.x-1.0'
 dependencies:
   - ctools
   - entity_reference_revisions

--- a/modules/openy_features/openy_taxonomy/modules/openy_txnm_news_category/openy_txnm_news_category.install
+++ b/modules/openy_features/openy_taxonomy/modules/openy_txnm_news_category/openy_txnm_news_category.install
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @file
+ * Update hooks for module.
+ */
+
+/**
+ * Implements hook_uninstall().
+ */
+function openy_txnm_news_category_uninstall() {
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('taxonomy_term', 'taxonomy_vocabulary', 'news_category', 'vid');
+  \Drupal::configFactory()
+    ->getEditable('pathauto.pattern._news_category_')
+    ->delete();
+}


### PR DESCRIPTION
## Note: Test and merge this after PR's merge:
- https://github.com/ymcatwincities/openy/pull/1119
- https://github.com/ymcatwincities/openy/pull/1120
- https://github.com/ymcatwincities/openy/pull/1121
- https://github.com/ymcatwincities/openy/pull/1123
- https://github.com/ymcatwincities/openy/pull/1124
- https://github.com/ymcatwincities/openy/pull/1125

## Steps for review

- [x] login as admin
- [x] go to /admin/modules/uninstall
- [x] uninstall "OpenY Demo Node News", "OpenY Demo Taxonomy News Category" modules
- [x] uninstall all "OpenY News *" paragraphs modules
- [x] uninstall "OpenY Node News" module
- [x] uninstall "OpenY Taxonomy News Category" module
- [x] go to /admin/structure/taxonomy
- [x] check that News Category not exist in this list
- [x] go to /admin/modules
- [x] install "OpenY Taxonomy News Category" module
- [x] go to /admin/structure/taxonomy
- [x] check that News Category exist in this list
- [x] go to /admin/structure/taxonomy/manage/news_category/add
- [x] check that all components that related to "OpenY Taxonomy News Category" module was restored and works fine
