### PR TITLE
[OPENY-143] Fix googletranslate block error for carnation theme in st…

### DIFF
--- a/modules/custom/openy_gtranslate/config/optional/block.block.openy_carnation_googletranslate.yml
+++ b/modules/custom/openy_gtranslate/config/optional/block.block.openy_carnation_googletranslate.yml
@@ -1,3 +1,4 @@
+uuid: 32fa8958-20d7-41e0-9e7c-a5768bf6dfac
 langcode: en
 status: true
 dependencies:

--- a/openy.install
+++ b/openy.install
@@ -811,6 +811,7 @@ function openy_update_8054() {
   $themes_list = [
     'openy_rose' => '5a698466-f499-4dda-a084-4d61c1d0e902',
     'openy_lily' => '5a698466-f499-4dda-a084-4d61c1d0e777',
+    'openy_carnation' => '32fa8958-20d7-41e0-9e7c-a5768bf6dfac',
   ];
   /** @var \Drupal\Core\Entity\EntityTypeManager $entityTypeManager */
   $entityTypeManager = \Drupal::service('entity_type.manager');

--- a/openy.profile
+++ b/openy.profile
@@ -75,6 +75,7 @@ function openy_gtranslate_place_blocks(array &$install_state) {
   $themes_list = [
     'openy_rose' => '5a698466-f499-4dda-a084-4d61c1d0e902',
     'openy_lily' => '5a698466-f499-4dda-a084-4d61c1d0e777',
+    'openy_carnation' => '32fa8958-20d7-41e0-9e7c-a5768bf6dfac',
   ];
   /** @var \Drupal\Core\Entity\EntityTypeManager $entityTypeManager */
   $entityTypeManager = \Drupal::service('entity_type.manager');


### PR DESCRIPTION

## Steps for review

- [x] install site in standard preset
- [x] visit admin/appearance .
- [x] Click  "Install set as default" for OpenY Carnation theme.
- [x] Make sure that no errors with google translate block.

## General checks
- [x] All coding styles are fulfilled and there are no any issues reported by CodeSniffer CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/ci-errors.png" width="200" alt="CI code sniffer errors">
- [x] All tests are running and there are no failed tests reported by CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/behat.png" width="200" alt="Behat test results">
- [x] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [x] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [x] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [x] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [x] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
