### PR TITLE
Add update hook dependencies for making Upgrade path to 2.x possible

### DIFF
--- a/openy.install
+++ b/openy.install
@@ -51,6 +51,8 @@ function openy_update_dependencies() {
   $dependencies['openy_node_alert'] = [
     8009 => [
       'system' => 8501,
+      'block_content' => 8600,
+      'media_entity' => 8201,
     ],
   ];
 


### PR DESCRIPTION
When upgrading from Open Y 1.x to 2.x, the absence of the following update dependencies will cause errors.