### PR TITLE
[OPENY-106] Front page demo grid content paragraph decoupling

### DIFF
--- a/modules/custom/openy_migrate/src/Plugin/migrate/process/SkipIfBundleNotExist.php
+++ b/modules/custom/openy_migrate/src/Plugin/migrate/process/SkipIfBundleNotExist.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace Drupal\openy_migrate\Plugin\migrate\process;
+
+use Drupal\Core\Entity\EntityManagerInterface;
+use Drupal\migrate\MigrateSkipProcessException;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\Row;
+use Drupal\migrate\MigrateSkipRowException;
+use Drupal\migrate\Plugin\MigrationInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Skips processing the current row when the bundle not exist.
+ *
+ * Available configuration keys:
+ * - method: (required) What to do if the input value is empty. Possible values:
+ *   - row: Skips the entire row when bundle not exist.
+ *   - process: Prevents further processing of the input property
+ *     when bundle not exist.
+ * - entity: (required) Entity machine name.
+ * - bundle: (required) Bundle machine name.
+ *
+ * Examples:
+ *
+ * @code
+ * process:
+ *   type:
+ *     plugin: skip_if_bundle_not_exist
+ *     method: row
+ *     entity: paragraph
+ *     bundle: demo
+ * @endcode
+ *
+ * If field_name is empty, skips the entire row and the message 'Field
+ * field_name is missed' is logged in the message table.
+ *
+ * @code
+ * process:
+ *   parent:
+ *     -
+ *       plugin: skip_if_bundle_not_exist
+ *       method: process
+ *       entity: node
+ *       bundle: article
+ *     -
+ *       plugin: migration
+ *       migration: custom_node_migration
+ * @endcode
+ *
+ * When article bundle not exist for node, any further processing of the
+ * property is skipped, the next plugin (migration) will not be run.
+ *
+ * @see \Drupal\migrate\Plugin\MigrateProcessInterface
+ *
+ * @MigrateProcessPlugin(
+ *   id = "skip_if_bundle_not_exist"
+ * )
+ */
+class SkipIfBundleNotExist extends ProcessPluginBase implements ContainerFactoryPluginInterface {
+
+
+  /**
+   * The entity manager.
+   *
+   * @var \Drupal\Core\Entity\EntityManagerInterface
+   */
+  protected $entityManager;
+
+  /**
+   * The current migration.
+   *
+   * @var \Drupal\migrate\Plugin\MigrationInterface
+   */
+  protected $migration;
+
+  /**
+   * Entity machine name.
+   *
+   * @var string
+   */
+  protected $entityName;
+
+  /**
+   * Bundle machine name.
+   *
+   * @var string
+   */
+  protected $entityBundle;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, MigrationInterface $migration, EntityManagerInterface $entity_manager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->migration = $migration;
+    $this->entityManager = $entity_manager;
+    $this->entityName = $configuration['entity'];
+    $this->entityBundle = $configuration['bundle'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition, MigrationInterface $migration = NULL) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $migration,
+      $container->get('entity.manager')
+    );
+  }
+
+  /**
+   * Skips the current row when bundle not exist.
+   *
+   * @param mixed $value
+   *   The input value.
+   * @param \Drupal\migrate\MigrateExecutableInterface $migrate_executable
+   *   The migration in which this process is being executed.
+   * @param \Drupal\migrate\Row $row
+   *   The row from the source to process.
+   * @param string $destination_property
+   *   The destination property currently worked on. This is only used together
+   *   with the $row above.
+   *
+   * @return string
+   *   Entity bundle name if exist.
+   *
+   * @throws \Drupal\migrate\MigrateSkipRowException
+   *   Thrown if entity bundle not exist and the row should be skipped,
+   *   records with STATUS_IGNORED status in the map.
+   */
+  public function row($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    $bundles = $this->entityManager->getBundleInfo($this->entityName);
+    if (!isset($bundles[$this->entityBundle])) {
+      throw new MigrateSkipRowException();
+    }
+    return $this->configuration['bundle'];
+  }
+
+  /**
+   * Stops processing the current property when bundle not exist.
+   *
+   * @param mixed $value
+   *   The input value.
+   * @param \Drupal\migrate\MigrateExecutableInterface $migrate_executable
+   *   The migration in which this process is being executed.
+   * @param \Drupal\migrate\Row $row
+   *   The row from the source to process.
+   * @param string $destination_property
+   *   The destination property currently worked on. This is only used together
+   *   with the $row above.
+   *
+   * @return string
+   *   Entity bundle name if exist.
+   *
+   * @throws \Drupal\migrate\MigrateSkipProcessException
+   *   Thrown if entity bundle not exist and rest of the process should
+   *   be skipped.
+   */
+  public function process($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    $bundles = $this->entityManager->getBundleInfo($this->entityName);
+    if (!isset($bundles[$this->entityBundle])) {
+      throw new MigrateSkipProcessException();
+    }
+    return $this->configuration['bundle'];
+  }
+
+}

--- a/modules/openy_features/openy_demo_content/modules/openy_demo_nlanding/config/install/migrate_plus.migration.lp_paragraph_grid_columns.yml
+++ b/modules/openy_features/openy_demo_content/modules/openy_demo_nlanding/config/install/migrate_plus.migration.lp_paragraph_grid_columns.yml
@@ -68,6 +68,11 @@ process:
     default_value: full_html
   field_prgf_clm_link/uri: link_uri
   field_prgf_clm_link/title: link_text
+  type:
+    plugin: skip_if_bundle_not_exist
+    method: row
+    entity: paragraph
+    bundle: grid_columns
 destination:
   plugin: 'entity:paragraph'
   default_bundle: grid_columns

--- a/modules/openy_features/openy_demo_content/modules/openy_demo_nlanding/config/install/migrate_plus.migration.lp_paragraph_grid_content.yml
+++ b/modules/openy_features/openy_demo_content/modules/openy_demo_nlanding/config/install/migrate_plus.migration.lp_paragraph_grid_content.yml
@@ -50,6 +50,11 @@ process:
     plugin: default_value
     default_value: field_content
   field_prgf_grid_style: style
+  type:
+    plugin: skip_if_bundle_not_exist
+    method: row
+    entity: paragraph
+    bundle: grid_content
   field_grid_columns:
     plugin: iterator
     source: column_ids


### PR DESCRIPTION
This is proof of concept for demo content decoupling. With minimal changes for current migrations we can remove all dependencies to openy features from demo content. In case if some entity bundle not exist - migration will be skiped .

## Some details about current PR
Here was implemented new Migration Process Plugin `SkipIfBundleNotExist`. With this Process Plugin we can skip row or process if entity bundle not exist.

For testing I have updated grid content paragraph migration. We have reference to this paragraph in `migrate_plus.migration.node_landing.yml`. `field_content` in this migration used "migration" process plugin that contain `skipOnEmpty` checking, so in case we have empty rows from grid content migration - they will be skipped in node_landing migration too.

## Steps for testing
For testing we need installed openy site and drush

- [ ] login as admin
- [ ] go to /admin/content?title=OpenY&type=landing_page&status=All&langcode=All
- [ ] open OpenY page
- [ ] check that you can see grid content on this page
- [ ] run in terminal `drush mr --all` - this will rollback all migrated content
- [ ] wait rollback finish
- [ ] check that content was removed
- [ ] go to /admin/modules/uninstall
- [ ] uninstall " OpenY Paragraph Grid Content" module
- [ ] run in terminal `drush mi --all --execute-dependencies` - this will run migration and create content
- [ ] go to /admin/content?title=OpenY&type=landing_page&status=All&langcode=All
- [ ] open OpenY page
- [ ] check that grid content not exist on this page