### PR TITLE
[OPENY-283] Fix the Site information page submit

### DIFF
--- a/modules/openy_features/openy_node/openy_node.module
+++ b/modules/openy_features/openy_node/openy_node.module
@@ -61,7 +61,7 @@ function openy_node_form_system_site_information_settings_alter(&$form, FormStat
     '#default_value' => $view->status() ? 0 : 1,
   ];
 
-  $form['actions']['submit']['#submit'][] = 'openy_node_form_submit';
+  $form['#submit'][] = 'openy_node_form_submit';
 }
 
 /**


### PR DESCRIPTION
## Details issue
When someone tries to edit site name or slogan or any other information on admin/config/system/site-information - submit never works.
After removing alter function https://github.com/ymcatwincities/openy/blob/8.x-2.x/modules/openy_features/openy_node/openy_node.module#L48 - form become working
See #1517
Issue #1516 

## Steps for review
- [ ] Log in as admin
- [ ] Edit site name or slogan or any other information on admin/config/system/site-information
- [ ] Check that submit works