### PR TITLE
[#1484] Fix matchHeight error in the admin panel

### DIFF
--- a/modules/openy_features/openy_node/modules/openy_node_alert/js/openy_node_alert.js
+++ b/modules/openy_features/openy_node/modules/openy_node_alert/js/openy_node_alert.js
@@ -6,9 +6,11 @@
    */
   Drupal.behaviors.alertsHeight = {
     attach: function (context, settings) {
-      setTimeout(function () {
-        $('[class^="alert"]', context).matchHeight();
-      }, 1000);
+      if (settings.path.currentPathIsAdmin !== true) {
+        setTimeout(function () {
+          $('[class^="alert"]', context).matchHeight();
+        }, 1000);
+      }
     }
   };
 


### PR DESCRIPTION
Issue: https://github.com/ymcatwincities/openy/issues/1484

### How to review:
- [ ] Make sure that matchHeight library not generates error in the admin panel and on some Open Y pages.

### Steps for review:
 - [ ] Login as admin
- [ ] Go to /admin/content page
- [ ] check the console(inspect code -> Console)