### PR TITLE
#1351 fixed slick index of removed slide

### DIFF
--- a/modules/openy_features/openy_node/modules/openy_node_alert/js/openy_node_alert.js
+++ b/modules/openy_features/openy_node/modules/openy_node_alert/js/openy_node_alert.js
@@ -32,9 +32,9 @@
         var slick = self.parents('.slick__slider').first();
         // Remove dismissed alerts.
         if ($.inArray(nid, dismissed) != -1) {
-          var index = self.parents('.slick__slide').eq(0).index();
-          if (slick.length > 0 && index > 0) {
-            var slickCheck = slick.slick('slickRemove', index -1);
+          var index = self.closest('.slick__slide').data('slick-index');
+          if (slick.length > 0 && index !== undefined) {
+            var slickCheck = slick.slick('slickRemove', index);
             if(!slickCheck) {
               self.remove();
               slick.parents('.slick-track').prevObject.remove();


### PR DESCRIPTION
## Steps for review

- [ ] Create or edit new Alert and configure it to show on specific page. After saving the alert node, it should appearing on the configured page.
- [ ] Open another page which is not in the list and close one or more slide(s).
- [ ] Go back to allowed page, configured Alert should appearing on this page.