### PR TITLE
[OPENY-72] openy_addthis decoupling

### DIFF
--- a/modules/custom/openy_addthis/openy_addthis.info.yml
+++ b/modules/custom/openy_addthis/openy_addthis.info.yml
@@ -3,3 +3,4 @@ type: module
 description: Openy addThis
 core: 8.x
 package: OpenY
+version: '8.x-1.0'

--- a/modules/custom/openy_addthis/openy_addthis.install
+++ b/modules/custom/openy_addthis/openy_addthis.install
@@ -17,6 +17,12 @@ function openy_addthis_install() {
  * Implements hook_uninstall().
  */
 function openy_addthis_uninstall() {
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('paragraph', 'paragraphs_type', 'addthis');
+  \Drupal::configFactory()
+    ->getEditable('openy_addthis.settings')
+    ->delete();
+
   // Remove our base field from the schema.
   \Drupal::service('entity.definition_update_manager')->applyUpdates();
 }

--- a/modules/custom/openy_addthis/openy_addthis.routing.yml
+++ b/modules/custom/openy_addthis/openy_addthis.routing.yml
@@ -5,3 +5,11 @@ openy_addthis.settings:
     _title: 'Openy addThis'
   requirements:
     _permission: 'administer site configuration'
+
+openy_addthis.prepare_module_uninstall:
+  path: '/admin/modules/uninstall/openy-addthis'
+  defaults:
+    _form: '\Drupal\openy_addthis\Form\PrepareUninstallForm'
+    _title: 'Openy addThis prepare for uninstall'
+  requirements:
+    _permission: 'administer modules'

--- a/modules/custom/openy_addthis/openy_addthis.services.yml
+++ b/modules/custom/openy_addthis/openy_addthis.services.yml
@@ -1,0 +1,6 @@
+services:
+  openy_addthis_uninstall_validator:
+    class: Drupal\openy_addthis\Entity\AddThisUninstallValidator
+    tags:
+      - { name: module_install.uninstall_validator }
+    arguments: ['@entity_type.manager', '@string_translation']

--- a/modules/custom/openy_addthis/src/Entity/AddThisUninstallValidator.php
+++ b/modules/custom/openy_addthis/src/Entity/AddThisUninstallValidator.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Drupal\openy_addthis\Entity;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\FieldableEntityStorageInterface;
+use Drupal\Core\Entity\Sql\SqlContentEntityStorage;
+use Drupal\Core\Extension\ModuleUninstallValidatorInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\Core\StringTranslation\TranslationInterface;
+use Drupal\Core\Url;
+
+/**
+ * Validates module uninstall readiness based on existing content entities.
+ */
+class AddThisUninstallValidator implements ModuleUninstallValidatorInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The entity manager.
+   *
+   * @var \Drupal\Core\Entity\EntityManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs a new ContentUninstallValidator.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_manager
+   *   The entity manager.
+   * @param \Drupal\Core\StringTranslation\TranslationInterface $string_translation
+   *   The string translation service.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_manager, TranslationInterface $string_translation) {
+    $this->entityTypeManager = $entity_manager;
+    $this->stringTranslation = $string_translation;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validate($module) {
+    $entity_types = $this->entityTypeManager->getDefinitions();
+    $reasons = [];
+    foreach ($entity_types as $entity_type_id => $entity_type) {
+      $storage = $this->entityTypeManager->getStorage($entity_type_id);
+
+      if ($storage instanceof SqlContentEntityStorage) {
+        foreach ($storage->getFieldStorageDefinitions() as $storage_definition) {
+          if (
+            $storage_definition->getProvider() == $module
+            && $storage instanceof FieldableEntityStorageInterface
+            && $storage->countFieldData($storage_definition, TRUE)
+          ) {
+
+            $reasons[] = $this->t('<a href="@url">Remove field values</a>: @field-name on entity type @entity_type.', [
+              '@field-name' => $storage_definition->getName(),
+              '@entity_type' => $entity_type->getLabel(),
+              '@url' => Url::fromRoute(
+                'openy_addthis.prepare_module_uninstall'
+              )->toString(),
+            ]);
+          }
+        }
+      }
+    }
+    return $reasons;
+  }
+
+}

--- a/modules/custom/openy_addthis/src/Form/PrepareUninstallForm.php
+++ b/modules/custom/openy_addthis/src/Form/PrepareUninstallForm.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Drupal\openy_addthis\Form;
+
+use Drupal\Core\Database\Database;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\ConfirmFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides a form removing addthis field data before module uninstall.
+ */
+class PrepareUninstallForm extends ConfirmFormBase {
+
+  /**
+   * The entity_type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * Constructs a new PrepareUninstallForm.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity manager.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+    $this->entityTypeManager = $entity_type_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'openy_addthis.prepare_module_uninstall';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getQuestion() {
+    return $this->t(
+      'Are you sure you want to delete all addthis field values?'
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDescription() {
+    return $this->t('This action cannot be undone.<br />Make a backup of your database if you want to be able to restore these items.');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getConfirmText() {
+    return $this->t('Delete all addthis field values');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCancelUrl() {
+    return Url::fromRoute('system.modules_uninstall');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $tables_to_update = [];
+
+    foreach ($this->entityTypeManager->getDefinitions() as $entity_type) {
+      if ($entity_type->id() == 'node') {
+        $tables_to_update[] = $entity_type->getDataTable();
+        $tables_to_update[] = $entity_type->getRevisionDataTable();
+      }
+    }
+
+    $db_connection = Database::getConnection();
+
+    foreach ($tables_to_update as $table) {
+      if ($table && $db_connection->schema()->fieldExists($table, 'addthis')) {
+        $db_connection->update($table)
+          ->fields(['addthis' => NULL])
+          ->execute();
+      }
+    }
+    drupal_set_message(t('All values have been deleted.'));
+
+    $form_state->setRedirect('system.modules_uninstall');
+  }
+
+}

--- a/modules/custom/openy_addthis/src/Form/PrepareUninstallForm.php
+++ b/modules/custom/openy_addthis/src/Form/PrepareUninstallForm.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\openy_addthis\Form;
 
-use Drupal\Core\Database\Database;
+use Drupal\Core\Database\Connection;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\ConfirmFormBase;
 use Drupal\Core\Form\FormStateInterface;
@@ -22,11 +22,19 @@ class PrepareUninstallForm extends ConfirmFormBase {
   protected $entityTypeManager;
 
   /**
+   * The database connection.
+   *
+   * @var \Drupal\Core\Database\Connection
+   */
+  protected $connection;
+
+  /**
    * {@inheritdoc}
    */
   public static function create(ContainerInterface $container) {
     return new static(
-      $container->get('entity_type.manager')
+      $container->get('entity_type.manager'),
+      $container->get('database')
     );
   }
 
@@ -35,9 +43,12 @@ class PrepareUninstallForm extends ConfirmFormBase {
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
    *   The entity manager.
+   * @param \Drupal\Core\Database\Connection $database
+   *   Database connection.
    */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager) {
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, Connection $database) {
     $this->entityTypeManager = $entity_type_manager;
+    $this->connection = $database;
   }
 
   /**
@@ -90,11 +101,9 @@ class PrepareUninstallForm extends ConfirmFormBase {
       }
     }
 
-    $db_connection = Database::getConnection();
-
     foreach ($tables_to_update as $table) {
-      if ($table && $db_connection->schema()->fieldExists($table, 'addthis')) {
-        $db_connection->update($table)
+      if ($table && $this->connection->schema()->fieldExists($table, 'addthis')) {
+        $this->connection->update($table)
           ->fields(['addthis' => NULL])
           ->execute();
       }


### PR DESCRIPTION
## Steps for review

- [x] Login as admin
- [x] go to any blog or news page
- [x] check that you can see social sharing block
- [x] create new landing page with "Social share icons" paragraph
- [x] check that you can see social sharing block
- [x] go to /admin/modules/uninstall
- [x] uninstall "OpenY Demo AddThis" module
- [x] check that you can see "Remove field values: addthis on entity type Content." message with link for "Openy addThis" module
![uninstall-addthis](https://user-images.githubusercontent.com/13733670/42166682-6cfde75e-7e14-11e8-97f7-2d23449428b4.png)
- [x] Click on link "Remove field values"
- [x] Press "Delete all addthis field values" button on form
- [x] After this you will be redirected back to  /admin/modules/uninstall
- [x] check that now you can uninstall "Openy addThis" module
- [x] uninstall "OpenY AddThis" module
- [x] go to /admin/structure/paragraphs_type
- [x] check that  "Social share icons" paragraph not exist in this list
- [x] go to any blog or news page
- [x] check that  "Social share icons" not exist in this pages
- [x] also check created landing page with this paragraph
- [x] go to /admin/modules
- [x] install "OpenY AddThis" and  "OpenY Demo AddThis"  modules (Demo module contain openy_addthis.settings.public_id)
- [x] go to any blog page and resave node - check that you can see  "Social share icons" on blog page
- [x] check that all components related to "OpenY AddThis" module was restored and works fine