### PR TITLE
[OPENY-260] Fix background image alignment on the installation

### DIFF
--- a/themes/openy_themes/openy_admin/css/install-page.css
+++ b/themes/openy_themes/openy_admin/css/install-page.css
@@ -20,6 +20,16 @@ body {
   background-size: cover;
 }
 
+@media (min-width: 768px) {
+  body.install-page {
+    display: block;
+  }
+
+  .layout-container {
+    margin-top: 180px;
+  }
+}
+
 #openy-terms-of-use .form-submit{
   background: #5b9bd5;
   color: #fff;


### PR DESCRIPTION
## Details issue
When installing the site part of the logo is not visible. See screenshot:
![install](https://user-images.githubusercontent.com/24233384/51994905-c3dff300-24c2-11e9-8454-f04a585404ea.png)

## Steps for review

- [ ] Go to the installation process
- [ ] Check that the logo on the background is visible and is not overlapped by the content block
