### PR TITLE
[OPENY-256] Fix placeholder error in template for schedules filter

### DIFF
--- a/modules/custom/openy_schedules/templates/openy-schedules-subcategory-filters.html.twig
+++ b/modules/custom/openy_schedules/templates/openy-schedules-subcategory-filters.html.twig
@@ -13,7 +13,11 @@
   <div class="filters">
     <div class="label">{{ 'Filtered by:'|t }}</div>
     {% for key, value in filters %}
-    <div class="filter">{{ value }}<a href="#" data-id="{{ key }}" class="remove" title="{{ 'Clear !key filter'|t({ '!key': key }) }}"><i class="fa fa-close" aria-hidden="true"></i></a></div>
+      <div class="filter">{{ value }}
+        <a href="#" data-id="{{ key }}" class="remove" title="{{ 'Clear @value filter'|t({ '@value': value }) }}">
+          <i class="fa fa-close" aria-hidden="true"></i>
+        </a>
+      </div>
     {% endfor %}
   </div>
 </div>


### PR DESCRIPTION
## Steps for review

- [x] visit page /schedules
- [x] make sure no error with Incorrect placeholder during page loading.
- [x] select WEST YMCA branch
- [x] move mouse cursor to the _Filtered by_ region hover on close sign near filter
- [x] make sure you see tooltip for close button like "Close West YMCA filter"

