### PR TITLE
fix alert removal in slick carousel

### DIFF
--- a/modules/openy_features/openy_node/modules/openy_node_alert/js/openy_node_alert.js
+++ b/modules/openy_features/openy_node/modules/openy_node_alert/js/openy_node_alert.js
@@ -33,7 +33,7 @@
         // Remove dismissed alerts.
         if ($.inArray(nid, dismissed) != -1) {
           if (slick.length > 0) {
-            slick.slick('slickRemove', self.parents('.slick__slide').eq(0).index());
+            slick.slick('slickRemove', self.parents('.slick__slide').eq(0).index()-1);
           }
           else {
             self.remove();
@@ -41,7 +41,11 @@
         }
         $('.site-alert__dismiss', self).on('click', function () {
           if (slick.length > 0) {
-            slick.slick('slickRemove', self.parents('.slick__slide').eq(0).index());
+            var slickCheck = slick.slick('slickRemove', self.parents('.slick__slide').eq(0).index()-1);
+            if(!slickCheck) {
+              self.remove();
+              slick.parents('.slick-track').prevObject.remove();
+            }
           }
           else {
             self.remove();

--- a/modules/openy_features/openy_node/modules/openy_node_alert/js/openy_node_alert.js
+++ b/modules/openy_features/openy_node/modules/openy_node_alert/js/openy_node_alert.js
@@ -32,8 +32,13 @@
         var slick = self.parents('.slick__slider').first();
         // Remove dismissed alerts.
         if ($.inArray(nid, dismissed) != -1) {
-          if (slick.length > 0) {
-            slick.slick('slickRemove', self.parents('.slick__slide').eq(0).index()-1);
+          var index = self.parents('.slick__slide').eq(0).index();
+          if (slick.length > 0 && index > 0) {
+            var slickCheck = slick.slick('slickRemove', index -1);
+            if(!slickCheck) {
+              self.remove();
+              slick.parents('.slick-track').prevObject.remove();
+            }
           }
           else {
             self.remove();


### PR DESCRIPTION
I noticed that the alerts were not clearing from the UI when they were in a slick carousel, the cookies were being saved so that alerts were not show on subsequent page loads. This should fix the alerts so that they are removed appropriately from the slick carousel.

## Steps for review

- [x] Create multiple alerts.
- [x] Dismiss an alert.
- [x] Corresponding alert should be removed from the UI.

## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/ci-errors.png" width="200" alt="CI code sniffer errors">
- [ ] All tests are running and there are no failed tests reported by CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/behat.png" width="200" alt="Behat test results">
- [x] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [x] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [x] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [x] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [x] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

[Drupal.org Issue](https://www.drupal.org/project/openy/issues/2982423)


