### PR TITLE
Fix bug of Camp menu

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_camp_menu/templates/camp-menu.html.twig
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_camp_menu/templates/camp-menu.html.twig
@@ -25,13 +25,15 @@
   <div class="container">
     <nav class="columns">
       <h2 class="visually-hidden">{{ 'Camp Menu'|t }}</h2>
-      <ul class="camp-menu">
-        {% for link in links %}
-          <li class="camp-menu__item">
-            {{ link }}
-          </li>
-        {% endfor %}
-      </ul>
+      <div class="wrapper">
+        <ul class="camp-menu">
+          {% for link in links %}
+            <li class="camp-menu__item">
+              {{ link }}
+            </li>
+          {% endfor %}
+        </ul>
+      </div>
     </nav>
   </div>
 </div>

--- a/themes/openy_themes/openy_rose/scripts/openy_rose.js
+++ b/themes/openy_themes/openy_rose/scripts/openy_rose.js
@@ -132,7 +132,7 @@
 
           $list.css('width', listWidth + listPadding + "px");
 
-          var columns = $this.find('.columns');
+          var columns = $this.find('.wrapper');
           if (columns.length == 0) {
             return;
           }


### PR DESCRIPTION
## Issue details:
Camp menu do not swipe on a mobile device. You can see this error on every page of a Camp content type.

![selection_173](https://user-images.githubusercontent.com/24233384/49875583-64565700-fe32-11e8-9b6a-d8b139c612f2.png)

It's happening because the IsScroll library adds swipe events to the first child and the first element was`<h2>`, instead `<ul>`.

- [x] Go to any page of Camp content type on a mobile device
- [x] Check that menu is scrolled.

Thank you for your contribution!
