### PR TITLE
Fix incorrect links for Repeat Schedules

### DIFF
--- a/modules/custom/openy_repeat/templates/openy-repeat-schedule-dashboard--table.html.twig
+++ b/modules/custom/openy_repeat/templates/openy-repeat-schedule-dashboard--table.html.twig
@@ -154,7 +154,7 @@
         </div>
 
         <div class="schedule-dashboard__modal--footer">
-          <a class="btn btn-lg btn-primary" v-bind:href="'node/' + locationPopup.nid">{{ 'View branch'|t }}</a>
+          <a class="btn btn-lg btn-primary" v-bind:href="'{{ url('<front>') }}node/' + locationPopup.nid">{{ 'View branch'|t }}</a>
         </div>
       </div>
     </div>
@@ -187,7 +187,7 @@
         </div>
 
         <div class="schedule-dashboard__modal--footer">
-          <a class="btn btn-lg btn-primary" v-bind:href="'node/' + classPopup.nid">{{ 'View More'|t }}</a>
+          <a class="btn btn-lg btn-primary" v-bind:href="'{{ url('<front>') }}node/' + classPopup.nid">{{ 'View More'|t }}</a>
         </div>
 
       </div>

--- a/openy.info.yml
+++ b/openy.info.yml
@@ -2,7 +2,7 @@ name: OpenY
 type: profile
 description: 'Open Y Drupal distribution.'
 core: 8.x
-version: '8.1.14-dev'
+version: '8.x-1.14-dev'
 distribution:
   name: OpenY
   install:


### PR DESCRIPTION
## Issue details:
When landing page has url alias which consists of several parts - links from modals contain theses parts and lead to 404 page.

Example:
- landing page with url "/schedules/group-exercise" contain links  like "/schedules/node/16"

Solution:
- Use base path in twig template

## Steps for review

- [x] Create landing page with url alias "/schedules/group-exercise"
- [x] Add "Repeat Schedules" paragraph to this landing page
- [x] Check that in location and class modals contain correct links
