### PR TITLE
[OPENY-91] Class CT decoupling

### DIFF
--- a/modules/openy_features/openy_node/modules/openy_node_class/openy_node_class.info.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_class/openy_node_class.info.yml
@@ -3,6 +3,7 @@ description: 'OpenY Class.'
 type: module
 core: 8.x
 package: OpenY
+version: '8.x-1.0'
 dependencies:
   - entity_reference_revisions
   - field

--- a/modules/openy_features/openy_node/modules/openy_node_class/openy_node_class.install
+++ b/modules/openy_features/openy_node/modules/openy_node_class/openy_node_class.install
@@ -1,7 +1,24 @@
 <?php
+
 /**
- * @file OpenY Node Class install file.
+ * @file
+ * OpenY Node Class install file.
  */
+
+/**
+ * Implements hook_uninstall().
+ */
+function openy_node_class_uninstall() {
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('node', 'node_type', 'class');
+  $configs = [
+    'pathauto.pattern.class',
+    'simple_sitemap.bundle_settings.node.class',
+  ];
+  foreach ($configs as $config) {
+    \Drupal::configFactory()->getEditable($config)->delete();
+  }
+}
 
 /**
  * Implements hook_update_dependencies().
@@ -10,7 +27,7 @@ function openy_node_class_update_dependencies() {
   $dependencies['openy_node_class'] = [
     8002 => [
       'openy_node' => 8003,
-    ]
+    ],
   ];
 
   return $dependencies;
@@ -41,7 +58,7 @@ function openy_node_class_update_8001() {
  */
 function openy_node_class_update_8002() {
   $config_dir = drupal_get_path('module', 'openy_node_class') . '/config/install/';
-  // Import new configuration
+  // Import new configuration.
   $config_importer = \Drupal::service('openy_upgrade_tool.importer');
   $config_importer->setDirectory($config_dir);
   $config_importer->importConfigs([
@@ -150,7 +167,7 @@ function openy_node_class_update_8004() {
   $config_dir = drupal_get_path('module', 'openy_node_class') . '/config/install/';
   // Update multiple configurations.
   $configs = [
-    'field.field.node.class.field_bottom_content' =>[
+    'field.field.node.class.field_bottom_content' => [
       'description',
     ],
     'field.field.node.class.field_class_activity' => [
@@ -185,7 +202,7 @@ function openy_node_class_update_8004() {
  */
 function openy_node_class_update_8005() {
   $config_dir = drupal_get_path('module', 'openy_node_class') . '/config/install/';
-  // Import new configuration
+  // Import new configuration.
   $config_importer = \Drupal::service('openy_upgrade_tool.importer');
   $config_importer->setDirectory($config_dir);
   $config_importer->importConfigs([


### PR DESCRIPTION
**Note:** Marge and test this only after https://github.com/ymcatwincities/openy/pull/1175

## Steps for review

- [x] login as admin
- [x] go to /admin/modules/uninstall
- [x] find "OpenY Session instance" module and remove all entity content by clicking on "Remove session instance entities." link
- [x] go to /admin/modules
- [x] install "Devel" module
- [x] go to /devel/php and execute this code (or you can uninstall one by one modules manually):

```php
\Drupal::service('module_installer')->uninstall([
  'openy_demo_nalert',
  'openy_demo_nsessions',
  'openy_demo_nlanding',
  'openy_prgf_schedule_search',
  'openy_prgf_class_sessions',
  'openy_schedules',
  'openy_prgf_branches_popup_all',
  'openy_prgf_branches_popup_class',
  'openy_prgf_classes_listing',
  'openy_popups',
  'openy_session_instance',
  'openy_node_session',
  'openy_node_class',
]);
```
- [x] go to /admin/structure/types
- [x] check that "Class" not exist in this list
- [x] go to /admin/modules
- [x] install "OpenY Class" module
- [x] check that all module components was restored