### PR TITLE
Fix fatal for blog post teasers rendered in openy_rose

### DIFF
--- a/themes/openy_themes/openy_rose/templates/node/node--blog--teaser.html.twig
+++ b/themes/openy_themes/openy_rose/templates/node/node--blog--teaser.html.twig
@@ -96,7 +96,7 @@
         {% if ( node.field_blog_style.value == "story" ) %}
           <div class="story-card">
             <div class="quote">
-              {% include base_path ~ directory ~ '/img/icons/quote_purple.svg' %}
+              {% include '@openy_rose/../img/icons/quote_purple.svg' %}
             </div>
           </div>
         {% endif %}

--- a/themes/openy_themes/openy_rose/templates/paragraph/paragraph--story-card--default.html.twig
+++ b/themes/openy_themes/openy_rose/templates/paragraph/paragraph--story-card--default.html.twig
@@ -49,7 +49,7 @@ set classes = [
   <a href="{{ content.field_prgf_link.0['#url'] }}">
     {{ content.field_prgf_title }}
     <div class="quote">
-      {% include base_path ~ directory ~ '/img/icons/quote_purple.svg' %}
+      {% include '@openy_rose/../img/icons/quote_purple.svg' %}
       {{ content.field_prgf_headline }}
     </div>
     <div class="link">


### PR DESCRIPTION
Reverts ymcatwincities/openy#1317

The reverted PR introduces a fatal error if there is a teaser of a blog post of type story on the page when openy_rose theme is the current theme.

That's easy to catch on any upgrade build at the moment.

`Twig_Error_Loader: Template "/build1191/profiles/contrib/openy/themes/openy_themes/openy_rose/img/icons/quote_purple.svg" is not defined in "profiles/contrib/openy/themes/openy_themes/openy_rose/templates/node/node--blog--teaser.html.twig" at line 99. in Twig_Loader_Chain->getCacheKey() (line 129 of /var/lib/jenkins/jobs/PR_BUILDER_COMPOSER/workspace/build1191/openy-project/vendor/twig/twig/lib/Twig/Loader/Chain.php).`

Addresses #1306
See https://www.drupal.org/docs/8/theming-drupal-8/including-part-template

Steps for review:
- [x] go to the upgrade build
- [x] make sure the front page isn't returning 500 anymore