### PR TITLE
[OPENY-270]: Terms of Use enhancement

### DIFF
--- a/src/Form/TermsOfUseForm.php
+++ b/src/Form/TermsOfUseForm.php
@@ -80,7 +80,7 @@ class TermsOfUseForm extends FormBase {
       '#weight' => 6,
     ];
 
-    // Submit button must displayed on installation Open Y only.
+    // Submit button must displayed on installation pages only.
     if ($route_name != 'openy_system.openy_terms_and_conditions') {
       $form['submit'] = [
         '#type' => 'submit',


### PR DESCRIPTION
## Steps for review

- [ ] Go throw installation process and make sure user can accept Terms of Use on manual installation without any regressions.
- [ ] Go to `/admin/openy/terms-and-conditions`
- [ ] Verify "Continue Installation" button is not displayed on the form.
- [ ] Verify all checkboxes are disabled.
- [ ] Install site with drush (with automatical acceptance of Terms of Use).
- [ ] Go to  `/admin/openy/terms-and-conditions`
- [ ] Verify "Continue Installation" button is not displayed on the form.
- [ ] Verify all checkboxes are disabled.

## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/ci-errors.png" width="200" alt="CI code sniffer errors">
- [ ] All tests are running and there are no failed tests reported by CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/behat.png" width="200" alt="Behat test results">
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
