### PR TITLE
Page of Class content type loading is very long time

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_class_sessions/src/Plugin/Block/ClassSessions.php
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_class_sessions/src/Plugin/Block/ClassSessions.php
@@ -86,10 +86,8 @@ class ClassSessions extends BlockBase implements ContainerFactoryPluginInterface
     // Set cache tags from node.
     $tags = $node->getCacheTags();
 
-    // If location parameter is set add to conditions.
-    if (!empty($location_id = $this->getQueryParamInt('location'))) {
-      $conditions['location'] = $location_id;
-    }
+    // Location parameter add to conditions.
+    $conditions['location'] = $this->getQueryParamInt('location');
 
     // If session parameter is set add to conditions.
     if (!empty($session_id = $this->getQueryParamInt('session'))) {


### PR DESCRIPTION
## Issue details:
When go to on a Class content type first time, and on this page a lot of sessions, it is loading is very long time. Because it is loading all sessions.
I think, if you aren't chose location on popup, sessions shouldn't view on a page. 

## Steps for review

- [ ] Go to any page of Class content type
- [ ] You shouldn't see nothing sessions, before you aren't chose location on popup
