### PR TITLE
Issue #1285: PEF Obey day of the week.

### DIFF
--- a/modules/custom/openy_repeat/src/RepeatManager.php
+++ b/modules/custom/openy_repeat/src/RepeatManager.php
@@ -229,7 +229,6 @@ class RepeatManager implements SessionInstanceManagerInterface {
     ];
 
     foreach ($session_schedule['dates'] as $schedule_item) {
-      $schedule_item['days'] = array_keys($weekday_mapping);
       foreach ($schedule_item['days'] as $weekDay) {
         // Starting period could start on Sunday. But we have Monday in the
         // settings. This is why we need to adjust day to proper day of


### PR DESCRIPTION
Fixes https://github.com/ymcatwincities/openy/issues/1285

To test:
* run integration with GroupExPro (/admin/config/services/gxp)
* ensure that schedules are on correct days

Here are settings for YMCA WNC:
client id: 89
activity: any
mapping: but adjust names of the locations to your branch names. No need to use all the mapping.
```
470,Asheville YMCA
3316,Black Mountain YMCA
473,Corpening Memorial YMCA
2858,Ferguson Family YMCA
472,Hendersonville Family YMCA
1219,YMCA at Mission Pardee Health Campus
461,Reuter Family YMCA
471,Woodfin YMCA
```

Credits YMCA WNC