### PR TITLE
[OPENY-269] Fix warning in the PEF pages

### DIFF
--- a/modules/custom/openy_group_schedules/src/Form/GroupexFormFull.php
+++ b/modules/custom/openy_group_schedules/src/Form/GroupexFormFull.php
@@ -348,7 +348,7 @@ class GroupexFormFull extends GroupexFormBase {
       $processed_classes_data[$id] = t($class);
     }
     $this->classesOptions = $this->classesOptions + $processed_classes_data;
-    
+
     $form['class_select'] = [
       '#type' => 'select',
       '#options' => $this->classesOptions,
@@ -583,7 +583,7 @@ class GroupexFormFull extends GroupexFormBase {
       $filter_date = !empty($values['date_select']) ? $values['date_select'] : $values['date'];
     }
     if (isset($user_input['date_select']) && $user_input['date_select'] != $filter_date) {
-      $filter_date = $user_input;
+      $filter_date = $user_input['date_select'];
     }
     $class = !empty($values['class_select']) ? $values['class_select'] : 'any';
     if ($class == 'any' && empty($user_input['class_select']) && is_numeric($query['class'])) {
@@ -618,7 +618,7 @@ class GroupexFormFull extends GroupexFormBase {
       $filter_length = 'week';
       $groupex_class = 'groupex_table_class_individual';
       $view_mode = 'class';
-    }    
+    }
     if (isset($triggering_element['#name']) && $triggering_element['#name'] == 'location_select' && $groupex_class = 'groupex_table_instructor_individual') {
       $location = $triggering_element['#value'];
       $class = 'any';

--- a/modules/custom/openy_group_schedules/src/Form/GroupexFormFull.php
+++ b/modules/custom/openy_group_schedules/src/Form/GroupexFormFull.php
@@ -309,18 +309,16 @@ class GroupexFormFull extends GroupexFormBase {
 
     // Get category options
     $raw_category_data = $this->getOptions($this->request(['query' => ['categories' => TRUE]]), 'id', 'name');
-    $this->categoryOptions = ['any' => $this->t('-All-')];
-    $processed_category_data = [];
+    $processed_category_data['any'] = $this->t('-All-');
     foreach ($raw_category_data as $key => $category) {
       // Remove excess key text & cleanup markup being sent back.
       $id = str_replace('DESC--[', '', $key);
       $processed_category_data[$id] = t($category);
     }
-    $this->categoryOptions = $this->categoryOptions + $processed_category_data;
 
     $form['category_select'] = [
       '#type' => 'select',
-      '#options' => $this->categoryOptions,
+      '#options' => $processed_category_data,
       '#default_value' => !empty($state['category']) ? $state['category'] : 'any',
       '#title' => $this->t('Category:'),
       '#prefix' => '<div id="category-select-wrapper" class="' . $category_select_classes . '">',
@@ -340,18 +338,16 @@ class GroupexFormFull extends GroupexFormBase {
 
     // Get classes options.
     $raw_classes_data = $this->getOptions($this->request(['query' => ['classes' => TRUE]]), 'id', 'title');
-    $this->classesOptions = ['any' => $this->t('-All-')];
-    $processed_classes_data = [];
+    $processed_classes_data['any'] = $this->t('-All-');
     foreach ($raw_classes_data as $key => $class) {
       // Remove excess key text & cleanup markup being sent back.
       $id = str_replace('DESC--[', '', $key);
       $processed_classes_data[$id] = t($class);
     }
-    $this->classesOptions = $this->classesOptions + $processed_classes_data;
 
     $form['class_select'] = [
       '#type' => 'select',
-      '#options' => $this->classesOptions,
+      '#options' => $processed_classes_data,
       '#default_value' => !empty($state['class']) ? $state['class'] : 'any',
       '#title' => $this->t('Class:'),
       '#prefix' => '<div id="class-select-wrapper" class="' . $class_select_classes . '">',


### PR DESCRIPTION
## Details issue
The following warning was discovered in the Drupal logs after visiting PEF pages under Schedules menu item:
```Warning: strtotime() expects parameter 1 to be string```

## Steps for review

- [ ] Go to /locations/east-ymca
- [ ] Select any date in the Demo Latest news posts block
- [ ] Select any category
- [ ] Click on the cross in the date field
![block](https://user-images.githubusercontent.com/24233384/52344928-0eb2bb00-2a2d-11e9-9da7-672549cc98ab.png)
- [ ] Сheck that the `Illegal choice any in Class: element.` error and `strtotime() expects parameter 1 to be string` warning are missing in the logs