### PR TITLE
[OPENY-72] Location finder paragraphs decoupling

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_loc_finder/openy_prgf_loc_finder.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_loc_finder/openy_prgf_loc_finder.info.yml
@@ -3,6 +3,7 @@ description: 'OpenY Paragraph Location Finder.'
 type: module
 core: 8.x
 package: OpenY
+version: '8.x-1.0'
 dependencies:
   - field
   - node

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_loc_finder/openy_prgf_loc_finder.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_loc_finder/openy_prgf_loc_finder.install
@@ -6,6 +6,18 @@
  */
 
 /**
+ * Implements hook_uninstall().
+ */
+function openy_prgf_loc_finder_uninstall() {
+  $modules_manager = \Drupal::service('openy.modules_manager');
+  $modules_manager->removeEntityBundle('paragraph', 'paragraphs_type', 'prgf_location_finder_filters');
+  $modules_manager->removeEntityBundle('paragraph', 'paragraphs_type', 'prgf_location_finder');
+  \Drupal::configFactory()
+    ->getEditable('views.view.locations')
+    ->delete();
+}
+
+/**
  * Add new field to Location Finder Filters paragraph.
  */
 function openy_prgf_loc_finder_update_8001() {


### PR DESCRIPTION
## Steps for review

- [x] login as admin
- [x] go to /locations page
- [x] check that you can see location filter block and locations
- [x] go to /admin/modules/uninstall
- [x] uninstall "OpenY Paragraph Location Finder" modules
- [x] go to /admin/structure/paragraphs_type
- [x] check that "Location finder filters" and "Location finder" paragraphs not exist in this list
- [x] return to /locations page
- [x] check that "Location finder filters" and "Location finder" paragraphs was removed from this page
- [x] go to /admin/modules
- [x] install "OpenY Paragraph Location Finder" module
- [x] return to /locations page
- [x] add "Location finder filters" and "Location finder" paragraphs
- [x] check that all components that related to "OpenY Paragraph Location Finder" module was restored and works fine