### PR TITLE
OS-235: fix assessebility error for scroll top link.

### DIFF
--- a/themes/openy_themes/openy_lily/templates/page/page.html.twig
+++ b/themes/openy_themes/openy_lily/templates/page/page.html.twig
@@ -163,7 +163,7 @@
     </footer>{# /#page-footer #}
 
     <div class="text-center return-to-top" data-spy="affix" data-offset-top="52">
-      <a href="#top" title="{{ 'Scroll to top'|t }}" class="btn btn-default">
+      <a href="#main-content" title="{{ 'Scroll to top'|t }}" class="btn btn-default" aria-label="{{  'Scroll to top'|t }}">
         <span class="glyphicon glyphicon-chevron-up"></span>
       </a>
     </div>{# /.return-to-top #}


### PR DESCRIPTION
Steps for reproduce:
Download extension. http://wave.webaim.org/extension/
Open site. 
Enable extension.
Check Scroll To Top link with extension. There is no any Alerts now.