### PR TITLE
Add Camp, Kids & Teens categories

### DIFF
--- a/modules/openy_features/openy_demo_content/modules/openy_demo_nclass/config/install/migrate_plus.migration.node_activity.yml
+++ b/modules/openy_features/openy_demo_content/modules/openy_demo_nclass/config/install/migrate_plus.migration.node_activity.yml
@@ -215,6 +215,46 @@ source:
       id: activity_discovery_day_camp
       title: 'Discovery Day Camp'
       subcategory: day_camps
+    -
+      id: activity_academic_enrichment_youth
+      title: 'Academic Enrichment - Youth'
+      subcategory: health_and_fitness_for_kids_and_teens
+    -
+      id: activity_academic_success
+      title: 'Academic Success'
+      subcategory: health_and_fitness_for_kids_and_teens
+    -
+      id: activity_arts_crafts
+      title: 'Arts & Crafts'
+      subcategory: health_and_fitness_for_kids_and_teens
+    -
+      id: activity_before_after_school_child_care
+      title: 'Before & After School Child Care'
+      subcategory: health_and_fitness_for_kids_and_teens
+    -
+      id: activity_before_after_school_programs
+      title: 'Before & After School Programs'
+      subcategory: health_and_fitness_for_kids_and_teens
+    -
+      id: activity_birthday_parties
+      title: 'Birthday Parties'
+      subcategory: health_and_fitness_for_kids_and_teens
+    -
+      id: activity_earth_service_corps
+      title: 'Earth Service Corps'
+      subcategory: health_and_fitness_for_kids_and_teens
+    -
+      id: activity_kids_zone_activity_centers
+      title: 'Kids Zone Activity Centers'
+      subcategory: health_and_fitness_for_kids_and_teens
+    -
+      id: activity_preschool_child_care
+      title: 'Preschool Child Care'
+      subcategory: health_and_fitness_for_kids_and_teens
+    -
+      id: activity_sports_classes_workshops_youth
+      title: 'Sports Classes & Workshops - Youth'
+      subcategory: health_and_fitness_for_kids_and_teens
   ids:
     id:
       type: string

--- a/modules/openy_features/openy_demo_content/modules/openy_demo_nclass/config/install/migrate_plus.migration.node_activity.yml
+++ b/modules/openy_features/openy_demo_content/modules/openy_demo_nclass/config/install/migrate_plus.migration.node_activity.yml
@@ -207,6 +207,14 @@ source:
       id: activity_drop_in_swim
       title: 'Drop-In Swim'
       subcategory: swim_lessons
+    -
+      id: activity_bold_one_week_expeditions
+      title: 'BOLD One-Week Expeditions'
+      subcategory: day_camps
+    -
+      id: activity_discovery_day_camp
+      title: 'Discovery Day Camp'
+      subcategory: day_camps
   ids:
     id:
       type: string

--- a/modules/openy_features/openy_demo_content/modules/openy_demo_nclass/config/install/migrate_plus.migration.node_class_02.yml
+++ b/modules/openy_features/openy_demo_content/modules/openy_demo_nclass/config/install/migrate_plus.migration.node_class_02.yml
@@ -1564,6 +1564,114 @@ source:
       activity: activity_discovery_day_camp
       body: |
         <p>Discovery Camp: Drop-off - Northshore YMCA 2017</p>
+    -
+      id: class_academic_enrichment_youth_1
+      title: 'AM Fit & Fun'
+      activity: activity_academic_enrichment_youth
+      body: |
+        <p>AM Fit & Fun</p>
+    -
+      id: class_academic_success_1
+      title: 'Academic Success'
+      activity: activity_academic_success
+      body: |
+        <p>Academic Success</p>
+    -
+      id: class_activity_arts_crafts_1
+      title: 'May Crafternoon: Handprint Sunshines'
+      activity: aactivity_arts_crafts
+      body: |
+        <p>May Crafternoon: Handprint Sunshines</p>
+    -
+      id: class_activity_arts_crafts_2
+      title: 'April Earth Day Birdhouses'
+      activity: aactivity_arts_crafts
+      body: |
+        <p>April Earth Day Birdhouses</p>
+    -
+      id: class_activity_arts_crafts_3
+      title: 'Crafternoon'
+      activity: aactivity_arts_crafts
+      body: |
+        <p>Crafternoon</p>
+    -
+      id: class_before_after_school_child_care_1
+      title: '2016/17 Woodmoor - (f) Non-School Days'
+      activity: activity_before_after_school_child_care
+      body: |
+        <p>2016/17 Woodmoor - (f) Non-School Days</p>
+    -
+      id: class_before_after_school_child_care_2
+      title: '2016/17 Woodmoor - (b) After Plus Care'
+      activity: activity_before_after_school_child_care
+      body: |
+        <p>2016/17 Woodmoor - (b) After Plus Care</p>
+    -
+      id: class_before_after_school_child_care_3
+      title: '2016/17 Woodmoor - (c) After Care'
+      activity: activity_before_after_school_child_care
+      body: |
+        <p>2016/17 Woodmoor - (c) After Care</p>
+    -
+      id: class_before_after_school_child_care_4
+      title: '2016/17 Sunrise - (a) Before and After Care'
+      activity: activity_before_after_school_child_care
+      body: |
+        <p>2016/17 Sunrise - (a) Before and After Care</p>
+    -
+      id: class_before_after_school_programs_1
+      title: '2016/17 Bellevue: No School Days - Package Option'
+      activity: activity_before_after_school_programs
+      body: |
+        <p>2016/17 Bellevue: No School Days - Package Option</p>
+    -
+      id: class_birthday_parties_1
+      title: 'Room Rental'
+      activity: activity_birthday_parties
+      body: |
+        <p>Room Rental</p>
+    -
+      id: class_birthday_parties_2
+      title: 'Birthday Party'
+      activity: activity_birthday_parties
+      body: |
+        <p>Birthday Party</p>
+    -
+      id: class_earth_service_corps_1
+      title: 'Earth Service Corps About YEST'
+      activity: activity_earth_service_corps
+      body: |
+        <p>Earth Service Corps About YEST</p>
+    -
+      id: class_kids_zone_activity_centers_1
+      title: 'Kids Zone 4 wks - 11 yrs'
+      activity: activity_kids_zone_activity_centers
+      body: |
+        <p>Kids Zone 4 wks - 11 yrs</p>
+    -
+      id: class_preschool_child_care_1
+      title: '2016/17 Northshore- Preschool Child Care (30m-4yr)'
+      activity: activity_preschool_child_care
+      body: |
+        <p>2016/17 Northshore- Preschool Child Care (30m-4yr)</p>
+    -
+      id: class_preschool_child_care_2
+      title: '2016/17 Northshore - Pre-K Child Care (4 - 5yrs)'
+      activity: activity_preschool_child_care
+      body: |
+        <p>2016/17 Northshore - Pre-K Child Care (4 - 5yrs)</p>
+    -
+      id: class_sports_classes_workshops_youth_1
+      title: 'HomeZone'
+      activity: activity_sports_classes_workshops_youth
+      body: |
+        <p>HomeZone</p>
+    -
+      id: class_sports_classes_workshops_youth_2
+      title: 'Youth Fitness Challenge'
+      activity: activity_sports_classes_workshops_youth
+      body: |
+        <p>Youth Fitness Challenge</p>
   ids:
     id:
       type: string

--- a/modules/openy_features/openy_demo_content/modules/openy_demo_nclass/config/install/migrate_plus.migration.node_class_02.yml
+++ b/modules/openy_features/openy_demo_content/modules/openy_demo_nclass/config/install/migrate_plus.migration.node_class_02.yml
@@ -1522,6 +1522,48 @@ source:
       activity: activity_drop_in_swim
       body: |
         <p>Lap Swim</p>
+    -
+      id: class_bold_one_week_expeditions_1
+      title: 'BOLD Cascade Challenge'
+      activity: activity_bold_one_week_expeditions
+      body: |
+        <p>BOLD Cascade Challenge</p>
+    -
+      id: class_bold_one_week_expeditions_2
+      title: 'A BOLD Backpacking Adventure: Discovery in the Olympics'
+      activity: activity_bold_one_week_expeditions
+      body: |
+        <p>A BOLD Backpacking Adventure: Discovery in the Olympics</p>
+    -
+      id: class_bold_one_week_expeditions_3
+      title: 'BOLD Rivers and Rocks'
+      activity: activity_bold_one_week_expeditions
+      body: |
+        <p>BOLD Rivers and Rocks</p>
+    -
+      id: class_bold_one_week_expeditions_4
+      title: 'BOLD Fishing and Backpacking in the North Cascades'
+      activity: activity_bold_one_week_expeditions
+      body: |
+        <p>BOLD Fishing and Backpacking in the North Cascades</p>
+    -
+      id: class_discovery_day_camp_1
+      title: 'Discover Camp: Drop-off - Carol Edwards Ctr. 2017'
+      activity: activity_discovery_day_camp
+      body: |
+        <p>Discover Camp: Drop-off - Carol Edwards Ctr. 2017</p>
+    -
+      id: class_discovery_day_camp_2
+      title: 'Discovery Camp: Drop-off - Kenmore Elementary 2017'
+      activity: activity_discovery_day_camp
+      body: |
+        <p>Discovery Camp: Drop-off - Kenmore Elementary 2017</p>
+    -
+      id: class_discovery_day_camp_3
+      title: 'Discovery Camp: Drop-off - Northshore YMCA 2017'
+      activity: activity_discovery_day_camp
+      body: |
+        <p>Discovery Camp: Drop-off - Northshore YMCA 2017</p>
   ids:
     id:
       type: string

--- a/modules/openy_features/openy_demo_content/modules/openy_demo_nsessions/config/install/migrate_plus.migration.node_session_04.yml
+++ b/modules/openy_features/openy_demo_content/modules/openy_demo_nsessions/config/install/migrate_plus.migration.node_session_04.yml
@@ -1590,6 +1590,294 @@ source:
       age_max: 18
       reg_uri: 'http://www.openymca.org'
       reg_title: 'Register Now'
+    -
+      id: session_kids_1
+      title: 'AM Fit & Fun'
+      class: class_academic_enrichment_youth_1
+      times:
+        -
+          time: academic_success_2
+      location: 1
+      facility: 92
+      online_registration: true
+      ticket_required: false
+      in_membership: false
+      age_min: 5
+      age_max: 18
+      reg_uri: 'http://www.openymca.org'
+      reg_title: 'Register Now'
+    -
+      id: session_kids_2
+      title: 'Academic Success'
+      class: class_academic_success_1
+      times:
+        -
+          time: academic_success_2
+      location: 1
+      facility: 92
+      online_registration: true
+      ticket_required: false
+      in_membership: false
+      age_min: 5
+      age_max: 18
+      reg_uri: 'http://www.openymca.org'
+      reg_title: 'Register Now'
+    -
+      id: session_kids_3
+      title: 'May Crafternoon: Handprint Sunshines'
+      class: class_activity_arts_crafts_1
+      times:
+        -
+          time: academic_success_2
+      location: 1
+      facility: 92
+      online_registration: true
+      ticket_required: false
+      in_membership: false
+      age_min: 5
+      age_max: 18
+      reg_uri: 'http://www.openymca.org'
+      reg_title: 'Register Now'
+    -
+      id: session_kids_4
+      title: 'April Earth Day Birdhouses'
+      class: class_activity_arts_crafts_2
+      times:
+        -
+          time: academic_success_2
+      location: 1
+      facility: 92
+      online_registration: true
+      ticket_required: false
+      in_membership: false
+      age_min: 5
+      age_max: 18
+      reg_uri: 'http://www.openymca.org'
+      reg_title: 'Register Now'
+    -
+      id: session_kids_5
+      title: 'Crafternoon'
+      class: class_activity_arts_crafts_3
+      times:
+        -
+          time: academic_success_2
+      location: 1
+      facility: 92
+      online_registration: true
+      ticket_required: false
+      in_membership: false
+      age_min: 5
+      age_max: 18
+      reg_uri: 'http://www.openymca.org'
+      reg_title: 'Register Now'
+    -
+      id: session_kids_6
+      title: '2016/17 Woodmoor - (f) Non-School Days'
+      class: class_before_after_school_child_care_1
+      times:
+        -
+          time: academic_success_2
+      location: 1
+      facility: 92
+      online_registration: true
+      ticket_required: false
+      in_membership: false
+      age_min: 5
+      age_max: 18
+      reg_uri: 'http://www.openymca.org'
+      reg_title: 'Register Now'
+    -
+      id: session_kids_7
+      title: '2016/17 Woodmoor - (b) After Plus Care'
+      class: class_before_after_school_child_care_2
+      times:
+        -
+          time: academic_success_2
+      location: 1
+      facility: 92
+      online_registration: true
+      ticket_required: false
+      in_membership: false
+      age_min: 5
+      age_max: 18
+      reg_uri: 'http://www.openymca.org'
+      reg_title: 'Register Now'
+    -
+      id: session_kids_8
+      title: '2016/17 Woodmoor - (c) After Care'
+      class: class_before_after_school_child_care_3
+      times:
+        -
+          time: academic_success_2
+      location: 1
+      facility: 92
+      online_registration: true
+      ticket_required: false
+      in_membership: false
+      age_min: 5
+      age_max: 18
+      reg_uri: 'http://www.openymca.org'
+      reg_title: 'Register Now'
+    -
+      id: session_kids_9
+      title: '2016/17 Sunrise - (a) Before and After Care'
+      class: class_before_after_school_child_care_4
+      times:
+        -
+          time: academic_success_2
+      location: 1
+      facility: 92
+      online_registration: true
+      ticket_required: false
+      in_membership: false
+      age_min: 5
+      age_max: 18
+      reg_uri: 'http://www.openymca.org'
+      reg_title: 'Register Now'
+    -
+      id: session_kids_10
+      title: '2016/17 Bellevue: No School Days - Package Option'
+      class: class_before_after_school_programs_1
+      times:
+        -
+          time: academic_success_2
+      location: 1
+      facility: 92
+      online_registration: true
+      ticket_required: false
+      in_membership: false
+      age_min: 5
+      age_max: 18
+      reg_uri: 'http://www.openymca.org'
+      reg_title: 'Register Now'
+    -
+      id: session_kids_11
+      title: 'Room Rental'
+      class: class_birthday_parties_1
+      times:
+        -
+          time: academic_success_2
+      location: 1
+      facility: 92
+      online_registration: true
+      ticket_required: false
+      in_membership: false
+      age_min: 5
+      age_max: 18
+      reg_uri: 'http://www.openymca.org'
+      reg_title: 'Register Now'
+    -
+      id: session_kids_12
+      title: 'Birthday Party'
+      class: class_birthday_parties_2
+      times:
+        -
+          time: academic_success_2
+      location: 1
+      facility: 92
+      online_registration: true
+      ticket_required: false
+      in_membership: false
+      age_min: 5
+      age_max: 18
+      reg_uri: 'http://www.openymca.org'
+      reg_title: 'Register Now'
+    -
+      id: session_kids_13
+      title: 'Earth Service Corps About YEST'
+      class: class_earth_service_corps_1
+      times:
+        -
+          time: academic_success_2
+      location: 1
+      facility: 92
+      online_registration: true
+      ticket_required: false
+      in_membership: false
+      age_min: 5
+      age_max: 18
+      reg_uri: 'http://www.openymca.org'
+      reg_title: 'Register Now'
+    -
+      id: session_kids_14
+      title: 'Kids Zone 4 wks - 11 yrs'
+      class: class_kids_zone_activity_centers_1
+      times:
+        -
+          time: academic_success_2
+      location: 1
+      facility: 92
+      online_registration: true
+      ticket_required: false
+      in_membership: false
+      age_min: 5
+      age_max: 18
+      reg_uri: 'http://www.openymca.org'
+      reg_title: 'Register Now'
+    -
+      id: session_kids_15
+      title: '2016/17 Northshore- Preschool Child Care (30m-4yr)'
+      class: class_preschool_child_care_1
+      times:
+        -
+          time: academic_success_2
+      location: 1
+      facility: 92
+      online_registration: true
+      ticket_required: false
+      in_membership: false
+      age_min: 5
+      age_max: 18
+      reg_uri: 'http://www.openymca.org'
+      reg_title: 'Register Now'
+    -
+      id: session_kids_16
+      title: '2016/17 Northshore - Pre-K Child Care (4 - 5yrs)'
+      class: class_preschool_child_care_2
+      times:
+        -
+          time: academic_success_2
+      location: 1
+      facility: 92
+      online_registration: true
+      ticket_required: false
+      in_membership: false
+      age_min: 5
+      age_max: 18
+      reg_uri: 'http://www.openymca.org'
+      reg_title: 'Register Now'
+    -
+      id: session_kids_17
+      title: 'HomeZone'
+      class: class_sports_classes_workshops_youth_1
+      times:
+        -
+          time: academic_success_2
+      location: 1
+      facility: 92
+      online_registration: true
+      ticket_required: false
+      in_membership: false
+      age_min: 5
+      age_max: 18
+      reg_uri: 'http://www.openymca.org'
+      reg_title: 'Register Now'
+    -
+      id: session_kids_18
+      title: 'Youth Fitness Challenge'
+      class: class_sports_classes_workshops_youth_2
+      times:
+        -
+          time: academic_success_2
+      location: 1
+      facility: 92
+      online_registration: true
+      ticket_required: false
+      in_membership: false
+      age_min: 5
+      age_max: 18
+      reg_uri: 'http://www.openymca.org'
+      reg_title: 'Register Now'
   ids:
     id:
       type: string

--- a/modules/openy_features/openy_demo_content/modules/openy_demo_nsessions/config/install/migrate_plus.migration.node_session_04.yml
+++ b/modules/openy_features/openy_demo_content/modules/openy_demo_nsessions/config/install/migrate_plus.migration.node_session_04.yml
@@ -1478,6 +1478,118 @@ source:
       age_max: 18
       reg_uri: 'http://www.openymca.org'
       reg_title: 'Register Now'
+    -
+      id: session_camp_1
+      title: 'BOLD Cascade Challenge'
+      class: class_bold_one_week_expeditions_1
+      times:
+        -
+          time: academic_success_2
+      location: 1
+      facility: 92
+      online_registration: true
+      ticket_required: false
+      in_membership: false
+      age_min: 5
+      age_max: 18
+      reg_uri: 'http://www.openymca.org'
+      reg_title: 'Register Now'
+    -
+      id: session_camp_2
+      title: 'A BOLD Backpacking Adventure: Discovery in the Olympics'
+      class: class_bold_one_week_expeditions_2
+      times:
+        -
+          time: academic_success_2
+      location: 1
+      facility: 92
+      online_registration: true
+      ticket_required: false
+      in_membership: false
+      age_min: 5
+      age_max: 18
+      reg_uri: 'http://www.openymca.org'
+      reg_title: 'Register Now'
+    -
+      id: session_camp_3
+      title: 'BOLD Rivers and Rocks'
+      class: class_bold_one_week_expeditions_3
+      times:
+        -
+          time: academic_success_2
+      location: 1
+      facility: 92
+      online_registration: true
+      ticket_required: false
+      in_membership: false
+      age_min: 5
+      age_max: 18
+      reg_uri: 'http://www.openymca.org'
+      reg_title: 'Register Now'
+    -
+      id: session_camp_4
+      title: 'BOLD Fishing and Backpacking in the North Cascades'
+      class: class_bold_one_week_expeditions_4
+      times:
+        -
+          time: academic_success_2
+      location: 1
+      facility: 92
+      online_registration: true
+      ticket_required: false
+      in_membership: false
+      age_min: 5
+      age_max: 18
+      reg_uri: 'http://www.openymca.org'
+      reg_title: 'Register Now'
+    -
+      id: session_camp_5
+      title: 'Discover Camp: Drop-off - Carol Edwards Ctr. 2017'
+      class: class_discovery_day_camp_1
+      times:
+        -
+          time: academic_success_2
+      location: 1
+      facility: 92
+      online_registration: true
+      ticket_required: false
+      in_membership: false
+      age_min: 5
+      age_max: 18
+      reg_uri: 'http://www.openymca.org'
+      reg_title: 'Register Now'
+    -
+      id: session_camp_6
+      title: 'Discovery Camp: Drop-off - Kenmore Elementary 2017'
+      class: class_discovery_day_camp_2
+      times:
+        -
+          time: academic_success_2
+      location: 1
+      facility: 92
+      online_registration: true
+      ticket_required: false
+      in_membership: false
+      age_min: 5
+      age_max: 18
+      reg_uri: 'http://www.openymca.org'
+      reg_title: 'Register Now'
+    -
+      id: session_camp_7
+      title: 'Discovery Camp: Drop-off - Northshore YMCA 2017'
+      class: class_discovery_day_camp_3
+      times:
+        -
+          time: academic_success_2
+      location: 1
+      facility: 92
+      online_registration: true
+      ticket_required: false
+      in_membership: false
+      age_min: 5
+      age_max: 18
+      reg_uri: 'http://www.openymca.org'
+      reg_title: 'Register Now'
   ids:
     id:
       type: string


### PR DESCRIPTION
### How to review:
Make sure that on the Camp Schedules Results page, only the following Categories should display:
- BOLD One-Week Expeditions
- Discovery Day Camp

Make sure that on the Kids & Teens Schedules Results page, only the following Categories should display:
- Academic Enrichment - Youth
- Academic Success
- Arts & Crafts
- Before & After School Child Care
- Before & After School Programs
- Birthday Parties
- Earth Service Corps
- Kids Zone Activity Centers
- Preschool Child Care
- Sports Classes & Workshops - Youth