### PR TITLE
[OPENY-219] Enable openy_map when locations package is enabled

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_loc_finder/openy_prgf_loc_finder.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_loc_finder/openy_prgf_loc_finder.info.yml
@@ -11,3 +11,4 @@ dependencies:
   - plugin
   - user
   - views
+  - openy_map


### PR DESCRIPTION
 Steps for review
- [x] install standard Open Y
- [x] enable Locations package
- [x] add a couple of branches nodes
- [x] create a landing page and add Location Finder and Location Finder filters paragraphs into the content area
- [x] verify the page works and shows the listing of branches as well as the filters and the map