### PR TITLE
[OPENY-67] Membership CT decoupling

### DIFF
--- a/modules/custom/openy_calc/openy_calc.info.yml
+++ b/modules/custom/openy_calc/openy_calc.info.yml
@@ -3,8 +3,10 @@ type: module
 description: OpenY membership calculator.
 core: 8.x
 package: OpenY
+version: '8.x-1.0'
 dependencies:
   - openy_map
   - openy_socrates
   - openy_mappings
+  - openy_node_mbrshp
   - daxko

--- a/modules/openy_features/openy_node/modules/openy_node_mbrshp/openy_node_mbrshp.info.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_mbrshp/openy_node_mbrshp.info.yml
@@ -3,6 +3,7 @@ description: 'OpenY Membership.'
 type: module
 core: 8.x
 package: OpenY
+version: '8.x-1.0'
 dependencies:
   - entity_browser
   - entity_reference_revisions

--- a/modules/openy_features/openy_node/modules/openy_node_mbrshp/openy_node_mbrshp.install
+++ b/modules/openy_features/openy_node/modules/openy_node_mbrshp/openy_node_mbrshp.install
@@ -6,6 +6,25 @@
  */
 
 /**
+ * Implements hook_uninstall().
+ */
+function openy_node_mbrshp_uninstall() {
+  $modules_manager = \Drupal::service('openy.modules_manager');
+  $modules_manager->removeEntityBundle('node', 'node_type', 'membership');
+  $modules_manager->removeEntityBundle('paragraph', 'paragraphs_type', 'membership_info');
+
+  $configFactory = \Drupal::configFactory();
+  $configs = [
+    'pathauto.pattern.membership',
+    'rabbit_hole.behavior_settings.node_type_membership',
+    'metatag.metatag_defaults.node__membership',
+  ];
+  foreach ($configs as $config) {
+    $configFactory->getEditable($config)->delete();
+  }
+}
+
+/**
  * Implements hook_update_dependencies().
  */
 function openy_node_mbrshp_update_dependencies() {
@@ -54,7 +73,7 @@ function openy_node_mbrshp_update_8002() {
  */
 function openy_node_mbrshp_update_8003() {
   $config_dir = drupal_get_path('module', 'openy_node_mbrshp') . '/config/install/';
-  // Import new configuration
+  // Import new configuration.
   $config_importer = \Drupal::service('openy_upgrade_tool.importer');
   $config_importer->setDirectory($config_dir);
   $config_importer->importConfigs([
@@ -107,7 +126,7 @@ function openy_node_mbrshp_update_8006() {
   $config_dir = drupal_get_path('module', 'openy_node_mbrshp') . '/config/install/';
   // Update multiple configurations.
   $configs = [
-    'field.field.node.membership.field_mbrshp_description' =>[
+    'field.field.node.membership.field_mbrshp_description' => [
       'description',
     ],
     'field.field.node.membership.field_mbrshp_image' => [
@@ -161,7 +180,7 @@ function openy_node_mbrshp_update_8008() {
   $config_dir = drupal_get_path('module', 'openy_node_mbrshp') . '/config/install/';
   // Update multiple configurations.
   $configs = [
-    'core.entity_form_display.node.membership.default' =>[
+    'core.entity_form_display.node.membership.default' => [
       'dependencies.module',
       'content',
     ],

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_mbrshp_calc/openy_prgf_mbrshp_calc.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_mbrshp_calc/openy_prgf_mbrshp_calc.install
@@ -22,7 +22,6 @@ function openy_prgf_mbrshp_calc_uninstall() {
     'core.entity_view_mode.media.calc_summary',
     'core.entity_view_mode.node.calc_preview',
     'core.entity_view_mode.node.calc_summary',
-    'core.entity_view_mode.paragraph.calc_preview',
     'image.style.node_mbrshp_calc_preview',
     'image.style.node_mbrshp_calc_summary',
   ];


### PR DESCRIPTION
## Please note:
`core.entity_view_mode.paragraph.calc_preview` exist in `core.entity_view_display.paragraph.membership_info.calc_preview.yml` dependencies, so on  membership_info paragraph deleting we got error because this config was removed in `openy_prgf_mbrshp_calc_uninstall`. Solution -  leave this config on `openy_prgf_mbrshp_calc` module uninstall.

## Steps for review

- [x] login as admin
- [x] go to /admin/content?title=&type=membership&status=All&langcode=All
- [x] Check that some membership nodes exist in this list
- [x] go to /admin/modules/uninstall
- [x] uninstall "OpenY Paragraph Membership Calculator", "OpenY Membership Calculator" and "OpenY Demo Node Membership" modules 
- [x] uninstall "OpenY Membership" module
- [x] return to /admin/content?title=&type=membership&status=All&langcode=All
- [x] check that memberships nodes was removed
- [x] go to /admin/structure/types
- [x] check that "Membership" not exist in this list
- [x] go to /admin/structure/paragraphs_type
- [x] check that "Membership info" not exist in this list
- [x] go to /admin/modules
- [x] Enable "OpenY Membership" module
- [x] check that all components that related to this module was restored and works fine