### PR TITLE
issue/1388 fixed ugly breadcrumbs in the demo content

### DIFF
--- a/modules/openy_features/openy_demo_content/modules/openy_demo_nclass/config/install/migrate_plus.migration.node_class_02.yml
+++ b/modules/openy_features/openy_demo_content/modules/openy_demo_nclass/config/install/migrate_plus.migration.node_class_02.yml
@@ -1579,7 +1579,7 @@ source:
     -
       id: class_activity_arts_crafts_1
       title: 'May Crafternoon: Handprint Sunshines'
-      activity: aactivity_arts_crafts
+      activity: activity_arts_crafts
       body: |
         <p>May Crafternoon: Handprint Sunshines</p>
 #    -
@@ -1690,7 +1690,7 @@ process:
   field_class_activity:
     plugin: migration
     migration: openy_demo_node_activity
-    no_stub: false
+    no_stub: true
     source: activity
   field_class_description/value: body
   field_class_description/format:

--- a/modules/openy_features/openy_demo_content/modules/openy_demo_nsessions/config/install/migrate_plus.migration.node_session_04.yml
+++ b/modules/openy_features/openy_demo_content/modules/openy_demo_nsessions/config/install/migrate_plus.migration.node_session_04.yml
@@ -1896,6 +1896,7 @@ process:
   field_session_class:
     plugin: migration
     migration: openy_demo_node_class_02
+    no_stub: true
     source: class
   field_session_location:
     plugin: migration


### PR DESCRIPTION
https://github.com/ymcatwincities/openy/issues/1388
## Steps for review

- [ ] run clean installation(fin init).
- [ ] after observe breadcrumbs on any page under PROGRAMS. breadcrumbs should be without ugly title like "wamamusluchevocanidithohonuthutuprawrishuspistugiprolathaprumothiweduwubrahiswashuspomustodruhupheswespesuuushuuashurouonuvecipiwaramithuslewodawatrigoshuwobrewruhigupobrestugocebamochu".

@podarok , @danylevskyi please review.