### PR TITLE
[YGBW-320]  Fix duplicate sessions on PEF Schedules page

### DIFF
--- a/modules/custom/openy_repeat/src/Controller/RepeatController.php
+++ b/modules/custom/openy_repeat/src/Controller/RepeatController.php
@@ -102,7 +102,8 @@ class RepeatController extends ControllerBase {
     $weekday = date('N', $date);
 
     $timestamp_start = $date;
-    $timestamp_end = $date + 24 * 60 * 60 * 60; // Next day.
+    // Next day.
+    $timestamp_end = $date + 24 * 60 * 60;
 
     $sql = "SELECT DISTINCT
               n.nid,


### PR DESCRIPTION
## Issue details
On YGBW project during testing new PEF Schedules page we found duplicates for most of the sessions.
![ygbw_pef_duplicates](https://user-images.githubusercontent.com/13733670/44658841-da14ef00-aa0a-11e8-89b8-847d7eef3e0f.png)

During investigation I have found small bug in `RepeatController.php`. This bug related to time range in db query:
```
    $timestamp_start = $date;
    $timestamp_end = $date + 24 * 60 * 60 * 60; // Next day.
```
`24 * 60 * 60 * 60` - adds 60 days instead of 1 day.
![screenshot from 2018-08-27 14-35-20](https://user-images.githubusercontent.com/13733670/44658978-61faf900-aa0b-11e8-92b2-e075b267120b.png)


After fixing this issue no more duplicates in schedules table:
![ygbw_pef_duplicates_with_fix](https://user-images.githubusercontent.com/13733670/44658965-5576a080-aa0b-11e8-92c9-e30d39156a5d.png)

## Steps for review

- [ ] On PEF Schedules page check that you can see sessions in correct time range (1 day).
