### PR TITLE
[OPENY-73] Featured Highlights block decoupling

### DIFF
--- a/modules/openy_features/openy_block/modules/openy_block_featured_highlights/openy_block_featured_highlights.info.yml
+++ b/modules/openy_features/openy_block/modules/openy_block_featured_highlights/openy_block_featured_highlights.info.yml
@@ -3,6 +3,7 @@ description: 'Implements custom block type with Featured Highlights content.'
 type: module
 core: 8.x
 package: OpenY
+version: '8.x-1.0'
 dependencies:
   - block_content
   - content_moderation

--- a/modules/openy_features/openy_block/modules/openy_block_featured_highlights/openy_block_featured_highlights.install
+++ b/modules/openy_features/openy_block/modules/openy_block_featured_highlights/openy_block_featured_highlights.install
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @file
+ * Module install file.
+ */
+
+/**
+ * Implements hook_uninstall().
+ */
+function openy_block_featured_highlights_uninstall() {
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('block_content', 'block_content_type', 'featured_highlights_block');
+}


### PR DESCRIPTION
## Steps for review

- [x] login as admin
- [x] go to /admin/modules
- [x] Enable "OpenY Featured Highlights block" module
- [x] go to /admin/structure/block/block-content
- [x] create new Featured Highlights block
- [x] go to /admin/modules/uninstall
- [x] uninstall "OpenY Featured Highlights block" module
- [x] return to /admin/structure/block/block-content page
- [x] check that created block was removed
- [x] go to /admin/structure/block/block-content/types
- [x] check that "Featured Highlights Block" not exist in this list
- [x] go to /admin/modules
- [x] Enable "OpenY Featured Highlights block" module
- [x] check that all components that related to this module was restored and works fine

