### PR TITLE
[OPENY-252] Remove hardcoded PEF Schedules menu id 

### DIFF
--- a/modules/openy_features/openy_demo_content/modules/openy_demo_nlanding/openy_demo_nlanding.module
+++ b/modules/openy_features/openy_demo_content/modules/openy_demo_nlanding/openy_demo_nlanding.module
@@ -91,7 +91,18 @@ function openy_demo_nlanding_pef_pages() {
   $locations_node->field_content->entity = $location_paragraph;
   $locations_node->save();
 
-  $parent_menu_link = \Drupal\menu_link_content\Entity\MenuLinkContent::load(39);
+
+  $database = \Drupal::database();
+  $query = $database->select('menu_link_content_data', 'm');
+  $query->condition('bundle', 'menu_link_content');
+  $query->condition('enabled', 1);
+  $query->condition('expanded', 1);
+  $query->condition('m.menu_name', 'main');
+  $query->condition('title', "Schedules");
+  $query->fields('m', ['id']);
+  $id = $query->execute()->fetchField();
+
+  $parent_menu_link = \Drupal\menu_link_content\Entity\MenuLinkContent::load($id);
 //  $menu_link = \Drupal\menu_link_content\Entity\MenuLinkContent::create([
 //    'title' => 'Program Schedules',
 //    'link' => ['uri' => 'entity:node/' . $locations_node->id()],


### PR DESCRIPTION
…to fix schedules submenus display



## Steps for review

- [x] check expanded Schedules menu
- [x] make sure that Camp, Group Classes, Kids and Teens , Personal Training, Program & Actibities, Swim menu items displayed and clickable
![image](https://user-images.githubusercontent.com/16559938/51401880-999e4500-1b54-11e9-90aa-4b46b63db690.png)

## General checks
- [x] All coding styles are fulfilled and there are no any issues reported by CodeSniffer CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/ci-errors.png" width="200" alt="CI code sniffer errors">
- [x] All tests are running and there are no failed tests reported by CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/behat.png" width="200" alt="Behat test results">
- [x] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [x] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [x] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [x] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [x] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
