### PR TITLE
[OPENY-76] Event paragraphs decoupling

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_event_latest/openy_prgf_event_latest.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_event_latest/openy_prgf_event_latest.info.yml
@@ -3,6 +3,7 @@ description: 'OpenY Paragraph Latest Event Posts'
 type: module
 core: 8.x
 package: 'OpenY'
+version: '8.x-1.0'
 dependencies:
   - datalayer
   - field

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_event_latest/openy_prgf_event_latest.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_event_latest/openy_prgf_event_latest.install
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @file
+ * Module install file.
+ */
+
+/**
+ * Implements hook_uninstall().
+ */
+function openy_prgf_event_latest_uninstall() {
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('paragraph', 'paragraphs_type', 'upcoming_events');
+  \Drupal::configFactory()
+    ->getEditable('views.view.latest_event_posts')
+    ->delete();
+}

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_event_listing/openy_prgf_event_listing.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_event_listing/openy_prgf_event_listing.info.yml
@@ -3,6 +3,7 @@ description: 'OpenY Paragraph Event Posts Listing.'
 type: module
 core: 8.x
 package: 'OpenY'
+version: '8.x-1.0'
 dependencies:
   - datalayer
   - field

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_event_listing/openy_prgf_event_listing.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_event_listing/openy_prgf_event_listing.install
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @file
+ * Module install file.
+ */
+
+/**
+ * Implements hook_uninstall().
+ */
+function openy_prgf_event_listing_uninstall() {
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('paragraph', 'paragraphs_type', 'event_posts_listing');
+  \Drupal::configFactory()
+    ->getEditable('views.view.listing_event_posts')
+    ->delete();
+}


### PR DESCRIPTION
## Steps for review

- [x] login as admin
- [x] go to /events and edit this page
- [x] check that you can see "Event Posts Listing" paragraph in content area
- [x] add "Upcoming Events" paragraph to content area and save node
- [x] go to /admin/modules/uninstall
- [x] uninstall "OpenY Demo Node Event" module
- [x] uninstall "OpenY Paragraph Latest Event Posts" module
- [x] return to /events page
- [x] check that "Upcoming Events" paragraph was removed from this page
- [x] go to /admin/structure/paragraphs_type
- [x] check that "Upcoming Events" paragraph not exist in this list
- [x] go to /admin/modules/uninstall
- [x] uninstall "OpenY Paragraph Event Posts Listing" module
- [x] return to /events page
- [x] check that "Event Posts Listing" paragraph was removed from this page
- [x] go to /admin/structure/paragraphs_type
- [x] check that "Event Posts Listing" paragraph not exist in this list
- [x] go to /admin/modules
- [x] install "OpenY Paragraph Latest Event Posts" and "OpenY Paragraph Event Posts Listing" modules
- [x] return to /events page
- [x] add "Upcoming Events" and "Event Posts Listing" paragraphs to content area
- [x] check that all components that related to this modules was restored and works fine

