### PR TITLE
[OPENY-284] Fix openy_node_alert updates.

### DIFF
--- a/modules/openy_features/openy_node/modules/openy_node_alert/openy_node_alert.install
+++ b/modules/openy_features/openy_node/modules/openy_node_alert/openy_node_alert.install
@@ -128,6 +128,14 @@ function openy_node_alert_update_8009() {
     'block.block.openy_lily_views_block__alerts_footer_alerts_local',
     'block.block.openy_lily_views_block__alerts_header_alerts',
     'block.block.openy_lily_views_block__alerts_header_alerts_local',
+    'block.block.openy_carnation_views_block__alerts_footer_alerts',
+    'block.block.openy_carnation_views_block__alerts_footer_alerts_local',
+    'block.block.openy_carnation_views_block__alerts_header_alerts',
+    'block.block.openy_carnation_views_block__alerts_header_alerts_local',
+    'block.block.openy_rose_views_block__alerts_footer_alerts',
+    'block.block.openy_rose_views_block__alerts_footer_alerts_local',
+    'block.block.openy_rose_views_block__alerts_header_alerts',
+    'block.block.openy_rose_views_block__alerts_header_alerts_local',
     'views.view.alerts',
   ];
   foreach ($configs_to_remove as $config) {

--- a/modules/openy_features/openy_node/modules/openy_node_alert/openy_node_alert.install
+++ b/modules/openy_features/openy_node/modules/openy_node_alert/openy_node_alert.install
@@ -119,6 +119,8 @@ function openy_node_alert_update_8007() {
  * Update permissions. Remove old configs.
  */
 function openy_node_alert_update_8009() {
+  // Enable modules one more time if 8007 already performed on site.
+  \Drupal::service('module_installer')->install(['rest', 'hal', 'serialization']);
   $configs_to_remove = [
     'block.block.views_block__alerts_footer_alerts',
     'block.block.views_block__alerts_footer_alerts_local',

--- a/modules/openy_features/openy_node/modules/openy_node_alert/openy_node_alert.install
+++ b/modules/openy_features/openy_node/modules/openy_node_alert/openy_node_alert.install
@@ -126,20 +126,19 @@ function openy_node_alert_update_8009() {
     'block.block.views_block__alerts_footer_alerts_local',
     'block.block.views_block__alerts_header_alerts',
     'block.block.views_block__alerts_header_alerts_local',
-    'block.block.openy_lily_views_block__alerts_footer_alerts',
-    'block.block.openy_lily_views_block__alerts_footer_alerts_local',
-    'block.block.openy_lily_views_block__alerts_header_alerts',
-    'block.block.openy_lily_views_block__alerts_header_alerts_local',
-    'block.block.openy_carnation_views_block__alerts_footer_alerts',
-    'block.block.openy_carnation_views_block__alerts_footer_alerts_local',
-    'block.block.openy_carnation_views_block__alerts_header_alerts',
-    'block.block.openy_carnation_views_block__alerts_header_alerts_local',
-    'block.block.openy_rose_views_block__alerts_footer_alerts',
-    'block.block.openy_rose_views_block__alerts_footer_alerts_local',
-    'block.block.openy_rose_views_block__alerts_header_alerts',
-    'block.block.openy_rose_views_block__alerts_header_alerts_local',
-    'views.view.alerts',
   ];
+  // Prepare list of alert block configs to remove for currently installed themes.
+  /** @var \Drupal\Core\Extension\ThemeHandlerInterface $theme_handler */
+  $theme_handler = \Drupal::service('theme_handler');
+  $list = $theme_handler->listInfo();
+  foreach ($list as $theme => $info) {
+    $configs_to_remove[] = 'block.block.' . $theme . '_views_block__alerts_footer_alerts';
+    $configs_to_remove[] = 'block.block.' . $theme . '_views_block__alerts_footer_alerts_local';
+    $configs_to_remove[] = 'block.block.' . $theme . '_views_block__alerts_header_alerts';
+    $configs_to_remove[] = 'block.block.' . $theme . '_views_block__alerts_header_alerts_local';
+  }
+  $configs_to_remove[] = 'views.view.alerts';
+
   foreach ($configs_to_remove as $config) {
     \Drupal::configFactory()->getEditable($config)->delete();
   }


### PR DESCRIPTION
There is no installation of modules rest, hal and serialization in 8.x-1.x version in update openy_node_alert_update_8007. So when hook 8007 already performed that modules will be disabled. I added installation of modules one more time in 8010.

Added removing of alert block configs for all installed themes. Thanks to @afi13 for help.
