### PR TITLE
[OPENY-237] Remove blazy for render icon

### DIFF
--- a/modules/openy_features/openy_media/modules/openy_media_image/config/install/core.entity_view_display.media.image.icon.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_image/config/install/core.entity_view_display.media.image.icon.yml
@@ -20,55 +20,9 @@ content:
     label: hidden
     settings:
       image_style: ''
-      thumbnail_style: ''
-      media_switch: ''
-      ratio: enforced
-      sizes: ''
-      breakpoints:
-        xs:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        sm:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        md:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        lg:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-        xl:
-          image_style: ''
-          width: ''
-          breakpoint: ''
-      current_view_mode: icon
-      background: false
-      caption:
-        title: '0'
-        alt: '0'
-      iframe_lazy: true
-      icon: ''
-      layout: ''
-      view_mode: ''
-      cache: 0
-      optionset: default
-      skin: ''
-      style: ''
-      box_caption: ''
-      box_caption_custom: ''
-      box_style: ''
-      box_media_style: ''
-      responsive_image_style: ''
-      grid: 0
-      grid_header: ''
-      grid_medium: 0
-      grid_small: 0
+      image_link: ''
     third_party_settings: {  }
-    type: blazy
+    type: image
     region: content
 hidden:
   created: true

--- a/modules/openy_features/openy_media/modules/openy_media_image/openy_media_image.install
+++ b/modules/openy_features/openy_media/modules/openy_media_image/openy_media_image.install
@@ -255,3 +255,24 @@ function openy_media_image_update_8009() {
     }
   }
 }
+
+/**
+ * Remove blazy for icons.
+ */
+function openy_media_image_update_8010() {
+  \Drupal::configFactory()
+    ->getEditable('core.entity_view_display.media.image.icon')
+    ->set('dependencies.module', ['image'])
+    ->set('content.field_media_image', [
+      'weight' => 0,
+      'label' => 'hidden',
+      'settings' => [
+        'image_style' => '',
+        'image_link' => '',
+      ],
+      'third_party_settings' => [],
+      'type' => 'image',
+      'region' => 'content',
+    ])
+    ->save();
+}

--- a/modules/openy_features/openy_media/modules/openy_media_image/openy_media_image.install
+++ b/modules/openy_features/openy_media/modules/openy_media_image/openy_media_image.install
@@ -260,19 +260,20 @@ function openy_media_image_update_8009() {
  * Remove blazy for icons.
  */
 function openy_media_image_update_8010() {
-  \Drupal::configFactory()
-    ->getEditable('core.entity_view_display.media.image.icon')
-    ->set('dependencies.module', ['image'])
-    ->set('content.field_media_image', [
-      'weight' => 0,
-      'label' => 'hidden',
-      'settings' => [
-        'image_style' => '',
-        'image_link' => '',
-      ],
-      'third_party_settings' => [],
-      'type' => 'image',
-      'region' => 'content',
-    ])
-    ->save();
+  $config_dir = drupal_get_path('module', 'openy_media_image') . '/config/install/';
+  // Update multiple configurations.
+  $configs = [
+    'core.entity_view_display.media.image.icon' => [
+      'dependencies.module',
+      'content.field_media_image',
+    ],
+  ];
+
+  $config_updater = \Drupal::service('openy_upgrade_tool.param_updater');
+  foreach ($configs as $config_name => $params) {
+    $config = $config_dir . $config_name . '.yml';
+    foreach ($params as $param) {
+      $config_updater->update($config, $config_name, $param);
+    }
+  }
 }


### PR DESCRIPTION
## Issue details:
When used Grid columns paragraph type and upload icons, they are rendered with Blazy. Blazy added custom inline styles and we can see big space after icons.
![before](https://user-images.githubusercontent.com/24233384/50150144-280d7580-02ce-11e9-930a-7ef04b89fffa.png)
I changed entity view display in media to `Image`.
![after](https://user-images.githubusercontent.com/24233384/50150273-7753a600-02ce-11e9-9887-434a28d81771.png)

## Steps for review
- [x] Go to /node/add/landing_page
- [x] Set `One column` value in Layout of Landing page
- [x] Add `Grid columns` paragraph to Content Area region
- [x] Set `3 items per row` value in Style
- [x] Add grid columns, and in last column upload this icon <img src="https://user-images.githubusercontent.com/24233384/50150325-b08c1600-02ce-11e9-83c4-3f18d19e7935.jpg" width="50" alt="Icon">
- [x] Save this page
- [x] You shouldn't see space as the picture. 
![after](https://user-images.githubusercontent.com/24233384/50150571-6c4d4580-02cf-11e9-9486-73a1b0591af7.png)


