### PR TITLE
OS-272: Upping the limit for lengthy titled breadcrumbs

### DIFF
--- a/themes/openy_themes/openy_carnation/openy_carnation.theme
+++ b/themes/openy_themes/openy_carnation/openy_carnation.theme
@@ -167,7 +167,7 @@ function openy_carnation_theme_suggestions_page_alter(array &$suggestions, array
 function openy_carnation_preprocess_breadcrumb(&$variables) {
   if (isset($variables['breadcrumb'])) {
     $last_item = end($variables['breadcrumb']);
-    if (strlen($last_item['text']) > 20) {
+    if (strlen($last_item['text']) > 50) {
       $variables['breadcrumb'][key($variables['breadcrumb'])]['text'] = t('Current page');
     }
   }


### PR DESCRIPTION
## Steps for review

- Visit a page that is nested a few levels deep. (ie. News Article with lengthy title).
- Ensure that the text over 50 characters is replaced with "Current Page" instead.

## General checks

https://www.drupal.org/project/openy/issues/3031507