### PR TITLE
[OPENY-87][OPENY-92] Session CT and SessionTime prgf decoupling

### DIFF
--- a/modules/custom/openy_popups/openy_popups.info.yml
+++ b/modules/custom/openy_popups/openy_popups.info.yml
@@ -3,3 +3,6 @@ type: module
 description: Implements OpenY Popups.
 core: 8.x
 package: OpenY
+version: '8.x-1.0'
+dependencies:
+  - openy_session_instance

--- a/modules/custom/openy_popups/openy_popups.info.yml
+++ b/modules/custom/openy_popups/openy_popups.info.yml
@@ -4,5 +4,3 @@ description: Implements OpenY Popups.
 core: 8.x
 package: OpenY
 version: '8.x-1.0'
-dependencies:
-  - openy_session_instance

--- a/modules/custom/openy_popups/src/Controller/PopupsController.php
+++ b/modules/custom/openy_popups/src/Controller/PopupsController.php
@@ -12,37 +12,11 @@ use Drupal\node\NodeInterface;
 use Drupal\openy_popups\Form\BranchesForm;
 use Drupal\openy_popups\Form\ClassBranchesForm;
 use Drupal\file\Entity\File;
-use Drupal\openy_session_instance\SessionInstanceManager;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * {@inheritdoc}
  */
 class PopupsController extends ControllerBase {
-
-  /**
-   * The SessionInstanceManager.
-   *
-   * @var \Drupal\openy_session_instance\SessionInstanceManagerInterface
-   */
-  protected $sessionInstanceManager;
-
-  /**
-   * Creates a new PopupsController.
-   *
-   * @param SessionInstanceManager $session_instance_manager
-   *   The SessionInstanceManager.
-   */
-  public function __construct(SessionInstanceManager $session_instance_manager) {
-    $this->sessionInstanceManager = $session_instance_manager;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static($container->get('session_instance.manager'));
-  }
 
   /**
    * Branch Popup.
@@ -122,7 +96,7 @@ class PopupsController extends ControllerBase {
 
     if ($node) {
       // Check special cases (0 or 1 available location).
-      $locations = ClassBranchesForm::getBranchesList($node, $this->sessionInstanceManager);
+      $locations = ClassBranchesForm::getBranchesList($node);
       $locations = $locations['branch'] + $locations['camp'];
       if (!$locations) {
         // Show 'Class unavailable' popup.

--- a/modules/custom/openy_popups/src/Plugin/Block/LocationPopupLink.php
+++ b/modules/custom/openy_popups/src/Plugin/Block/LocationPopupLink.php
@@ -4,9 +4,6 @@ namespace Drupal\openy_popups\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
 use Drupal\Core\Form\FormStateInterface;
-use \Drupal\openy_session_instance\SessionInstanceManagerInterface;
-use Symfony\Component\DependencyInjection\ContainerInterface;
-use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 
 /**
  * Block with popup link.
@@ -17,49 +14,7 @@ use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
  *   category = @Translation("Paragraph Blocks")
  * )
  */
-class LocationPopupLink extends BlockBase implements ContainerFactoryPluginInterface  {
-
-  /**
-   * The SessionInstanceManager.
-   *
-   * @var \Drupal\openy_session_instance\SessionInstanceManagerInterface
-   */
-  protected $sessionInstanceManager;
-
-  /**
-   * Creates a new BranchSessionsForm.
-   *
-   * @param SessionInstanceManagerInterface $session_instance_manager
-   *   The SessionInstanceManager.
-   */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, SessionInstanceManagerInterface $session_instance_manager) {
-    parent::__construct($configuration, $plugin_id, $plugin_definition);
-    $this->sessionInstanceManager = $session_instance_manager;
-  }
-
-  /**
-   * Create location popup link block.
-   *
-   * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
-   *   ContainerInterface object.
-   * @param array $configuration
-   *   Configuration array.
-   * @param $plugin_id
-   *   Plugin ID.
-   * @param $plugin_definition
-   *   Plugin Definition
-   *
-   * @return static
-   *   New LocationPopupLink.
-   */
-  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
-    return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-      $container->get('session_instance.manager')
-    );
-  }
+class LocationPopupLink extends BlockBase {
 
   /**
    * {@inheritdoc}
@@ -109,7 +64,12 @@ class LocationPopupLink extends BlockBase implements ContainerFactoryPluginInter
       if ($node && $node->getType() == 'class') {
         $type = 'class';
         $nid = $node->id();
-        $location_count = $this->sessionInstanceManager->getLocationCountByClassNode($node);
+
+        $location_count = NULL;
+        if (\Drupal::hasService('session_instance.manager')) {
+          $location_count = \Drupal::service('session_instance.manager')
+            ->getLocationCountByClassNode($node);
+        }
       }
     }
     if ($node && $node->getType() == 'program_subcategory') {

--- a/modules/openy_features/openy_node/modules/openy_node_session/openy_node_session.info.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_session/openy_node_session.info.yml
@@ -3,6 +3,7 @@ description: 'OpenY Session.'
 type: module
 core: 8.x
 package: OpenY
+version: '8.x-1.0'
 dependencies:
   - datetime_range
   - entity_reference_revisions

--- a/modules/openy_features/openy_node/modules/openy_node_session/openy_node_session.install
+++ b/modules/openy_features/openy_node/modules/openy_node_session/openy_node_session.install
@@ -1,14 +1,29 @@
 <?php
+
 /**
- * @file OpenY Node Session install file.
+ * @file
+ * OpenY Node Session install file.
  */
+
+/**
+ * Implements hook_uninstall().
+ */
+function openy_node_session_uninstall() {
+  $modules_manager = \Drupal::service('openy.modules_manager');
+  $modules_manager->removeEntityBundle('paragraph', 'paragraphs_type', 'session_time');
+  $modules_manager->removeEntityBundle('node', 'node_type', 'session');
+
+  \Drupal::configFactory()
+    ->getEditable('rabbit_hole.behavior_settings.node_type_session')
+    ->delete();
+}
 
 /**
  * Update Session for rabbit hole, hiding pages from anonymous users.
  */
 function openy_node_session_update_8001() {
   $config_dir = drupal_get_path('module', 'openy_node_session') . '/config/install/';
-  // Import new configuration
+  // Import new configuration.
   $config_importer = \Drupal::service('openy_upgrade_tool.importer');
   $config_importer->setDirectory($config_dir);
   $config_importer->importConfigs([
@@ -52,7 +67,7 @@ function openy_node_session_update_8002() {
   $config_dir = drupal_get_path('module', 'openy_node_session') . '/config/install/';
   // Update multiple configurations.
   $configs = [
-    'field.field.node.session.field_session_class' =>[
+    'field.field.node.session.field_session_class' => [
       'description',
     ],
     'field.field.node.session.field_session_description' => [

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_classes_listing/openy_prgf_classes_listing.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_classes_listing/openy_prgf_classes_listing.info.yml
@@ -8,6 +8,7 @@ dependencies:
   - field
   - node
   - openy_node_class
+  - openy_node_session
   - openy_prgf
   - paragraphs
   - plugin


### PR DESCRIPTION
## Steps for review

- [x] login as admin
- [x] open any class page
- [x] check that class branch popup works fine
- [x] go to /admin/modules/uninstall
- [x] find "OpenY Session instance" module and remove all entity content by clicking on "Remove session instance entities." link
- [x] go to /admin/modules
- [x] install "Devel" module
- [x] go to /devel/php and execute this code (or you can uninstall one by one modules manually):

```php
\Drupal::service('module_installer')->uninstall([
  'openy_demo_nalert',
  'openy_demo_nsessions',
  'openy_demo_nlanding',
  'openy_prgf_schedule_search',
  'openy_prgf_class_sessions',
  'openy_schedules',
  'openy_prgf_classes_listing',
  'openy_session_instance',
  'openy_node_session',
]);
```
- [x] go to /admin/structure/types
- [x] check that "Session" not exist in this list
- [x] go to /admin/structure/paragraphs_type
- [x] check that "session_time" not exist in this list
- [x] go to /admin/modules
- [x] install "OpenY Session" module
- [x] check that all module components was restored
- [x] check that `openy_session_instance` deleting not broke class page (popups not work without it, but at least we not get fatal errors)
- [x] check that on any class page was removed paragraphs that related to sessions


