### PR TITLE
AF: Hide country counter.

### DIFF
--- a/modules/custom/openy_activity_finder/templates/openy-activity-finder-program-search.html.twig
+++ b/modules/custom/openy_activity_finder/templates/openy-activity-finder-program-search.html.twig
@@ -279,7 +279,7 @@
                     </div>
                   </div>
                   <div class="col-4 col-xs-5 text-right">
-                    <span class="h6 text-muted text-gray-500 font-weight-light mr-3">${ getLocationsCounter("{{ key }}") } {{ 'results'|t }}</span>
+                    <span class="h6 text-muted text-gray-500 font-weight-light mr-3" style="display:none;">${ getLocationsCounter("{{ key }}") } {{ 'results'|t }}</span>
                     <i class="fa fa-plus plus" aria-hidden="true"></i>
                     <i class="fa fa-minus minus" aria-hidden="true"></i>
                   </div>

--- a/modules/custom/openy_activity_finder/templates/openy-activity-finder-program-search.html.twig
+++ b/modules/custom/openy_activity_finder/templates/openy-activity-finder-program-search.html.twig
@@ -108,7 +108,9 @@
 
               <div class="row">
                 {% for age in ages %}
+                  {% block af_col_1_row_class %}
                   <div class="col-xs-4 col-sm-6 col-md-4">
+                  {% endblock %}
                     <div class="openy-card__item">
                       <label for="af-age-filter-{{ age.value }}" class="justify-content-center" data-mh="openy-card__item-label--ages">
                         <input v-model="checkedAges" @change="toggleCardState" type="checkbox" value="{{ age.value }}" id="af-age-filter-{{ age.value }}" class="d-none hidden">
@@ -129,7 +131,9 @@
 
               <div class="row">
                 {% for day in days %}
+                  {% block af_col_2_row_class %}
                   <div class="col-xs-4 col-sm-6 col-md-4">
+                  {% endblock %}
                     <div class="openy-card__item">
                       <label for="af-day-filter-{{ day.value }}" class="justify-content-center" data-mh="openy-card__item-label--days">
                         <input v-model="checkedDays" @change="toggleCardState" type="checkbox" value="{{ day.value }}" id="af-day-filter-{{ day.value }}" class="d-none hidden">

--- a/themes/openy_themes/openy_carnation/templates/openy_activity_finder/openy-activity-finder-program-search.html.twig
+++ b/themes/openy_themes/openy_carnation/templates/openy_activity_finder/openy-activity-finder-program-search.html.twig
@@ -26,3 +26,11 @@
 {% block af_col_3_class %}
 <div class="activity-finder__col col-12 col-lg-4">
 {% endblock %}
+
+{% block af_col_1_row_class %}
+<div class="col-4 col-sm-6 col-md-4">
+{% endblock %}
+
+{% block af_col_2_row_class %}
+<div class="col-4 col-sm-6 col-md-4">
+{% endblock %}


### PR DESCRIPTION
Solr backend does not display country counter in Activity Finder on last step.

Decision was to hide it completely for now.

![image](https://user-images.githubusercontent.com/294265/52653452-dab01d80-2ea4-11e9-88f3-9231b699a7d1.png)
