### PR TITLE
[OPENY-124] Temporary hide OpenY Components tab on modules page

### DIFF
--- a/modules/custom/openy_system/openy_system.links.task.yml
+++ b/modules/custom/openy_system/openy_system.links.task.yml
@@ -1,5 +1,5 @@
-system.openy_modules_list:
-  route_name: openy_system.modules_list
-  base_route: system.modules_list
-  title: 'OpenY Components'
-  weight: 30
+#system.openy_modules_list:
+#  route_name: openy_system.modules_list
+#  base_route: system.modules_list
+#  title: 'OpenY Components'
+#  weight: 30


### PR DESCRIPTION
## Steps for review

- [x] Login as admin.
- [x] visit _/admin/modules_.
- [x] make sure that not OpenY Components tab.


## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/ci-errors.png" width="200" alt="CI code sniffer errors">
- [ ] All tests are running and there are no failed tests reported by CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/behat.png" width="200" alt="Behat test results">
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
