### PR TITLE
Add config allow_unpublished_references in RepeatManager

### DIFF
--- a/modules/custom/openy_repeat/config/install/openy_repeat.settings.yml
+++ b/modules/custom/openy_repeat/config/install/openy_repeat.settings.yml
@@ -1,0 +1,1 @@
+allow_unpublished_references: 0

--- a/modules/custom/openy_repeat/openy_repeat.install
+++ b/modules/custom/openy_repeat/openy_repeat.install
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @file
+ * Module installation file.
+ */
+
+/**
+ * Introduce "allow_unpublished_references" config.
+ */
+function openy_repeat_update_8001() {
+  $config = \Drupal::service('config.factory')->getEditable('openy_repeat.settings');
+  $config->set('allow_unpublished_references', 0);
+  $config->save();
+}


### PR DESCRIPTION
### How to review:

Fix for #1536

 - [ ] Make sure there is new config item `allow_unpublished_references` in `openy_repeat`
 - [ ] Make sure that by default `RepeatManager` skips activitis with unpublished references
 - [ ] Make sure that setting `allow_unpublished_references` to `true` allows using unpublished references in `RepeatManager`.