### PR TITLE
PEF: Make classname filter affect generated PDF

### DIFF
--- a/modules/custom/openy_repeat/js/repeat.js
+++ b/modules/custom/openy_repeat/js/repeat.js
@@ -376,7 +376,6 @@
         $('.form-group-classname input:checked').each(function () {
           classnames_checked.push(encodeURIComponent($(this).val()));
         });
-        classnames_checked = classnames_checked.join(',');
 
         var limitCategories = window.OpenY.field_prgf_repeat_schedule_categ || [];
         if (limitCategories && limitCategories.length > 0) {
@@ -391,7 +390,9 @@
         }
         limit = limit.join(',');
         var pdf_query = window.location.search + '&rooms=' + rooms_checked + '&limit=' + limit;
-        pdf_query += '&cn=' + classnames_checked;
+        $(classnames_checked).each(function () {
+          pdf_query += '&cn[]=' + this;
+        });
         $('.btn-schedule-pdf-generate').attr('href', drupalSettings.path.baseUrl + 'schedules/get-pdf' + pdf_query);
       });
     },

--- a/modules/custom/openy_repeat/js/repeat.js
+++ b/modules/custom/openy_repeat/js/repeat.js
@@ -361,9 +361,10 @@
       if (typeof(addtocalendar) !== 'undefined') {
         addtocalendar.load();
       }
-      // Additionally collect checked rooms filter options.
-      $('.btn-schedule-pdf-generate').on('click', function () {
+      // Consider moving out of 'updated' handler.
+      $('.btn-schedule-pdf-generate').off('click').on('click', function () {
         var rooms_checked = [],
+            classnames_checked = [],
             limit = [];
         $('.checkbox-room-wrapper input').each(function () {
           if ($(this).is(':checked')) {
@@ -371,6 +372,12 @@
           }
         });
         rooms_checked = rooms_checked.join(',');
+
+        $('.form-group-classname input:checked').each(function () {
+          classnames_checked.push(encodeURIComponent($(this).val()));
+        });
+        classnames_checked = classnames_checked.join(',');
+
         var limitCategories = window.OpenY.field_prgf_repeat_schedule_categ || [];
         if (limitCategories && limitCategories.length > 0) {
           if (limitCategories.length == 1) {
@@ -384,6 +391,7 @@
         }
         limit = limit.join(',');
         var pdf_query = window.location.search + '&rooms=' + rooms_checked + '&limit=' + limit;
+        pdf_query += '&cn=' + classnames_checked;
         $('.btn-schedule-pdf-generate').attr('href', drupalSettings.path.baseUrl + 'schedules/get-pdf' + pdf_query);
       });
     },

--- a/modules/custom/openy_repeat/js/repeat.js
+++ b/modules/custom/openy_repeat/js/repeat.js
@@ -3,7 +3,7 @@
     return;
   }
 
-  if (window.OpenY.field_prgf_repeat_schedules_pref) {
+  if (window.OpenY.field_prgf_repeat_schedules_pref && window.OpenY.field_prgf_repeat_schedules_pref.length) {
     var locationPage = window.OpenY.field_prgf_repeat_schedules_pref[0] || '';
     if (locationPage) {
       $('.clear-all').attr('href', locationPage.url).removeClass('hidden');
@@ -11,7 +11,7 @@
   }
 
   // PDF link show/hidden.
-  if (window.OpenY.field_prgf_repeat_schedules_pdf) {
+  if (window.OpenY.field_prgf_repeat_schedules_pdf && window.OpenY.field_prgf_repeat_schedules_pdf.length) {
     var pdfLink = window.OpenY.field_prgf_repeat_schedules_pdf[0] || '';
     if (pdfLink) {
       $('.btn-schedule-pdf')

--- a/modules/custom/openy_repeat/openy_repeat.libraries.yml
+++ b/modules/custom/openy_repeat/openy_repeat.libraries.yml
@@ -19,6 +19,8 @@ openy_repeat:
     - openy_system/moment
     - openy_repeat/bootstrap-datepicker
     - openy_repeat/openy_repeat.schedules
+    - openy_repeat/openy_repeat.natsort
+
 
 bootstrap-datepicker:
   version: 0.1
@@ -42,3 +44,8 @@ openy_repeat.schedules:
   version: 0.1
   js:
     js/schedules.js: {}
+
+openy_repeat.natsort:
+  version: 1.0
+  js:
+    /libraries/alphanum/alphanum.js: {}

--- a/modules/custom/openy_repeat/src/Controller/RepeatController.php
+++ b/modules/custom/openy_repeat/src/Controller/RepeatController.php
@@ -388,7 +388,7 @@ class RepeatController extends ControllerBase {
     $parameters = $request->query->all();
     $category = !empty($parameters['categories']) ? $parameters['categories'] : '0';
     $rooms = !empty($parameters['rooms']) ? $parameters['rooms'] : '';
-    $classnames = !empty($parameters['cn']) ? $parameters['cn'] : '';
+    $classnames = !empty($parameters['cn']) ? $parameters['cn'] : [];
     $location = !empty($parameters['locations']) ? $parameters['locations'] : '0';
     $date = !empty($parameters['date']) ? $parameters['date'] : '';
     $mode = !empty($parameters['mode']) ? $parameters['mode'] : 'activity';
@@ -416,9 +416,6 @@ class RepeatController extends ControllerBase {
     }
     if (!empty($rooms)) {
       $rooms = explode(',', $rooms);
-    }
-    if (!empty($classnames)) {
-      $classnames = explode(',', $classnames);
     }
     // Group by activity.
     if ($mode == 'activity') {

--- a/modules/custom/openy_repeat/src/Controller/RepeatController.php
+++ b/modules/custom/openy_repeat/src/Controller/RepeatController.php
@@ -388,6 +388,7 @@ class RepeatController extends ControllerBase {
     $parameters = $request->query->all();
     $category = !empty($parameters['categories']) ? $parameters['categories'] : '0';
     $rooms = !empty($parameters['rooms']) ? $parameters['rooms'] : '';
+    $classnames = !empty($parameters['cn']) ? $parameters['cn'] : '';
     $location = !empty($parameters['locations']) ? $parameters['locations'] : '0';
     $date = !empty($parameters['date']) ? $parameters['date'] : '';
     $mode = !empty($parameters['mode']) ? $parameters['mode'] : 'activity';
@@ -416,14 +417,17 @@ class RepeatController extends ControllerBase {
     if (!empty($rooms)) {
       $rooms = explode(',', $rooms);
     }
+    if (!empty($classnames)) {
+      $classnames = explode(',', $classnames);
+    }
     // Group by activity.
     if ($mode == 'activity') {
-      $result = $this->groupByActivity($result, $rooms);
+      $result = $this->groupByActivity($result, $rooms, $classnames);
       $theme = 'openy_repeat__pdf__table__activity';
     }
     // Group by day.
     if ($mode == 'day') {
-      $result = $this->groupByDay($result, $rooms);
+      $result = $this->groupByDay($result, $rooms, $classnames);
       $theme = 'openy_repeat__pdf__table__day';
     }
 
@@ -438,7 +442,7 @@ class RepeatController extends ControllerBase {
   /**
    * Group results by Activity & Location.
    */
-  public function groupByActivity($result, $rooms) {
+  public function groupByActivity($result, $rooms, $classnames = []) {
     if (empty($result)) {
       return FALSE;
     }
@@ -474,6 +478,11 @@ class RepeatController extends ControllerBase {
             continue;
           }
         }
+        if ($classnames && !in_array($session->name, $classnames)) {
+          unset($result[$day][$key]);
+          continue;
+        }
+
         $formatted_result['content'][$session->location][$session->name] = [
           'room' => $session->room,
           'dates' => $date_keys
@@ -495,7 +504,7 @@ class RepeatController extends ControllerBase {
   /**
    * Group results by day.
    */
-  public function groupByDay($result, $rooms) {
+  public function groupByDay($result, $rooms, $classnames = []) {
     if (empty($result)) {
       return FALSE;
     }
@@ -530,6 +539,11 @@ class RepeatController extends ControllerBase {
             continue;
           }
         }
+        if ($classnames && !in_array($session->name, $classnames)) {
+          unset($result[$day][$key]);
+          continue;
+        }
+
         $weekday = DrupalDateTime::createFromFormat('Y-m-d', $day)->format('l');
         $formatted_result['content'][$session->category . '|' .$session->location][$weekday][$session->time_start . '-' . $session->time_end][] = [
           'room' => $session->room,


### PR DESCRIPTION
## Steps for review

- [ ] log in to the website
- [ ] go to any schedule page (e.g. `/group-exercise-classes`)
- [ ] edit the page node, edit the Repeat Schedules paragraph in Content Area
- [ ] set its Filters checkbox "by class name" checked
- [ ] save the page node
- [ ] verify the page is showing Class name filter in the sidebar now
- [ ] verify the options in the filter are in the correct order
- [ ] verify whenever you select any of the filter's options the results are narrowed to such classes
- [ ] verify "Weekly schedule PDF" link (button) is presented on the page
- [ ] verify the link navigates to the PDF version of the schedule
- [ ] verify selected class name filter options are affecting the PDF link URL and the generated PDF content is also affected.
- [ ] verify class names with commas are not a problem (`/personal-training`)
