### PR TITLE
[OPENY-192] Fix nonexisting service error when unistalling packages

### DIFF
--- a/docs/Development/Module Develompent.md
+++ b/docs/Development/Module Develompent.md
@@ -1,0 +1,5 @@
+### Module content removal
+
+When deleting an entity, where plugins or services of removing module are used, 
+then content removal should be done in the hook_uninstall() of that module.
+See openy_prgf_camp_menu.install as example.

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_camp_menu/openy_prgf_camp_menu.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_camp_menu/openy_prgf_camp_menu.install
@@ -6,6 +6,17 @@
  */
 
 /**
+ * Implements hook_uninstall().
+ */
+function openy_prgf_camp_menu_uninstall() {
+  // Remove paragraphs before module uninstall to avoid error with missing service
+  // that used in camp_menu block.
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('paragraph', 'paragraphs_type', 'camp_menu');
+}
+
+
+/**
  * Update Paragraph Camp Menu field_prgf_block.
  */
 function openy_prgf_camp_menu_update_8001() {

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_class_location/openy_prgf_class_location.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_class_location/openy_prgf_class_location.install
@@ -5,6 +5,16 @@
  */
 
 /**
+ * Implements hook_uninstall().
+ */
+function openy_prgf_class_location_uninstall() {
+  // Remove paragraphs before module uninstall to avoid error with missing service
+  // that used in class_location block.
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('paragraph', 'paragraphs_type', 'class_location');
+}
+
+/**
  * Update class location paragraph configuration.
  */
 function openy_prgf_class_location_update_8001() {

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_class_sessions/openy_prgf_class_sessions.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_class_sessions/openy_prgf_class_sessions.install
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @file
+ * OpenY class sessions paragraph.
+ */
+
+/**
+ * Implements hook_uninstall().
+ */
+function openy_prgf_class_sessions_uninstall() {
+  // Remove paragraphs before module uninstall to avoid error with missing service
+  // that used in class_sessions block.
+  \Drupal::service('openy.modules_manager')
+    ->removeEntityBundle('paragraph', 'paragraphs_type', 'class_sessions');
+}

--- a/openy.profile
+++ b/openy.profile
@@ -154,7 +154,6 @@ function openy_demo_content_configs_map($key = NULL) {
       'openy_demo_ncampaign',
       'openy_demo_ninterstitial',
       */
-      'openy_gxp',
     ],
     'standard' => [
       'openy_demo_nalert',


### PR DESCRIPTION
## Steps for review

- [x] login as admin.
- [x] visit admin/openy/extend/uninstall
- [x] uninstall Camp package
- [x] visit admin/reports/dblog.
- [x] make sure that camp related modules deleted without errors
- [x] return to admin/openy/extend/uninstall
- [x] uninstall Programs package.
- [x] make sure that Programs related modules deleted without errors

