### PR TITLE
[OPENY-85] Group Schedules (GroupEx Pro) paragraph decoupling

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_group_schedules/openy_prgf_group_schedules.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_group_schedules/openy_prgf_group_schedules.info.yml
@@ -3,6 +3,7 @@ description: 'Group Schedules paragraph.'
 type: module
 core: 8.x
 package: OpenY
+version: '8.x-1.0'
 dependencies:
   - field
   - openy_group_schedules

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_group_schedules/openy_prgf_group_schedules.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_group_schedules/openy_prgf_group_schedules.install
@@ -19,6 +19,14 @@ function openy_prgf_group_schedules_install() {
 }
 
 /**
+ * Implements hook_uninstall().
+ */
+function openy_prgf_group_schedules_uninstall() {
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('paragraph', 'paragraphs_type', 'group_schedules');
+}
+
+/**
  * Update group schedule field display form from select to autocomplete.
  */
 function openy_prgf_group_schedules_update_8001() {


### PR DESCRIPTION
## Steps for review

- [x] login as admin
- [x] go to "/schedules/group-schedules"
- [x] check that you can see "Group Schedules (GroupEx Pro)" paragraph
- [x] go to /admin/modules/uninstall
- [x] uninstall "OpenY Demo Node Alert", "OpenY Demo Node Sessions" modules
- [x] uninstall "OpenY Demo Node Landing Page" module
- [x] uninstall "OpenY Paragraph Group Schedules" module
- [x] return to "/schedules/group-schedules"
- [x] check that "Group Schedules (GroupEx Pro)" paragraph was removed from page
- [x] go to /admin/structure/paragraphs_type
- [x] check that "Group Schedules (GroupEx Pro)" paragraph not exist in this list
- [x] go to /admin/modules
- [x] install "OpenY Paragraph Group Schedules" module
- [x] return to "/schedules/group-schedules"
- [x] edit this node
- [x] add "Group Schedules (GroupEx Pro)" paragraph
- [x] check that all components related to "OpenY Paragraph Group Schedules" module was restored