### PR TITLE
[OPENY-86] Program Registration (Daxko) paragraph decoupling

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_pgm_reg/openy_prgf_pgm_reg.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_pgm_reg/openy_prgf_pgm_reg.info.yml
@@ -3,6 +3,7 @@ description: 'Provide a paragraph with a Program Registration Block for Landing 
 type: module
 core: 8.x
 package: OpenY
+version: '8.x-1.0'
 dependencies:
   - field
   - openy_programs_search

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_pgm_reg/openy_prgf_pgm_reg.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_pgm_reg/openy_prgf_pgm_reg.install
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @file
+ * Installation file.
+ */
+
+/**
+ * Implements hook_uninstall().
+ */
+function openy_prgf_pgm_reg_uninstall() {
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('paragraph', 'paragraphs_type', 'program_registration');
+}


### PR DESCRIPTION
## Steps for review

- [x] login as admin
- [x] /admin/config/services/daxko
- [x] configure daxko if you have credentials (if not - skip content creation part)
- [x] go to "/node/add/landing_page"
- [x] add "Program Registration (Daxko)" paragraph to content area and create node
- [x] check that you can see "Program Registration (Daxko)" paragraph
- [x] go to /admin/modules/uninstall
- [x] uninstall "OpenY Program Registration Paragraph" module
- [x] return to created landing page
- [x] check that "Program Registration (Daxko)" paragraph was removed from page
- [x] go to /admin/structure/paragraphs_type
- [x] check that "Program Registration (Daxko)" paragraph not exist in this list
- [x] go to /admin/modules
- [x] install "OpenY Program Registration Paragraph" module
- [x] return to created landing page
- [x] edit this node
- [x] add "Program Registration (Daxko)" paragraph to content area and save node
- [x] check that all components related to "OpenY Program Registration Paragraph" module was restored

## Note
For not configured daxko when you try to add paragraph - nothing happens, in logs you can find next error:
```
Drupal\daxko\DaxkoClientException: Failed to make a request for uri branches?limit=100 with message cURL error 3: <url> malformed (see http://curl.haxx.se/libcurl/c/libcurl-errors.html). in Drupal\daxko\DaxkoClient->makeRequest() (line 63 of /var/www/docroot/profiles/contrib/openy/modules/custom/daxko/src/DaxkoClient.php).
```
I think we need to create separated issue for this.

cc @podarok @ddrozdik 