### PR TITLE
[OPENY-66] Branch CT decoupling

### DIFF
--- a/modules/openy_features/openy_location/modules/openy_loc_branch/openy_loc_branch.info.yml
+++ b/modules/openy_features/openy_location/modules/openy_loc_branch/openy_loc_branch.info.yml
@@ -3,6 +3,7 @@ description: 'OpenY Branch.'
 type: module
 core: 8.x
 package: OpenY
+version: '8.x-1.0'
 dependencies:
   - address
   - datalayer

--- a/modules/openy_features/openy_location/modules/openy_loc_branch/openy_loc_branch.install
+++ b/modules/openy_features/openy_location/modules/openy_loc_branch/openy_loc_branch.install
@@ -6,6 +6,25 @@
  */
 
 /**
+ * Implements hook_uninstall().
+ */
+function openy_loc_branch_uninstall() {
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('node', 'node_type', 'branch');
+
+  $configFactory = \Drupal::configFactory();
+  $configs = [
+    'pathauto.pattern.branch',
+    'rabbit_hole.behavior_settings.node_type_branch',
+    'simple_sitemap.bundle_settings.node.branch',
+    'tour.tour.openy-branch-add',
+  ];
+  foreach ($configs as $config) {
+    $configFactory->getEditable($config)->delete();
+  }
+}
+
+/**
  * Implements hook_update_dependencies().
  */
 function openy_loc_branch_update_dependencies() {


### PR DESCRIPTION
## Note:

We can't do normal testing of this PR because "OpenY Branch" exist in dependencies almost in all OpenY modules and some of them can't be uninstalled.  

```
OpenY Branch.
Machine name: openy_loc_branch
Version: 8.x-1.0
Required by: 
OpenY Membership
OpenY Facility
OpenY Node Blog
OpenY Node Event
OpenY Session
OpenY Session instance
OpenY Schedules
OpenY Paragraph Schedule Search
OpenY Paragraph Featured Blog Posts
OpenY Paragraph Class Sessions
OpenY Paragraph Latest Blog Posts
OpenY Paragraph Latest Blog Posts (Camp)
OpenY Paragraph Latest Blog Posts (Branch)
OpenY Paragraph Blog Posts Listing
OpenY Paragraph Location Finder
OpenY Paragraph Amenities
OpenY Paragraph Location By Amenities
OpenY Membership Calculator
OpenY Paragraph Membership Calculator
OpenY Paragraph Latest Event Posts
OpenY Paragraph Event Posts Listing
OpenY Branch Selector
OpenY Demo Node Landing Page
OpenY Demo Node Alert
OpenY Demo Taxonomy Blog Category
OpenY Demo Node Blog
OpenY Demo Node Camp
OpenY Demo Node Event
OpenY Demo Taxonomy Facility Type
OpenY Demo Node Facility
OpenY Demo Node Membership
OpenY Paragraph Latest News Posts (Branch)
OpenY Demo Node News
OpenY Demo Node Sessions
```

So I suggest just check code from hook_uninstall with devel help.

## Steps for review

- [x] login as admin
- [x] go to /admin/content?title=&type=branch&status=All&langcode=All
- [x] Check that some branch nodes exist in this list
- [x] go to /admin/modules
- [x] install devel module
- [x] go to /devel/php
- [x] run code from hook_uninstall
- [x] return to /admin/content?title=&type=branch&status=All&langcode=All
- [x] check that branch nodes was removed
- [x] go to /admin/structure/types
- [x] check that "Branch" not exist in this list