### PR TITLE
OS-273: Grid Content component in Carnation #1429. D.org Issue #3031507 by AaronChristian

### DIFF
--- a/themes/openy_themes/openy_carnation/templates/paragraph/paragraph--grid-content--default.html.twig
+++ b/themes/openy_themes/openy_carnation/templates/paragraph/paragraph--grid-content--default.html.twig
@@ -39,6 +39,7 @@
 {%
 set classes = [
   'row',
+  'justify-content-center',
   'paragraph',
   'paragraph--column-in-a-grid',
   'paragraph--type--' ~ paragraph.bundle|clean_class,
@@ -49,18 +50,18 @@ set classes = [
 {% set item_class = 'col-12 col-lg' %}
 
 {% if grid_style == '2' %}
-  {% set item_class = 'col-12 col-sm-6 row-eq-height' %}
+  {% set item_class = 'col-lg-6' %}
 {% elseif grid_style == '3' %}
-  {% set item_class = 'col-12 col-sm-4 row-eq-height' %}
+  {% set item_class = 'col-lg-4' %}
 {% elseif grid_style == '4' %}
-  {% set item_class = 'col-12 col-sm-3 row-eq-height' %}
+  {% set item_class = 'col-lg-3' %}
 {% endif %}
 <div{{ attributes.addClass(classes) }}>
   {% for key, item in content.field_grid_columns %}
     {% if key matches '/^\\d+$/' %}
-      <div class="{{ item_class }}">
-        {{ item }}
-      </div>
+    <div class="col-12 {{ item_class }} row-eq-height">
+      {{ item }}
+    </div>
     {% endif %}
   {% endfor %}
 </div>


### PR DESCRIPTION
## Steps for review

- In the carnation theme, create a grid paragraph type with 3 columns. Set the row display to 2 items, and ensure that the columns break after the 2nd element.

https://www.drupal.org/project/openy/issues/3031430
