### PR TITLE
[OPENY-68] Amenities & Color taxonomy decoupling

### DIFF
--- a/modules/openy_features/openy_taxonomy/modules/openy_txnm_amenities/openy_txnm_amenities.info.yml
+++ b/modules/openy_features/openy_taxonomy/modules/openy_txnm_amenities/openy_txnm_amenities.info.yml
@@ -1,6 +1,7 @@
 name: 'OpenY Taxonomy Amenities'
 description: 'OpenY Taxonomy Amenities.'
 package: OpenY
+version: '8.x-1.0'
 type: module
 core: 8.x
 dependencies:

--- a/modules/openy_features/openy_taxonomy/modules/openy_txnm_amenities/openy_txnm_amenities.install
+++ b/modules/openy_features/openy_taxonomy/modules/openy_txnm_amenities/openy_txnm_amenities.install
@@ -6,6 +6,22 @@
  */
 
 /**
+ * Implements hook_uninstall().
+ */
+function openy_txnm_amenities_uninstall() {
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('taxonomy_term', 'taxonomy_vocabulary', 'amenities', 'vid');
+  $configFactory = \Drupal::configFactory();
+  $configs = [
+    'pathauto.pattern.amenities',
+    'core.entity_view_mode.taxonomy_term.icon',
+  ];
+  foreach ($configs as $config) {
+    $configFactory->getEditable($config)->delete();
+  }
+}
+
+/**
  * Update configs for Drupal Core upgrade.
  */
 function openy_txnm_amenities_update_8001() {

--- a/modules/openy_features/openy_taxonomy/modules/openy_txnm_color/openy_txnm_color.info.yml
+++ b/modules/openy_features/openy_taxonomy/modules/openy_txnm_color/openy_txnm_color.info.yml
@@ -3,6 +3,7 @@ description: 'OpenY Taxonomy Color.'
 type: module
 core: 8.x
 package: OpenY
+version: '8.x-1.0'
 dependencies:
   - field
   - jquery_colorpicker

--- a/modules/openy_features/openy_taxonomy/modules/openy_txnm_color/openy_txnm_color.install
+++ b/modules/openy_features/openy_taxonomy/modules/openy_txnm_color/openy_txnm_color.install
@@ -6,6 +6,22 @@
  */
 
 /**
+ * Implements hook_uninstall().
+ */
+function openy_txnm_color_uninstall() {
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('taxonomy_term', 'taxonomy_vocabulary', 'color', 'vid');
+  $configFactory = \Drupal::configFactory();
+  $configs = [
+    'rabbit_hole.behavior_settings.taxonomy_vocabulary_color',
+    'core.entity_view_mode.taxonomy_term.color',
+  ];
+  foreach ($configs as $config) {
+    $configFactory->getEditable($config)->delete();
+  }
+}
+
+/**
  * Add description to color vocabulary.
  */
 function openy_txnm_color_update_8001() {
@@ -21,7 +37,7 @@ function openy_txnm_color_update_8001() {
  */
 function openy_txnm_color_update_8002() {
   $config_dir = drupal_get_path('module', 'openy_txnm_color') . '/config/install/';
-  // Import new configuration
+  // Import new configuration.
   $config_importer = \Drupal::service('openy_upgrade_tool.importer');
   $config_importer->setDirectory($config_dir);
   $config_importer->importConfigs([


### PR DESCRIPTION
## Note:

We can't do normal testing of this PR because "OpenY Taxonomy Amenities" exist in dependencies of "OpenY Branch" module  see https://github.com/ymcatwincities/openy/pull/1150.  

Similar situation with "OpenY Taxonomy Color" module, it used in most openy modules:
```
Required by: Openy Block Menu, OpenY Paragraph Microsites Menu, OpenY Branch, OpenY Membership, OpenY Facility, OpenY Program, OpenY Program Subcategory, OpenY Node Blog, OpenY Node Event, OpenY Paragraph Small Banner, OpenY Paragraph Banner, OpenY Activity, OpenY Class, OpenY Session, OpenY Session instance, OpenY Schedules, OpenY Paragraph Schedule Search, OpenY Paragraph Featured Blog Posts, OpenY Paragraph Classes Listing, OpenY Paragraph Class Sessions, OpenY Paragraph Latest Blog Posts, OpenY Paragraph Latest Blog Posts (Camp), OpenY Paragraph Latest Blog Posts (Branch), OpenY Paragraph Blog Posts Listing, OpenY Paragraph Location Finder, OpenY Membership Calculator, OpenY Paragraph Membership Calculator, OpenY Paragraph Latest Event Posts, OpenY Paragraph Event Posts Listing, OpenY Paragraph Categories Listing, OpenY Node - Social Post, OpenY Branch Selector, OpenY Demo Block Microsites Menu, OpenY Demo Node Landing Page, OpenY Demo Node Alert, OpenY Demo Taxonomy Blog Category, OpenY Demo Node Blog, OpenY Demo Node Camp, OpenY Demo Node Program, OpenY Demo Node Program Subcategory, OpenY Demo Node Class, OpenY Demo Node Event, OpenY Demo Taxonomy Facility Type, OpenY Demo Node Facility, OpenY Demo Node Membership, OpenY Paragraph Latest News Posts (Branch), OpenY Demo Node News, OpenY Demo Node Sessions, OpenY Node Alert
```

So I suggest just check code from hook_uninstall with devel help.

## Steps for review

- [x] login as admin
- [x] go to /admin/structure/taxonomy/manage/amenities/overview
- [x] Check that you can see list of amenities taxonomy terms
- [x] go to /admin/modules
- [x] install devel module
- [x] go to /devel/php
- [x] run code from hook_uninstall
```php
  \Drupal::service('openy.modules_manager')
    ->removeEntityBundle('taxonomy_term', 'taxonomy_vocabulary', 'amenities', 'vid');
  $configFactory = \Drupal::configFactory();
  $configs = [
    'pathauto.pattern.amenities',
    'core.entity_view_mode.taxonomy_term.icon',
  ];
  foreach ($configs as $config) {
    $configFactory->getEditable($config)->delete();
  }
```
- [x] return to /admin/structure/taxonomy/manage/amenities/overview
- [x] check that amenities taxonomy terms and vocabulary was removed
- [x] go to /admin/structure/taxonomy
- [x] check that "Amenities" not exist in this list
- [x] go to /admin/structure/taxonomy/manage/color/overview
- [x] Check that you can see list of color taxonomy terms
- [x] go to /devel/php
- [x] run code from hook_uninstall
```php
  \Drupal::service('openy.modules_manager')
    ->removeEntityBundle('taxonomy_term', 'taxonomy_vocabulary', 'color', 'vid');
  $configFactory = \Drupal::configFactory();
  $configs = [
    'rabbit_hole.behavior_settings.taxonomy_vocabulary_color',
    'core.entity_view_mode.taxonomy_term.color',
  ];
  foreach ($configs as $config) {
    $configFactory->getEditable($config)->delete();
  }
```
- [x] return to /admin/structure/taxonomy/manage/color/overview
- [x] check that color taxonomy terms and vocabulary was removed
- [x] go to /admin/structure/taxonomy
- [x] check that "Color" not exist in this list