### PR TITLE
[YGBW-337] Fix padding issue on taxonomy page

### DIFF
--- a/themes/openy_themes/openy_rose/templates/views/views-view-unformatted--taxonomy_term.html.twig
+++ b/themes/openy_themes/openy_rose/templates/views/views-view-unformatted--taxonomy_term.html.twig
@@ -22,7 +22,7 @@
       <h3>{{ title }}</h3>
     {% endif %}
 
-    <div class="main-region col-sm-12">
+    <div class="main-region col-12">
       {% for row in rows %}
         {%
           set row_classes = [

--- a/themes/openy_themes/openy_rose/templates/views/views-view-unformatted--taxonomy_term.html.twig
+++ b/themes/openy_themes/openy_rose/templates/views/views-view-unformatted--taxonomy_term.html.twig
@@ -17,7 +17,6 @@
  * @ingroup themeable
  */
 #}
-<div class="container">
   <div class="row taxonomy-term">
     {% if title %}
       <h3>{{ title }}</h3>
@@ -40,4 +39,3 @@
       {% endfor %}
     </div>
   </div>
-</div>


### PR DESCRIPTION
## Issue details:
On blog category page exist issue with padding.

![sports-ygbw_before-fix](https://user-images.githubusercontent.com/13733670/45811637-4adfbc00-bcd6-11e8-8b26-a718ca65ad92.png)


**Steps to reproduce:**
- Add small banner to any blog category, that contain blog posts.
- Check that padding in  views results is different from both sides

Issue related to this commit - https://github.com/ymcatwincities/openy/pull/862/commits/67d6535f28150d43509c3f163546bf3d71140193

Reason that now page contain 2 divs with "container class":
See:
- `openy/themes/openy_themes/openy_rose/templates/views/views-view-unformatted--taxonomy_term.html.twig`
- `openy/themes/openy_themes/openy_rose/templates/views/views-view.html.twig`

**Solution:** All taxonomy page content should be wrapped to container, so we need to remove one div from  `openy/themes/openy_themes/openy_rose/templates/views/views-view-unformatted--taxonomy_term.html.twig`

## Steps for review

- [x] Login as admin
- [x] Add small banner to any blog category, that contain blog posts.
- [x] Check that padding in views results looks similar from both sides
![sports-ygbw_after-fix](https://user-images.githubusercontent.com/13733670/45811916-0ef92680-bcd7-11e8-8a5a-fd88f341e754.png)
- [x] Check blog category without blogs, empty results message should be inside container
![sports-ygbw_after-fix_empty-results](https://user-images.githubusercontent.com/13733670/45811989-3d770180-bcd7-11e8-84a0-0df1eb81f21b.png)

