### PR TITLE
Issue #1453: Schedules: IE padding issue

### DIFF
--- a/modules/custom/openy_repeat/css/repeat.css
+++ b/modules/custom/openy_repeat/css/repeat.css
@@ -340,6 +340,7 @@ label[aria-expanded=false] .minus {
 .schedules-data__row>div {
   padding: 8px 20px;
   flex: 0 0 50%;
+  max-width: 50%; /** Small hack for IE10/11 to fix padding for flex child elements **/
 }
 
 


### PR DESCRIPTION
Issue: https://github.com/ymcatwincities/openy/issues/1453
## Steps for review

- [x] Schedules looks OK for mobile and desktop version in IE and Edge.
- [x] Schedules looks OK for mobile and desktop version in Chrome.
- [x] Schedules looks OK for mobile and desktop version in Firefox.

## General checks
- [x] All coding styles are fulfilled and there are no any issues reported by CodeSniffer CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/ci-errors.png" width="200" alt="CI code sniffer errors">
- [x] All tests are running and there are no failed tests reported by CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/behat.png" width="200" alt="Behat test results">
- [x] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [x] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [x] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [x] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [x] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
