### PR TITLE
[ISSUE-1428]: Breadcrumbs are cut off on location finder in Carnation

### DIFF
--- a/modules/openy_features/openy_node/modules/openy_node_alert/js/openy_node_alert.js
+++ b/modules/openy_features/openy_node/modules/openy_node_alert/js/openy_node_alert.js
@@ -50,6 +50,7 @@
             if(!slickCheck) {
               self.remove();
               slick.parents('.slick-track').prevObject.remove();
+              $('.slick-arrow').remove();
             }
           }
           else {

--- a/themes/openy_themes/openy_carnation/dist/css/style.css
+++ b/themes/openy_themes/openy_carnation/dist/css/style.css
@@ -7604,7 +7604,7 @@ html.js .ajax-new-content:empty {
 .breadcrumbs-wrapper {
   position: absolute;
   bottom: -25px;
-  z-index: 2;
+  z-index: 10;
   left: 0;
   right: 0; }
 

--- a/themes/openy_themes/openy_carnation/src/scss/component/_breadcrumbs.scss
+++ b/themes/openy_themes/openy_carnation/src/scss/component/_breadcrumbs.scss
@@ -8,7 +8,7 @@ $breadcrumbColorsLength: length($breadcrumbColors);
 .breadcrumbs-wrapper {
   position: absolute;
   bottom: -25px;
-  z-index: 2;
+  z-index: 10;
   left: 0;
   right: 0;
 }


### PR DESCRIPTION
Issue: #1428

## Steps for review

- [ ] Enable 'Carnation' theme.
- [ ] Go to Locations page `/locations`.
- [ ] Close alerts popup.
- [ ] Make sure breadcrumbs are displayed correctly.
- [ ] Slick arrows are not displayed after closing of alerts popup (if several alerts).
- [ ] There no any regressions on front.

## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/ci-errors.png" width="200" alt="CI code sniffer errors">
- [ ] All tests are running and there are no failed tests reported by CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/behat.png" width="200" alt="Behat test results">
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
