### PR TITLE
[OPENY-107] OpenY Session instance decoupling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -179,7 +179,8 @@
             },
             "drupal/core": {
                 "1236098 - Notice: Undefined index in _color_rewrite_stylesheet()": "https://www.drupal.org/files/issues/undefined-index-in-_color_rewrite_stylesheet-1236098-37.patch",
-                "2484693 - Telephone Link field formatter InvalidArgumentException with 5 digits or fewer in the number": "https://www.drupal.org/files/issues/2484693-54.patch"
+                "2484693 - Telephone Link field formatter InvalidArgumentException with 5 digits or fewer in the number": "https://www.drupal.org/files/issues/2484693-54.patch",
+                "2862702 - PrepareModulesEntityUninstallForm::formTitle does not exist": "https://www.drupal.org/files/issues/2862702-3.patch"
             },
             "drupal/dropzonejs": {
                 "2833965 - Multiple submissions of the same form on double-clicking 'Select entities'" : "https://www.drupal.org/files/issues/dropzonejs-prevent_multiple_form_submissions-2833965-10.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "90c1787170e5f5f414bad09d3761c30a",
+    "content-hash": "5c9a9a34adc4e256639c9b7ce572eff7",
     "packages": [
         {
             "name": "abraham/twitteroauth",
@@ -1589,7 +1589,8 @@
             "extra": {
                 "patches_applied": {
                     "1236098 - Notice: Undefined index in _color_rewrite_stylesheet()": "https://www.drupal.org/files/issues/undefined-index-in-_color_rewrite_stylesheet-1236098-37.patch",
-                    "2484693 - Telephone Link field formatter InvalidArgumentException with 5 digits or fewer in the number": "https://www.drupal.org/files/issues/2484693-54.patch"
+                    "2484693 - Telephone Link field formatter InvalidArgumentException with 5 digits or fewer in the number": "https://www.drupal.org/files/issues/2484693-54.patch",
+                    "2862702 - PrepareModulesEntityUninstallForm::formTitle does not exist": "https://www.drupal.org/files/issues/2862702-3.patch"
                 }
             },
             "autoload": {
@@ -2858,7 +2859,7 @@
                 },
                 "drupal": {
                     "version": "8.x-2.2",
-                    "datestamp": "1506372845",
+                    "datestamp": "1531469021",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"

--- a/modules/custom/openy_addthis/src/Entity/AddThisUninstallValidator.php
+++ b/modules/custom/openy_addthis/src/Entity/AddThisUninstallValidator.php
@@ -41,15 +41,18 @@ class AddThisUninstallValidator implements ModuleUninstallValidatorInterface {
    * {@inheritdoc}
    */
   public function validate($module) {
-    $entity_types = $this->entityTypeManager->getDefinitions();
     $reasons = [];
+    if ($module !== 'openy_addthis') {
+      return $reasons;
+    }
+    $entity_types = $this->entityTypeManager->getDefinitions();
     foreach ($entity_types as $entity_type_id => $entity_type) {
       $storage = $this->entityTypeManager->getStorage($entity_type_id);
 
       if ($storage instanceof SqlContentEntityStorage) {
         foreach ($storage->getFieldStorageDefinitions() as $storage_definition) {
           if (
-            $storage_definition->getProvider() == $module
+            $storage_definition->getProvider() === 'openy_addthis'
             && $storage instanceof FieldableEntityStorageInterface
             && $storage->countFieldData($storage_definition, TRUE)
           ) {

--- a/modules/custom/openy_branch_selector/openy_branch_selector.info.yml
+++ b/modules/custom/openy_branch_selector/openy_branch_selector.info.yml
@@ -4,4 +4,4 @@ description: Provides link to save location as My YMCA.
 core: 8.x
 package: OpenY
 dependencies:
-  - openy_session_instance
+  - openy_loc_branch


### PR DESCRIPTION
## Related issues:
- https://www.drupal.org/project/drupal/issues/2876872
- https://www.drupal.org/project/drupal/issues/2862702

## Steps for review

- [x] login as admin
- [x] go to /admin/modules/uninstall
- [x] uninstall "OpenY Demo Node Alert", "OpenY Demo Node Sessions", "OpenY Demo Node Landing Page" modules
- [x] uninstall "OpenY Paragraph Schedule Search", "OpenY Paragraph Class Sessions" modules
- [x] uninstall "OpenY Schedules" module
- [x] check that on "OpenY Session instance" module you can remove all entity content by clicking on "Remove session instance entities." link
- [x] remove this entities and uninstall "OpenY Session instance" module
- [x] go to /admin/structure
- [x] check that "Session Instance settings" and "Session Instance list" not exist in this list
- [x] go to /admin/structure/views
- [x] check that session_instances_listing views not exist here
- [x] go to /admin/modules
- [x] install "OpenY Session instance" module
- [x] check that all module components was restored