### PR TITLE
OS-173: Fixes the breadcrumbs z-index for the locations page.

### DIFF
--- a/themes/openy_themes/openy_carnation/dist/css/style.css
+++ b/themes/openy_themes/openy_carnation/dist/css/style.css
@@ -7594,7 +7594,7 @@ html.js .ajax-new-content:empty {
 .breadcrumbs-wrapper {
   position: absolute;
   bottom: -25px;
-  z-index: 2;
+  z-index: 1000;
   left: 0;
   right: 0; }
 

--- a/themes/openy_themes/openy_carnation/src/scss/component/_breadcrumbs.scss
+++ b/themes/openy_themes/openy_carnation/src/scss/component/_breadcrumbs.scss
@@ -8,7 +8,7 @@ $breadcrumbColorsLength: length($breadcrumbColors);
 .breadcrumbs-wrapper {
   position: absolute;
   bottom: -25px;
-  z-index: 2;
+  z-index: 1000;
   left: 0;
   right: 0;
 }
@@ -18,7 +18,6 @@ $breadcrumbColorsLength: length($breadcrumbColors);
   display: flex;
 
   li {
-
     span,
     a {
       @include cachet();


### PR DESCRIPTION
## Steps for review

- [ ] Visit the locations page.
- [ ] Ensure after dismissing all alerts that the breadcrumbs are placed above the google map.

https://www.drupal.org/project/openy/issues/3000670

## General checks
- [x] All coding styles are fulfilled and there are no any issues reported by CodeSniffer CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/ci-errors.png" width="200" alt="CI code sniffer errors">
- [ ] All tests are running and there are no failed tests reported by CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/behat.png" width="200" alt="Behat test results">
- [x] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [x] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [x] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [x] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [x] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
