### PR TITLE
Fix full site path saved in config to avoid between domain issue

### DIFF
--- a/modules/custom/openy_map/src/Form/SettingsForm.php
+++ b/modules/custom/openy_map/src/Form/SettingsForm.php
@@ -164,20 +164,20 @@ class SettingsForm extends ConfigFormBase {
       if (is_dir($themePath)) {
         $themeFiles = scandir($themePath);
         foreach ($themeFiles as $themeFile) {
-          $path = $themePath . '/' . $themeFile;
-          if (is_dir($path)) {
+          $relative_path = $themePath . '/' . $themeFile;
+          if (is_dir($relative_path)) {
             continue;
           }
-          $path = file_create_url($path);
-          $fileOptions[$path] = '<img src="' . $path . '" />';
+          $path = file_create_url($relative_path);
+          $fileOptions[$relative_path] = '<img src="' . $path . '" />';
         }
       }
       $openYMapPath = drupal_get_path('module', 'openy_map') . '/img';
       foreach (scandir($openYMapPath) as $imgFile) {
-        $path = $openYMapPath . '/' . $imgFile;
-        if (!in_array($imgFile, $themeFiles) && !is_dir($path)) {
-          $path = file_create_url($path);
-          $fileOptions[$path] = '<img src="' . $path . '" />';
+        $relative_path = $openYMapPath . '/' . $imgFile;
+        if (!in_array($imgFile, $themeFiles) && !is_dir($relative_path)) {
+          $path = file_create_url($relative_path);
+          $fileOptions[$relative_path] = '<img src="' . $path . '" />';
         }
       }
 


### PR DESCRIPTION
issue https://github.com/ymcatwincities/openy/issues/1256
Make sure these boxes are checked before asking for review of your pull request - thank you!

If there is a new feature, please create PR against 8.x-1.xx-dev branch.

If this is a bug fix - use 8.x-1.x branch. We'll tag for release if the bug is critical asap or tag for release next bug fix release until critical issue arrived.

## Steps for review

- [ ] Go to admin/config/services/openy_map
- [ ] Select Locations Map icon
- [ ] Go to /admin/config/development/configuration/single/export
- [ ] Select in "Configuration name" list - 'openy_map.settings'
- [ ] Check config Line "type_icons:" there is should not full site path only relative like "theme/../...." or "profiles/contrib/openy/modules/custom/openy_map/img/map_icon_blue.png"

Thank you for your contribution!
