### PR TITLE
Fix for "Notice: Undefined variable: locations"

### DIFF
--- a/modules/custom/openy_session_instance/src/SessionInstanceManager.php
+++ b/modules/custom/openy_session_instance/src/SessionInstanceManager.php
@@ -553,6 +553,7 @@ class SessionInstanceManager implements SessionInstanceManagerInterface {
    * {@inheritdoc}
    */
   public function getLocationsByClassNode(NodeInterface $node) {
+    $locations = [];
     $nids = $this->getLocationIDsByClassNode($node);
 
     if ($nids) {


### PR DESCRIPTION
On https://seattleymca.org project during openy update and switching from custom session instance implementation to OpenY Session Instance I got next error:

> Notice: Undefined variable: locations in Drupal\openy_session_instance\SessionInstanceManager->getLocationsByClassNode() (line 564 of /var/www/docroot/profiles/contrib/openy/modules/custom/openy_session_instance/src/SessionInstanceManager.php) #0 /var/www/docroot/core/includes/bootstrap.inc(566): _drupal_error_handler_real(8, 'Undefined varia...', '/var/www/docroo...', 564, Array) /var/www/docroot/profiles/contrib/openy/modules/custom/openy_session_instance/src/SessionInstanceManager.php(564): 

