### PR TITLE
[OPENY-273] Fix warning in console

### DIFF
--- a/modules/custom/openy_repeat/js/repeat.js
+++ b/modules/custom/openy_repeat/js/repeat.js
@@ -120,10 +120,10 @@
 
       var dateGet = this.$route.query.date;
       if (dateGet) {
-        this.date = dateGet;
+        this.date = new Date(dateGet).toISOString();
       }
       else {
-        this.date = moment().format('D MMM YYYY');
+        this.date = moment().toISOString();
       }
 
       var locationsGet = this.$route.query.locations;


### PR DESCRIPTION
## Details issue
On schedule pages, we can see the warning in console
![warning](https://user-images.githubusercontent.com/24233384/51988524-ea4b6180-24b5-11e9-9c8c-5f4b344143b3.png)

## Steps for review

- [ ] Go to /group-exercise-classes?date=30 Jan 2019&locations=&categories=
- [ ] Check that the warning isn't displayed



Thank you for your contribution!
