### PR TITLE
[OPENY-264] Store date of accepting T&C

### DIFF
--- a/modules/custom/openy_system/openy_system.routing.yml
+++ b/modules/custom/openy_system/openy_system.routing.yml
@@ -95,3 +95,10 @@ openy_system.openy_terms_and_conditions:
     _title: 'Terms and conditions'
   requirements:
     _permission: 'access content'
+
+openy_system.terms:
+  path: '/terms.txt'
+  defaults:
+    _controller: '\Drupal\openy_system\Controller\TermsOfUseController::content'
+  requirements:
+    _access: 'TRUE'

--- a/modules/custom/openy_system/src/Controller/TermsOfUseController.php
+++ b/modules/custom/openy_system/src/Controller/TermsOfUseController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Drupal\openy_system\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Symfony\Component\HttpFoundation\Response;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+
+/**
+ * Provides output terms.txt output.
+ */
+class TermsOfUseController extends ControllerBase implements ContainerInjectionInterface {
+
+  /**
+   * Provides the terms.txt file.
+   *
+   * @return \Symfony\Component\HttpFoundation\Response
+   *   The terms.txt file as a response object with 'text/plain' content type.
+   */
+  public function content() {
+    $config = \Drupal::config('openy.terms_and_conditions.schema');
+    $timestamp = $config->get('accepted_version');
+    $content = $this->t('Terms and Conditions were not accepted');
+
+    // Is accepted.
+    if ($timestamp) {
+      $date = \Drupal::service('date.formatter')
+        ->format($timestamp, 'custom', 'F d, Y', 'UTC');
+      $time = \Drupal::service('date.formatter')
+        ->format($timestamp, 'custom', 'H:i:s', 'UTC');
+      $content = $this->t(
+        'Terms and Conditions were accepted on @date at @time time UTC',
+        [
+          '@date' => $date,
+          '@time' => $time,
+        ]
+      );
+    }
+
+    return new Response($content, 200, ['Content-Type' => 'text/plain']);
+  }
+
+}

--- a/modules/custom/openy_system/src/Controller/TermsOfUseController.php
+++ b/modules/custom/openy_system/src/Controller/TermsOfUseController.php
@@ -3,6 +3,8 @@
 namespace Drupal\openy_system\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Datetime\DateFormatterInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 
@@ -12,21 +14,44 @@ use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 class TermsOfUseController extends ControllerBase implements ContainerInjectionInterface {
 
   /**
+   * TermsOfUseController constructor.
+   *
+   * @param \Drupal\Core\Datetime\DateFormatterInterface $dateFormatter
+   */
+  public function __construct(DateFormatterInterface $dateFormatter) {
+    $this->dateFormatter = $dateFormatter;
+  }
+
+  /**
+   * {@inheritdoc}
+   *
+   * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+   *   The Drupal service container.
+   *
+   * @return static
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('date.formatter')
+    );
+  }
+
+  /**
    * Provides the terms.txt file.
    *
    * @return \Symfony\Component\HttpFoundation\Response
    *   The terms.txt file as a response object with 'text/plain' content type.
    */
   public function content() {
-    $config = \Drupal::config('openy.terms_and_conditions.schema');
+    $config = $this->config('openy.terms_and_conditions.schema');
     $timestamp = $config->get('accepted_version');
     $content = $this->t('Terms and Conditions were not accepted');
 
     // Is accepted.
     if ($timestamp) {
-      $date = \Drupal::service('date.formatter')
+      $date = $this->dateFormatter
         ->format($timestamp, 'custom', 'F d, Y', 'UTC');
-      $time = \Drupal::service('date.formatter')
+      $time = $this->dateFormatter
         ->format($timestamp, 'custom', 'H:i:s', 'UTC');
       $content = $this->t(
         'Terms and Conditions were accepted on @date at @time time UTC',


### PR DESCRIPTION
## Details issue
Add the /terms.txt page that will show information from Drupal config which is stored upon saving the Terms and Conditions form

## Steps for review
- [ ] Go to /terms.txt
- [ ] Check that you see information about when the Terms and Conditions were accepted

Thank you for your contribution!
