### PR TITLE
Fix openy_socrates

### DIFF
--- a/modules/custom/openy_socrates/src/OpenySocratesCompilerPass.php
+++ b/modules/custom/openy_socrates/src/OpenySocratesCompilerPass.php
@@ -35,7 +35,7 @@ class OpenySocratesCompilerPass implements CompilerPassInterface {
         );
       }
       $priority = isset($attributes[0]['priority']) ? $attributes[0]['priority'] : 0;
-      $dds['priorities'][$priority][] = new Reference($id);
+      $dds[0][$priority][] = new Reference($id);
     }
 
     $definition->addMethodCall('collectDataServices', $dds);
@@ -54,7 +54,7 @@ class OpenySocratesCompilerPass implements CompilerPassInterface {
       }
 
       $periodicity = isset($attributes[0]['periodicity']) ? $attributes[0]['periodicity'] : 0;
-      $openy_cron_service_instances['cron'][$periodicity][] = new Reference($id);
+      $openy_cron_service_instances[0][$periodicity][] = new Reference($id);
     }
 
     $definition->addMethodCall('collectCronServices', $openy_cron_service_instances);


### PR DESCRIPTION
The PR fixes:

> NOTICE: PHP message: Symfony\Component\DependencyInjection\Exception\InvalidArgumentException: Invalid service "socrates": the value of argument "priorities" of method "Drupal\openy_socrates\OpenySocratesFacade::collectDataServices()" must be null, an instance of Symfony\Component\DependencyInjection\Reference or an instance of Symfony\Component\DependencyInjection\Definition, array given. in /var/www/site/vendor/symfony/dependency-injection/Compiler/ResolveNamedArgumentsPass.php on line 68 #0 /var/www/site/vendor/symfony/dependency-injection/Compiler/AbstractRecursivePass.php(60): Symfony\Component\DependencyInjection\Compiler\ResolveNamedArgumentsPass->processValue(Object(Symfony\Component\DependencyInjection\Definition), true)


## Steps for review

- [ ] Verify the build is built successfully.