### PR TITLE
Update CSS for better Program Header Image responsiveness

### DIFF
--- a/themes/openy_themes/openy_lily/sass/global/_openy-lily-styles.scss
+++ b/themes/openy_themes/openy_lily/sass/global/_openy-lily-styles.scss
@@ -889,3 +889,8 @@ body .ajax-progress-throbber {
   min-height: 300px;
   max-height: 500px;
 }
+
+.program-header .content .image img { 
+  max-width: none; 
+  float: right; 
+}


### PR DESCRIPTION
Here is the issue this commit addresses - for reference: https://github.com/ymcatwincities/openy/issues/1275

## Steps for review

- [x] Using Lily Theme, navigation to any Program page with a Header Image
- [x] Narrow browser window, you will see program image "pinch", because height is static and width is percent.
- [x] Apply this commit
- [x] Same image should not maintain original aspect ratio, and overflow should be hidden as browser width scales down.

