### PR TITLE
GroupExPro. Rollback migration during manual Sync operation.

### DIFF
--- a/modules/custom/openy_gxp/openy_gxp.drush.inc
+++ b/modules/custom/openy_gxp/openy_gxp.drush.inc
@@ -20,9 +20,6 @@ function openy_gxp_drush_command() {
  * Command 'openy-gxp-sync'.
  */
 function drush_openy_gxp_sync() {
-  // First rollback all the data completely.
-  drush_migrate_tools_migrate_rollback('gxp_offerings_import');
-
   // Next run the import.
   $form_state = new \Drupal\Core\Form\FormState();
   \Drupal::formBuilder()->submitForm('Drupal\openy_gxp\Form\ImportForm', $form_state);

--- a/modules/custom/openy_gxp/src/Form/ImportForm.php
+++ b/modules/custom/openy_gxp/src/Form/ImportForm.php
@@ -48,7 +48,9 @@ class ImportForm extends FormBase {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $config = \Drupal::configFactory()->get('openy_gxp.settings');
 
-    $operations = [];
+    $operations = [
+      ['Drupal\openy_gxp\Form\ImportForm::rollbackMigrations', []]
+    ];
     foreach (explode("\n", $config->get('locations')) as $row) {
       list($gxpLocationId, $locationName) = explode(',', $row);
       $gxpLocationId = (int) $gxpLocationId;
@@ -72,6 +74,15 @@ class ImportForm extends FormBase {
     );
 
     batch_set($batch);
+  }
+
+  /**
+   * Rollback all imported programs.
+   */
+  public static function rollbackMigrations() {
+    $migration = \Drupal::service('plugin.manager.migration')->createInstance('gxp_offerings_import');
+    $executable = new MigrateExecutable($migration, new MigrateMessage());
+    $executable->rollback();
   }
 
   /**


### PR DESCRIPTION
Currently for GroupExPro we clean up old data (rolling back migration) only during drush command. This PR adds this feature to the form that can be run manually.

Credit to YMCA WNC