### PR TITLE
[OPENY-90] Activity CT decoupling

### DIFF
--- a/modules/openy_features/openy_node/modules/openy_node_activity/openy_node_activity.info.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_activity/openy_node_activity.info.yml
@@ -3,6 +3,7 @@ description: 'OpenY Activity.'
 type: module
 core: 8.x
 package: OpenY
+version: '8.x-1.0'
 dependencies:
   - field
   - field_group

--- a/modules/openy_features/openy_node/modules/openy_node_activity/openy_node_activity.install
+++ b/modules/openy_features/openy_node/modules/openy_node_activity/openy_node_activity.install
@@ -6,6 +6,21 @@
  */
 
 /**
+ * Implements hook_uninstall().
+ */
+function openy_node_activity_uninstall() {
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('node', 'node_type', 'activity');
+  $configs = [
+    'pathauto.pattern.activity',
+    'rabbit_hole.behavior_settings.node_type_activity',
+  ];
+  foreach ($configs as $config) {
+    \Drupal::configFactory()->getEditable($config)->delete();
+  }
+}
+
+/**
  * Update Activity for rabbit hole, hiding pages from anonymous users.
  */
 function openy_node_activity_update_8003() {


### PR DESCRIPTION
**Note:** Marge and test this only after https://github.com/ymcatwincities/openy/pull/1176

## Steps for review

- [x] login as admin
- [x] go to /admin/modules/uninstall
- [x] find "OpenY Session instance" module and remove all entity content by clicking on "Remove session instance entities." link
- [x] go to /admin/modules
- [x] install "Devel" module
- [x] go to /devel/php and execute this code (or you can uninstall one by one modules manually):

```php
\Drupal::service('module_installer')->uninstall([
  'openy_demo_nalert',
  'openy_demo_nsessions',
  'openy_demo_nlanding',
  'openy_prgf_schedule_search',
  'openy_prgf_class_sessions',
  'openy_schedules',
  'openy_prgf_branches_popup_all',
  'openy_prgf_branches_popup_class',
  'openy_prgf_classes_listing',
  'openy_popups',
  'openy_session_instance',
  'openy_node_session',
  'openy_node_class',
  'openy_node_activity',
]);
```
- [x] go to /admin/structure/types
- [x] check that "Activity" not exist in this list
- [x] go to /admin/modules
- [x] install "OpenY Activity" module
- [x] check that all module components was restored