### PR TITLE
[OPENY-64] Grid columns & Grid Content decoupling

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_grid_content/openy_prgf_grid_content.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_grid_content/openy_prgf_grid_content.info.yml
@@ -3,6 +3,7 @@ description: 'OpenY Paragraph Grid Content.'
 type: module
 core: 8.x
 package: OpenY
+version: '8.x-1.0'
 dependencies:
   - entity_browser
   - entity_reference_revisions

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_grid_content/openy_prgf_grid_content.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_grid_content/openy_prgf_grid_content.install
@@ -6,6 +6,15 @@
  */
 
 /**
+ * Implements hook_uninstall().
+ */
+function openy_prgf_grid_content_uninstall() {
+  $modules_manager = \Drupal::service('openy.modules_manager');
+  $modules_manager->removeEntityBundle('paragraph', 'paragraphs_type', 'grid_columns');
+  $modules_manager->removeEntityBundle('paragraph', 'paragraphs_type', 'grid_content');
+}
+
+/**
  * Implements hook_update_dependencies().
  */
 function openy_prgf_grid_content_dependencies() {
@@ -25,7 +34,7 @@ function openy_prgf_grid_content_update_8001() {
   $config_dir = drupal_get_path('module', 'openy_prgf_grid_content') . '/config/install/';
   // Update multiple configurations.
   $configs = [
-    'core.entity_form_display.paragraph.grid_columns.default.yml' =>[
+    'core.entity_form_display.paragraph.grid_columns.default.yml' => [
       'content.field_prgf_clm_class.settings.placeholder',
       'content.field_prgf_clm_headline.settings.placeholder',
       'content.field_prgf_clm_link.settings.placeholder_url',


### PR DESCRIPTION
## Steps for review

- [x] login as admin
- [x] go to front page
- [x] check that in Content Area you can see "Grid Content" paragraph ("Volunteers needed!" and "We Appreciate Your Support" blocks)
- [x] edit this page
- [x] check that in Content Area you can see "Grid Content" paragraph
- [x] go to /admin/modules/uninstall
- [x] uninstall "OpenY Paragraph Grid Content" module
- [x] return to front page
- [x] check that "Grid Content" paragraph not exist on this page
- [x] go to /admin/structure/paragraphs_type
- [x] check that "Grid Content" paragraph not exist in this list
- [x] go to /admin/modules
- [x] install "OpenY Paragraph Grid Content" module
- [x] go to front page and edit this page
- [x] add "Grid Content" paragraph to content area
- [x] check that all components that related to "OpenY Taxonomy News Category" module was restored and works fine
