### PR TITLE
[OPENY-135] Fix error when uninstalling `openy_media_local_video` module

### DIFF
--- a/modules/custom/openy_system/src/OpenyModulesManager.php
+++ b/modules/custom/openy_system/src/OpenyModulesManager.php
@@ -85,10 +85,10 @@ class OpenyModulesManager {
       'bundle_field' => 'type',
     ],
     // TODO: fix media_entity info after switching to core media.
-    'media_entity' => [
+    'media' => [
       'prefix' => 'media_entity.bundle',
       'config_entity_type' => 'media_bundle',
-      'bundle_field' => 'type',
+      'bundle_field' => 'bundle',
     ],
     'taxonomy_term' => [
       'prefix' => 'taxonomy.vocabulary',

--- a/modules/openy_features/openy_media/modules/openy_media_document/openy_media_document.info.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_document/openy_media_document.info.yml
@@ -15,7 +15,6 @@ dependencies:
   - media_entity
   - media_entity_document
   - openy_media
-  - openy_media_document
   - path
   - taxonomy
   - user

--- a/modules/openy_features/openy_media/modules/openy_media_image/openy_media_image.info.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_image/openy_media_image.info.yml
@@ -17,7 +17,6 @@ dependencies:
   - media_entity
   - media_entity_image
   - openy_media
-  - openy_media_image
   - path
   - taxonomy
   - user

--- a/modules/openy_features/openy_media/modules/openy_media_video/openy_media_video.info.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_video/openy_media_video.info.yml
@@ -13,7 +13,6 @@ dependencies:
   - image
   - media_entity
   - openy_media
-  - openy_media_video
   - path
   - taxonomy
   - user


### PR DESCRIPTION

## Steps for review

- [x] login as admin
- [x] visit /admin/modules/uninstall
- [x] Uninstall openy_media_local_video
- [x] Make sure no fatal errors.


## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/ci-errors.png" width="200" alt="CI code sniffer errors">
- [ ] All tests are running and there are no failed tests reported by CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/behat.png" width="200" alt="Behat test results">
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
