### PR TITLE
Fixes the old BS3 classes on the footer column blocks.

### DIFF
--- a/themes/openy_themes/openy_carnation/templates/page/page.html.twig
+++ b/themes/openy_themes/openy_carnation/templates/page/page.html.twig
@@ -165,19 +165,19 @@
           {% endif %}
 
           {% if page.footer_tel|render|trim is not empty %}
-          <div class="col-xs-12 col-lg">
+          <div class="col-12 col-lg">
               {{ page.footer_tel }}
           </div>
           {% endif %}
 
           {% if page.footer_mail|render|trim is not empty %}
-          <div class="col-xs-12 col-lg">
+          <div class="col-12 col-lg">
               {{ page.footer_mail }}
           </div>
           {% endif %}
 
           {% if page.footer_social|render|trim is not empty %}
-          <div class="col-xs-12 col-lg text-center">
+          <div class="col-12 col-lg text-center">
             {{ page.footer_social }}
           </div>
           {% endif %}


### PR DESCRIPTION
## Steps for review

- [ ] Open up page.html.twig and confirm that the old boostrap 3 classes **col-xs-12** have been removed from 3 of the 4 footer columns.

https://www.drupal.org/project/openy/issues/3035743
