### PR TITLE
"Class 'Drupal\openy_moderation_wrapper\Drupal' not found" error

### DIFF
--- a/modules/custom/openy_moderation_wrapper/src/EntityModerationStatus.php
+++ b/modules/custom/openy_moderation_wrapper/src/EntityModerationStatus.php
@@ -85,7 +85,7 @@ class EntityModerationStatus {
 
     $moderation_module = $this->active_moderation_module();
     if (\Drupal::moduleHandler()->moduleExists($moderation_module)) {
-      $moderation_service = Drupal::service($moderation_module . '.moderation_information');
+      $moderation_service = \Drupal::service($moderation_module . '.moderation_information');
       // The entity got archived.
       if ($original->moderation_state->entity &&
         $original->moderation_state->entity->isPublishedState() &&


### PR DESCRIPTION
On https://seattleymca.org project during openy update and switching from custom session instance implementation to OpenY Session Instance I got next error:

> Error: Class 'Drupal\openy_moderation_wrapper\Drupal' not found in Drupal\openy_moderation_wrapper\EntityModerationStatus->entity_moderation_state_change() (line 88 of /var/www/docroot/profiles/contrib/openy/modules/custom/openy_moderation_wrapper/src/EntityModerationStatus.php) #0 /var/www/docroot/profiles/contrib/openy/modules/custom/openy_session_instance/openy_session_instance.module(69): Drupal\openy_moderation_wrapper\EntityModerationStatus->entity_moderation_state_change(Object(Drupal\node\Entity\Node)) #1 /var/www/docroot/profiles/contrib/openy/modules/custom/openy_session_instance/openy_session_instance.module(37): openy_session_instance_actualize_sessions(Object(Drupal\node\Entity\Node)) #2 [internal function]: openy_session_instance_entity_update(Object(Drupal\node\Entity\Node)) #3 /var/www/docroot/core/lib/Drupal/Core/Extension/ModuleHandler.php(402): call_user_func_array('openy_session_i...', Array) #4 /var/www/docroot/core/lib/Drupal/Core/Entity/EntityStorageBase.php(169): Drupal\Core\Extension\ModuleHandler->invokeAll('entity_update', Array) #5 /var/www/docroot/core/lib/Drupal/Core/Entity/ContentEntityStorageBase.php(435): Drupal\Core\Entity\EntityStorageBase->invokeHook('update', Object(Drupal\node\Entity\Node)) #6 /var/www/docroot/core/lib/Drupal/Core/Entity/EntityStorageBase.php(470): Drupal\Core\Entity\ContentEntityStorageBase->invokeHook('update', Object(Drupal\node\Entity\Node)) #7 /var/www/docroot/core/lib/Drupal/Core/Entity/ContentEntityStorageBase.php(320): Drupal\Core\Entity\EntityStorageBase->doPostSave(Object(Drupal\node\Entity\Node), true) #8 /var/www/docroot/core/lib/Drupal/Core/Entity/EntityStorageBase.php(395): Drupal\Core\Entity\ContentEntityStorageBase->doPostSave(Object(Drupal\node\Entity\Node), true) #9 /var/www/docroot/core/lib/Drupal/Core/Entity/Sql/SqlContentEntityStorage.php(796): Drupal\Core\Entity\EntityStorageBase->save(Object(Drupal\node\Entity\Node)) #10 /var/www/docroot/core/lib/Drupal/Core/Entity/Entity.php(377): Drupal\Core\Entity\Sql\SqlContentEntityStorage->save(Object(Drupal\node\Entity\Node)) #11 /var/www/docroot/core/modules/node/src/NodeForm.php(286): Drupal\Core\Entity\Entity->save() #12 [internal function]: Drupal\node\NodeForm->save(Array, Object(Drupal\Core\Form\FormState)) #13 /var/www/docroot/core/lib/Drupal/Core/Form/FormSubmitter.php(111): call_user_func_array(Array, Array) #14 /var/www/docroot/core/lib/Drupal/Core/Form/FormSubmitter.php(51): Drupal\Core\Form\FormSubmitter->executeSubmitHandlers(Array, Object(Drupal\Core\Form\FormState)) #15 /var/www/docroot/core/lib/Drupal/Core/Form/FormBuilder.php(585): Drupal\Core\Form\FormSubmitter->doSubmitForm(Array, Object(Drupal\Core\Form\FormState)) #16 

This error related to openy_moderation_wrapper module.
