### PR TITLE
[OPENY-77] Breadcrumbs config updates

### DIFF
--- a/openy.install
+++ b/openy.install
@@ -915,3 +915,17 @@ function openy_update_8059() {
 function openy_update_8060() {
   \Drupal::service('module_installer')->install(['openy_system']);
 }
+
+/**
+ * Breadcrumbs config moving.
+ */
+function openy_update_8061() {
+  // Remove config that will be renamed.
+  \Drupal::configFactory()->getEditable('block.block.breadcrumbs')->delete();
+  $config_dir = drupal_get_path('theme', 'openy_rose') . '/config/install/';
+  $config_importer = \Drupal::service('openy_upgrade_tool.importer');
+  $config_importer->setDirectory($config_dir);
+  $config_importer->importConfigs([
+    'block.block.openy_rose_breadcrumbs',
+  ]);
+}

--- a/themes/openy_themes/openy_rose/config/install/block.block.openy_rose_breadcrumbs.yml
+++ b/themes/openy_themes/openy_rose/config/install/block.block.openy_rose_breadcrumbs.yml
@@ -5,7 +5,7 @@ dependencies:
     - system
   theme:
     - openy_rose
-id: breadcrumbs
+id: openy_rose_breadcrumbs
 theme: openy_rose
 region: breadcrumb
 weight: 0

--- a/themes/openy_themes/openy_rose/templates/block/block--openy-rose-breadcrumbs.html.twig
+++ b/themes/openy_themes/openy_rose/templates/block/block--openy-rose-breadcrumbs.html.twig
@@ -1,7 +1,7 @@
 {#
 /**
  * @file
- * Default theme implementation to display a breadcrumbs block.
+ * OpenY Rose theme implementation to display a breadcrumbs block.
  *
  * Available variables:
  * - plugin_id: The ID of the block implementation.


### PR DESCRIPTION
 it is decided that no sense to decouple Easy Breadcrumbs module since it will be always enabled
## Steps for review

- [x] login as admin
- [x] open any page except homepage like programs/health-and-fitness
- [x] make sure that breadcrumbs are displayed

## General checks
- [x] All coding styles are fulfilled and there are no any issues reported by CodeSniffer CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/ci-errors.png" width="200" alt="CI code sniffer errors">
- [x] All tests are running and there are no failed tests reported by CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/behat.png" width="200" alt="Behat test results">
- [x] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [x] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [x] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [x] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [x] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
