### PR TITLE
[OPENY-84] Schedule search form & list paragraphs decoupling

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_schedule_search/openy_prgf_schedule_search.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_schedule_search/openy_prgf_schedule_search.info.yml
@@ -3,6 +3,7 @@ description: 'OpenY Paragraph Schedule Search.'
 type: module
 core: 8.x
 package: OpenY
+version: '8.x-1.0'
 dependencies:
   - field
   - openy_prgf

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_schedule_search/openy_prgf_schedule_search.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_schedule_search/openy_prgf_schedule_search.install
@@ -1,7 +1,18 @@
 <?php
+
 /**
- * @file OpenY Paragraph Schedule Search install file.
+ * @file
+ * OpenY Paragraph Schedule Search install file.
  */
+
+/**
+ * Implements hook_uninstall().
+ */
+function openy_prgf_schedule_search_uninstall() {
+  $modules_manager = \Drupal::service('openy.modules_manager');
+  $modules_manager->removeEntityBundle('paragraph', 'paragraphs_type', 'schedule_search_form');
+  $modules_manager->removeEntityBundle('paragraph', 'paragraphs_type', 'schedule_search_list');
+}
 
 /**
  * Update Paragraph Schedule Search field_prgf_block.


### PR DESCRIPTION
## Steps for review

- [x] login as admin
- [x] go to "/schedules?location=5"
- [x] check that you can see schedules form in header and schedules listing in content area
- [x] go to /admin/modules/uninstall
- [x] uninstall "OpenY Demo Node Alert", "OpenY Demo Node Sessions" modules
- [x] uninstall "OpenY Demo Node Landing Page" module
- [x] uninstall "OpenY Paragraph Schedule Search" module
- [x] return to /schedules?location=5 page
- [x] check that schedules form and schedules listing blocks was removed from page
- [x] go to /admin/structure/paragraphs_type
- [x] check that "Schedule search form" and "Schedule search list" paragraphs not exist in this list
- [x] go to /admin/modules
- [x] install "OpenY Paragraph Schedule Search" module
- [x] return to /schedules?location=5 page
- [x] edit this node
- [x] add "Schedule search form" to header area and "Schedule search list" to content area
- [x] check that all components related to "OpenY Paragraph Schedule Search" module was restored