### PR TITLE
PEF: Make landing pages with Schedule blocks indexable by Search API

### DIFF
--- a/modules/custom/openy_repeat/src/Plugin/Block/RepeatSchedulesBlock.php
+++ b/modules/custom/openy_repeat/src/Plugin/Block/RepeatSchedulesBlock.php
@@ -86,7 +86,9 @@ class RepeatSchedulesBlock extends BlockBase {
       $checked_locations = explode(',', $locations);
     }
     // Find repeat_schedules paragraph.
-    $node = \Drupal::routeMatch()->getParameter('node');
+    if (!$node = \Drupal::routeMatch()->getParameter('node')) {
+      return [];
+    }
     $paragraphs = $node->field_content->referencedEntities();
     foreach ($paragraphs as $p) {
       if ($p->bundle() == 'repeat_schedules') {


### PR DESCRIPTION
## Steps for review

Not sure if it's testable on builds. Generally speaking, the issue is when landing pages are indexed by Search API, the blocks are not rendered in the a context where `\Drupal::routeMatch()->getParameter('node')` returns the expected node object, thus `$paragraphs = $node->field_content->referencedEntities();` fails and the whole indexing process fails with fatal errors.