### PR TITLE
Issue #1283: GroupExPro correct timezone during import.

### DIFF
--- a/modules/custom/openy_gxp/src/Plugin/migrate/process/OpenYGXPSchedule.php
+++ b/modules/custom/openy_gxp/src/Plugin/migrate/process/OpenYGXPSchedule.php
@@ -24,8 +24,18 @@ class OpenYGXPSchedule extends ProcessPluginBase {
     $value = json_decode($value, TRUE);
 //    {"times":[{"start":"18:00","end":"20:00"}],"days":["Friday"],"start_date":"2018-02-16","end_date":"2018-02-16"}
 
-    $startDate = $value['start_date'] . 'T' . $value['times']['start'] . ':00';
-    $endDate = $value['end_date'] . 'T' . $value['times']['end'] . ':00';
+    // Convert to UTC timezone to save to database.
+    $siteTimezone = new \DateTimeZone(drupal_get_user_timezone());
+    $gmtTimezone = new \DateTimeZone('GMT');
+
+    $startTime = new \DateTime($value['start_date'] . ' ' . $value['times']['start'] . ':00', $siteTimezone);
+    $startTime->setTimezone($gmtTimezone);
+
+    $endTime = new \DateTime($value['end_date'] . ' ' . $value['times']['end'] . ':00', $siteTimezone);
+    $endTime->setTimezone($gmtTimezone);
+
+    $startDate = $startTime->format(DATETIME_DATETIME_STORAGE_FORMAT);
+    $endDate = $endTime->format(DATETIME_DATETIME_STORAGE_FORMAT);
 
     $days = [];
     foreach ($value['days'] as $day) {


### PR DESCRIPTION
Fixes https://github.com/ymcatwincities/openy/issues/1283

Steps to test:
* install PEF GroupExPro integration module
* import the content
* ensure that session times are saved and displayed correctly

The problem was that time was coming in default timezone (whatever site is in, example New York), but we need to save it in UTC to the database.

Credits to YMCA WNC.