### PR TITLE
Fix PEF category sorting (use "natural order" algorithm)

### DIFF
--- a/modules/custom/openy_repeat/src/Plugin/Block/RepeatSchedulesBlock.php
+++ b/modules/custom/openy_repeat/src/Plugin/Block/RepeatSchedulesBlock.php
@@ -47,7 +47,9 @@ class RepeatSchedulesBlock extends BlockBase {
 
     $connection = \Drupal::database();
     $query = $connection->query($sql);
-    return $query->fetchCol();
+    $result = $query->fetchCol();
+    natsort($result);
+    return $result;
   }
 
   /**


### PR DESCRIPTION
## Issue details
Alphanumeric strings sorts incorrect in categories filter (PEF sidebar).
![pef_sort_issue](https://user-images.githubusercontent.com/13733670/44666570-5dd9d600-aa21-11e8-8f54-d147a47e8215.png)

I tried to improve mysql query order logic (see [MySQL Natural Sorting with ORDER BY Clause](http://www.mysqltutorial.org/mysql-natural-sorting/)), but none of suggested methods did not give the desired result, so I decided to use [natsort](http://php.net/manual/en/function.natsort.php) php function.

Categories list with this fix:
![pef_sort_issue_fixed](https://user-images.githubusercontent.com/13733670/44666627-76e28700-aa21-11e8-8442-602b03625424.png)

## Steps for review

- [ ] Create similar categories with different numbers it title
- [ ] Check that categories list on PEF schedules has natural order
