### PR TITLE
Skip moderation state checking if bundle not support content moderation

### DIFF
--- a/modules/custom/openy_moderation_wrapper/src/EntityModerationStatus.php
+++ b/modules/custom/openy_moderation_wrapper/src/EntityModerationStatus.php
@@ -25,6 +25,9 @@ class EntityModerationStatus {
    */
   protected $moduleHandler;
 
+  /**
+   * Constructs EntityModerationStatus object.
+   */
   public function __construct(ConfigFactoryInterface $config_factory, ModuleHandlerInterface $module_handler) {
     $this->configFactory = $config_factory;
     $this->moduleHandler = $module_handler;
@@ -56,17 +59,18 @@ class EntityModerationStatus {
    */
   public function entity_moderation_status(EntityInterface $entity) {
     $moderation_module = $this->active_moderation_module();
-
     if ($this->moduleHandler->moduleExists($moderation_module)) {
       $moderation_info = \Drupal::service($moderation_module . '.moderation_information');
+      // Check that entity bundle support moderation.
+      if ($moderation_info->getWorkflowForEntity($entity)) {
+        // Contains checking:
+        // isLatestRevision, isDefaultRevision, isPublishedState.
+        return $moderation_info->isLiveRevision($entity);
+      }
+    }
 
-      // Contains checking: isLatestRevision, isDefaultRevision, isPublishedState.
-      return $moderation_info->isLiveRevision($entity);
-    }
-    else {
-      // Fallback to is isPublished & isDefaultRevision.
-      return ($entity->isPublished() && $entity->isDefaultRevision());
-    }
+    // Fallback to is isPublished & isDefaultRevision.
+    return ($entity->isPublished() && $entity->isDefaultRevision());
   }
 
   /**
@@ -78,35 +82,50 @@ class EntityModerationStatus {
    * @return bool
    *   Flag indicated the entity has changed its state.
    */
-  function entity_moderation_state_change(EntityInterface $entity) {
+  public function entity_moderation_state_change(EntityInterface $entity) {
     if (!$original = $entity->original) {
       return FALSE;
     }
 
     $moderation_module = $this->active_moderation_module();
+    $check_published_state = FALSE;
     if (\Drupal::moduleHandler()->moduleExists($moderation_module)) {
       $moderation_service = \Drupal::service($moderation_module . '.moderation_information');
-      // The entity got archived.
-      if ($original->moderation_state->entity &&
-        $original->moderation_state->entity->isPublishedState() &&
-        !$moderation_service->isLiveRevision($entity)
-      ) {
-        return TRUE;
-      }
+      // Check that entity bundle support moderation.
+      if ($moderation_service->getWorkflowForEntity($entity)) {
+        // The entity got archived.
+        if ($original->moderation_state->entity &&
+          $original->moderation_state->entity->isPublishedState() &&
+          !$moderation_service->isLiveRevision($entity)
+        ) {
+          return TRUE;
+        }
 
-      // The entity got published.
-      if ((!$original->moderation_state->entity || !$original->moderation_state->entity->isPublishedState()) &&
-        $moderation_service->isLiveRevision($entity)
-      ) {
-        return TRUE;
+        // The entity got published.
+        if ((!$original->moderation_state->entity || !$original->moderation_state->entity->isPublishedState()) &&
+          $moderation_service->isLiveRevision($entity)
+        ) {
+          return TRUE;
+        }
+      }
+      else {
+        $check_published_state = TRUE;
       }
     }
-    // The entity published state changed.
-    elseif ($entity->isDefaultRevision() &&
-      ((!$original->isPublished() && $entity->isPublished()) ||
-        ($original->isPublished() && !$entity->isPublished()))
-    ) {
-      return TRUE;
+    else {
+      $check_published_state = TRUE;
+    }
+
+    // Check published state in case disabled moderation module or
+    // not moderated entity bundle.
+    if ($check_published_state) {
+      // The entity published state changed.
+      if ($entity->isDefaultRevision() &&
+        ((!$original->isPublished() && $entity->isPublished()) ||
+          ($original->isPublished() && !$entity->isPublished()))
+      ) {
+        return TRUE;
+      }
     }
 
     return FALSE;


### PR DESCRIPTION
Backported from the YMCA of Greater Seattle
----
In case moderation state disabled for the class content type we got incorrect work for session instances and repeat event recreating. Both services use `EntityModerationStatus` from `openy_moderation_wrapper` module so we need to add additional checking to these service methods. 

For this checking, I have used `getWorkflowForEntity` from `ModerationInformation` service that exists in content and workbench moderation. 
```php
  /**
   * Gets the workflow for the given content entity.
   *
   * @param \Drupal\Core\Entity\ContentEntityInterface $entity
   *   The content entity to get the workflow for.
   *
   * @return \Drupal\workflows\WorkflowInterface|null
   *   The workflow entity. NULL if there is no workflow.
   */
  public function getWorkflowForEntity(ContentEntityInterface $entity) {
    $bundles = $this->bundleInfo->getBundleInfo($entity->getEntityTypeId());
    if (isset($bundles[$entity->bundle()]['workflow'])) {
      return $this->entityTypeManager->getStorage('workflow')->load($bundles[$entity->bundle()]['workflow']);
    };
    return NULL;
  }
```

## Steps to reproduce

- [x] Login as admin
- [x] Go to /admin/modules/uninstall and remove all modules that related to repeat event (it override session instance manager)
- [x] Go to /admin/config/workflow/workflows/manage/editorial
- [x] If your section `THIS WORKFLOW APPLIES TO:` contain not configured Content types row - add all content types except session.
- [x] Create class with valid rules for session instance (it must be published and contain filled in the Activity field with correct data)
- [x] Create several sessions with valid rules for session instance (it must be published and contain filled in the fields with correct data)
- [x] Check that on /admin/structure/session_instance you can see created instances
- [x] Go to /admin/config/workflow/workflows/manage/editorial
- [x] Disable moderation for class content type
- [x] Repeat steps with classes and sessions
- [x] Check that session instances not created