### PR TITLE
[OPENY-153] Add confirmation dialog to packages uninstall form submit

### DIFF
--- a/modules/custom/openy_system/js/openy_system.js
+++ b/modules/custom/openy_system/js/openy_system.js
@@ -1,0 +1,14 @@
+(function ($) {
+  "use strict";
+
+  /**
+   * Add confirmation message after uninstall package form submit.
+   */
+  Drupal.behaviors.openy_confirm_form = {
+    attach: function (context, settings) {
+      $("#packages-uninstall-confirm").on('click', function ()  {
+        return confirm(Drupal.t("Are you sure you want to uninstall packages?"))
+      });
+    }
+  };
+})(jQuery);

--- a/modules/custom/openy_system/js/openy_system.js
+++ b/modules/custom/openy_system/js/openy_system.js
@@ -7,7 +7,7 @@
   Drupal.behaviors.openy_confirm_form = {
     attach: function (context, settings) {
       $("#packages-uninstall-confirm").on('click', function ()  {
-        return confirm(Drupal.t("Are you sure you want to uninstall packages?"))
+        return confirm(Drupal.t("Are you sure you want to uninstall packages? Data and content from within these packages will be lost."))
       });
     }
   };

--- a/modules/custom/openy_system/openy_system.libraries.yml
+++ b/modules/custom/openy_system/openy_system.libraries.yml
@@ -1,0 +1,4 @@
+openy_system:
+  version: 1.x
+  js:
+    js/openy_system.js: {}

--- a/modules/custom/openy_system/src/Form/OpenyModulesUninstallConfirmForm.php
+++ b/modules/custom/openy_system/src/Form/OpenyModulesUninstallConfirmForm.php
@@ -14,6 +14,16 @@ class OpenyModulesUninstallConfirmForm extends ModulesUninstallConfirmForm {
   /**
    * {@inheritdoc}
    */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form = parent::buildForm($form, $form_state);
+    $form['#attached']['library'][] = 'openy_system/openy_system';
+    $form['actions']['submit']['#id'] = 'packages-uninstall-confirm';
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     parent::submitForm($form, $form_state);
     // Set redirect to project uninstall page

--- a/modules/custom/openy_system/src/OpenyModulesManager.php
+++ b/modules/custom/openy_system/src/OpenyModulesManager.php
@@ -461,5 +461,4 @@ class OpenyModulesManager {
     $this->removeModuleConfigs(array_merge($module_install_configs, $module_optional_configs));
   }
 
-
 }


### PR DESCRIPTION


## Steps for review

- [ ] login as admin
- [ ] open page admin/openy/extend/uninstall 
- [ ] select pakage and click Uninstall.
- [ ] make sure that browser's confirmation dialog window displayed.

## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/ci-errors.png" width="200" alt="CI code sniffer errors">
- [ ] All tests are running and there are no failed tests reported by CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/behat.png" width="200" alt="Behat test results">
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
