### PR TITLE
[OPENY-140] Fix membership calculator google map errors

### DIFF
--- a/modules/custom/openy_map/js/map.js
+++ b/modules/custom/openy_map/js/map.js
@@ -26,7 +26,9 @@
       // Marker designating the center point.
       search_center_marker: null,
       // Geocoder.
-      geocoder: typeof google.maps !== 'undefined' ? new google.maps.Geocoder() : {},
+      geocoder: function() {
+        return typeof google.maps !== 'undefined' ? new google.maps.Geocoder() : {};
+      },
 
       // Checks if the provider library object has loaded
       libraryIsLoaded: function () {
@@ -189,7 +191,7 @@
           }
         };
 
-        this.geocoder.geocode({
+        this.geocoder().geocode({
           'address': q
         }, $.proxy(f, this));
       },
@@ -286,7 +288,7 @@
         this.map.setZoom(14);
         if (position.coords.accuracy <= 15840) { // 3 miles.
 
-          this.geocoder.geocode({
+          this.geocoder().geocode({
               'latLng': this.search_center_point
             },
             $.proxy(
@@ -1542,6 +1544,10 @@
 
   Drupal.behaviors.openyMap = {
     attach: function (context, settings) {
+      if (typeof settings.openyMap === 'undefined' || typeof settings.openyMapSettings === 'undefined') {
+        return;
+      }
+
       var data = settings.openyMap;
       var map;
 


### PR DESCRIPTION
## Issue details
After update OpenY to 8.1.13 that contain `Add support for Leaflet maps` #1198 we got issues on membership calculator paragraph:
- `Uncaught ReferenceError: google is not defined` on second step of membership calculator
- `Uncaught TypeError: Cannot read property 'equals' of undefined at Object.draw_map_locations` on third step of membership calculator

Google map not display on page with this error.
I have provided fix for YGBW project, so current PR is backport for OpenY.

You can check fixed version on this page - https://www.ymcagbw.org/membership

## Steps for review

- [ ] Login as admin
- [ ] Go to `/admin/config/services/openy_map`
- [ ] Go to `/join` page
- [ ] Check that map works on second and third steps
- [ ] Go to `/locations` page, check that map works here too 
