### PR TITLE
PEF: Exclusions, sorting, timezones, handling weekdays, durations.

### DIFF
--- a/modules/custom/openy_repeat/src/RepeatManager.php
+++ b/modules/custom/openy_repeat/src/RepeatManager.php
@@ -229,14 +229,7 @@ class RepeatManager implements SessionInstanceManagerInterface {
     ];
 
     foreach ($session_schedule['dates'] as $schedule_item) {
-      if (!$schedule_item['frequency'] == 'weekly' && !$schedule_item['frequency'] == 'daily') {
-        continue;
-      }
-      // Daily is the same as Weekly but on every day of the week.
-      if ($schedule_item['frequency'] == 'daily') {
-        $schedule_item['frequency'] = 'weekly';
-        $schedule_item['days'] = array_keys($weekday_mapping);
-      }
+      $schedule_item['days'] = array_keys($weekday_mapping);
       foreach ($schedule_item['days'] as $weekDay) {
         // Starting period could start on Sunday. But we have Monday in the
         // settings. This is why we need to adjust day to proper day of
@@ -405,7 +398,6 @@ class RepeatManager implements SessionInstanceManagerInterface {
       }
 
       $schedule_item = [
-        'frequency' => $date->field_session_time_frequency->getValue()[0]['value'],
         'days' => [],
         'period' => [],
         'time' => [],
@@ -428,10 +420,8 @@ class RepeatManager implements SessionInstanceManagerInterface {
         $schedule['to'] = $schedule_item['period']['to'];
       }
 
-      if ($schedule_item['frequency'] == 'weekly') {
-        foreach ($date->field_session_time_days->getValue() as $value) {
-          $schedule_item['days'][] = $value['value'];
-        }
+      foreach ($date->field_session_time_days->getValue() as $value) {
+        $schedule_item['days'][] = $value['value'];
       }
 
       $schedule['dates'][] = $schedule_item;


### PR DESCRIPTION
**Exclusions**
Create a class with exclusion. For example create class starts 1 Aug to 5 Sept for every Wednesday 9 to 10am. Create exclusion on 15 Aug 9am to 10am. Ensure that class is missing on 15 August but all other days is present and correctly displayed

**Sorting**
Schedules now sorted by start time

**Handling weekdays**
Create a session every Thursday and ensure it displays on Thursdays only. Previously it could be shown on Friday instead.

**Class duration**
Create a session that is 12 hours. Ensure it displays properly. Previously only first digit was displayed (i.e. 1 instead of 12).

**Timezones**
Ensure that times of classes are properly displayed according to the site's timezone. For example import your GroupExPro classes and review their times.

**Daily sessions**
~~Create a session that has "daily" schedule. No need to specify days of the week. It should happen every single day. Ensure they got displayed properly on schedules.~~

Daily frequency was specific to Brandywine. Removed it to avoid getValue() error mentioned in review.