### PR TITLE
PEF: optimize performance

### DIFF
--- a/modules/custom/openy_repeat/js/repeat.js
+++ b/modules/custom/openy_repeat/js/repeat.js
@@ -256,19 +256,11 @@
           categories: this.categories.join(',')
         }});
       },
-      populatePopupL: function(location_name) {
-        for (var i = 0; i < this.table.length; i++) {
-          if (this.table[i].location === location_name) {
-            this.locationPopup = this.table[i].location_info;
-          }
-        }
+      populatePopupL: function(index) {
+        this.locationPopup = this.filteredTable[index].location_info;
       },
-      populatePopupC: function(class_id) {
-        for (var i = 0; i < this.table.length; i++) {
-          if (this.table[i].class === class_id) {
-            this.classPopup = this.table[i].class_info;
-          }
-        }
+      populatePopupC: function(index) {
+        this.classPopup = this.filteredTable[index].class_info;
       },
       backOneDay: function() {
         this.date = moment(this.date).add(-1, 'day').format('D MMM YYYY');

--- a/modules/custom/openy_repeat/templates/openy-repeat-schedule-dashboard--table.html.twig
+++ b/modules/custom/openy_repeat/templates/openy-repeat-schedule-dashboard--table.html.twig
@@ -44,12 +44,12 @@
 
           {# location #}
           <div v-cloak>
-            <strong><a class="schedule-dashboard__modal--location-link" role="button" v-on:click="populatePopupL(item.location)" data-toggle="modal" data-target=".schedule-dashboard__modal--location">${ item.location }</a></strong>
+            <strong><a class="schedule-dashboard__modal--location-link" role="button" v-on:click="populatePopupL(index)" data-toggle="modal" data-target=".schedule-dashboard__modal--location">${ item.location }</a></strong>
           </div>
 
           {# class #}
           <div v-cloak>
-            <strong><a class="schedule-dashboard__modal--class-link" role="button" v-on:click="populatePopupC(item.class)" data-toggle="modal" data-target=".schedule-dashboard__modal--class">${ item.name }</a></strong>
+            <strong><a class="schedule-dashboard__modal--class-link" role="button" v-on:click="populatePopupC(index)" data-toggle="modal" data-target=".schedule-dashboard__modal--class">${ item.name }</a></strong>
           </div>
 
           {# time #}

--- a/modules/custom/openy_repeat/templates/openy-repeat-schedule-dashboard--table.html.twig
+++ b/modules/custom/openy_repeat/templates/openy-repeat-schedule-dashboard--table.html.twig
@@ -44,12 +44,12 @@
 
           {# location #}
           <div v-cloak>
-            <strong><a class="schedule-dashboard__modal--location-link" role="button" v-on:click="populatePopupL(index)" data-toggle="modal" data-target=".schedule-dashboard__modal--location">${ item.location }</a></strong>
+            <strong><a class="schedule-dashboard__modal--location-link" role="button" v-on:click="$parent.populatePopupL(index)" data-toggle="modal" data-target=".schedule-dashboard__modal--location">${ item.location }</a></strong>
           </div>
 
           {# class #}
           <div v-cloak>
-            <strong><a class="schedule-dashboard__modal--class-link" role="button" v-on:click="populatePopupC(index)" data-toggle="modal" data-target=".schedule-dashboard__modal--class">${ item.name }</a></strong>
+            <strong><a class="schedule-dashboard__modal--class-link" role="button" v-on:click="$parent.populatePopupC(index)" data-toggle="modal" data-target=".schedule-dashboard__modal--class">${ item.name }</a></strong>
           </div>
 
           {# time #}


### PR DESCRIPTION
Just noticed the location and class popups lag on my mobile on new PEF schedules when there is a big dataset.

I found out the problem was in scanning the whole dataset for an appropriate record. According to the documentation https://vuejs.org/v2/guide/computed.html, computed properties are cached. So why not to use the already indexed and filtered table?

It guarantees constant less than 1ms access time on any device no matter how big the set of data, while the old code could result in ~1s delay and grew linearly with the size of the dataset.
