### PR TITLE
Fix bug query of Popups form

### DIFF
--- a/modules/custom/openy_popups/src/Form/BranchesForm.php
+++ b/modules/custom/openy_popups/src/Form/BranchesForm.php
@@ -149,7 +149,7 @@ class BranchesForm extends FormBase {
       $query->condition('n.type', 'session');
       $query->condition('fps.field_activity_category_target_id', $this->nodeId);
       $query->condition('n.status', 1);
-      $query = $query;
+      $query->groupBy('fl.field_session_location_target_id');
       $items = $query->execute()->fetchAll();
 
       foreach ($items as $item) {


### PR DESCRIPTION
## Issue details:
When went to Subcategory page, popup with locations not displayed and return error in console.
It's happened, because query in db return million+ duplicated. 
![image](https://user-images.githubusercontent.com/24233384/49860923-ce0f3a80-fe0b-11e8-874f-9fa9f57c759e.png)

## Steps for review

- [ ] Open file `/modules/custom/openy_popups/src/Form/BranchesForm.php`.
- [ ] Check the variable `$items` returns result without duplicates.

Thank you for your contribution!
