### PR TITLE
[OPENY-290] Add bulk update actions for OpenY Upgrade log

### DIFF
--- a/modules/custom/openy_upgrade_tool/config/install/views.view.openy_upgrade_dashboard.yml
+++ b/modules/custom/openy_upgrade_tool/config/install/views.view.openy_upgrade_dashboard.yml
@@ -70,6 +70,59 @@ display:
       row:
         type: fields
       fields:
+        openy_upgrade_log_bulk_form:
+          id: openy_upgrade_log_bulk_form
+          table: openy_upgrade_log
+          field: openy_upgrade_log_bulk_form
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Bulk update'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          action_title: Action
+          include_exclude: exclude
+          selected_actions: {  }
+          entity_type: openy_upgrade_log
+          plugin_id: bulk_form
         name:
           id: name
           table: openy_upgrade_log
@@ -602,10 +655,314 @@ display:
       defaults:
         filters: false
         filter_groups: false
+        fields: false
       filter_groups:
         operator: AND
         groups:
           1: AND
+      fields:
+        openy_upgrade_log_bulk_form:
+          id: openy_upgrade_log_bulk_form
+          table: openy_upgrade_log
+          field: openy_upgrade_log_bulk_form
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Bulk update'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          action_title: Action
+          include_exclude: include
+          selected_actions:
+            - apply_openy_version
+          entity_type: openy_upgrade_log
+          plugin_id: bulk_form
+        name:
+          id: name
+          table: openy_upgrade_log
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Config Name'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: null
+          entity_field: name
+          plugin_id: field
+        changed:
+          id: changed
+          table: openy_upgrade_log
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Changed
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: medium
+            custom_date_format: ''
+            timezone: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: openy_upgrade_log
+          entity_field: changed
+          plugin_id: field
+        user_id:
+          id: user_id
+          table: openy_upgrade_log
+          field: user_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Updated by'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: openy_upgrade_log
+          entity_field: user_id
+          plugin_id: field
+        operations:
+          id: operations
+          table: openy_upgrade_log
+          field: operations
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Operations links'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          destination: false
+          entity_type: openy_upgrade_log
+          plugin_id: entity_operations
     cache_metadata:
       max-age: 0
       contexts:

--- a/modules/custom/openy_upgrade_tool/config/optional/system.action.apply_active_version.yml
+++ b/modules/custom/openy_upgrade_tool/config/optional/system.action.apply_active_version.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - openy_upgrade_tool
+id: apply_active_version
+label: 'Apply current active version'
+type: openy_upgrade_log
+plugin: apply_active_version
+configuration: {  }

--- a/modules/custom/openy_upgrade_tool/config/optional/system.action.apply_openy_version.yml
+++ b/modules/custom/openy_upgrade_tool/config/optional/system.action.apply_openy_version.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - openy_upgrade_tool
+id: apply_openy_version
+label: 'Apply Open Y version'
+type: openy_upgrade_log
+plugin: apply_openy_version
+configuration: {  }

--- a/modules/custom/openy_upgrade_tool/config/schema/openy_upgrade_tool.schema.yml
+++ b/modules/custom/openy_upgrade_tool/config/schema/openy_upgrade_tool.schema.yml
@@ -5,3 +5,10 @@ openy_upgrade_tool.settings:
     force_mode:
       type: boolean
       label: 'Force mode'
+action.configuration.apply_active_version:
+  type: action_configuration_default
+  label: 'Apply current active version'
+
+action.configuration.apply_openy_version:
+  type: action_configuration_default
+  label: 'Apply Open Y version'

--- a/modules/custom/openy_upgrade_tool/openy_upgrade_tool.install
+++ b/modules/custom/openy_upgrade_tool/openy_upgrade_tool.install
@@ -190,3 +190,17 @@ function openy_upgrade_tool_update_8007() {
     }
   }
 }
+
+/**
+ * Add bulk update actions for OpenY Upgrade dashboard.
+ */
+function openy_upgrade_tool_update_8008() {
+  $config_dir = drupal_get_path('module', 'openy_upgrade_tool') . '/config/install/';
+  // Import new configuration.
+  $config_importer = \Drupal::service('openy_upgrade_tool.importer');
+  $config_importer->setDirectory($config_dir);
+  // Update views for bulk edit form and import actions.
+  $config_importer->importConfigSimple('views.view.openy_upgrade_dashboard');
+  $config_importer->importConfigSimple('system.action.apply_active_version');
+  $config_importer->importConfigSimple('system.action.apply_openy_version');
+}

--- a/modules/custom/openy_upgrade_tool/src/Plugin/Action/ApplyCurrentActiveVersionAction.php
+++ b/modules/custom/openy_upgrade_tool/src/Plugin/Action/ApplyCurrentActiveVersionAction.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Drupal\openy_upgrade_tool\Plugin\Action;
+
+use Drupal\Core\Action\Plugin\Action\EntityActionBase;
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * Apply current active version for openy_upgrade_log entity.
+ *
+ * @Action(
+ *   id = "apply_active_version",
+ *   action_label = @Translation("Apply current active version"),
+ *   type = "openy_upgrade_log"
+ * )
+ */
+class ApplyCurrentActiveVersionAction extends EntityActionBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute($entity = NULL) {
+    $entity->applyCurrentActiveVersion();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function access($object, AccountInterface $account = NULL, $return_as_object = FALSE) {
+    $key = $object->getEntityType()->getKey('status');
+
+    /** @var \Drupal\Core\Entity\EntityInterface $object */
+    $result = $object->access('update', $account, TRUE)
+      ->andIf($object->$key->access('edit', $account, TRUE));
+
+    return $return_as_object ? $result : $result->isAllowed();
+  }
+
+}

--- a/modules/custom/openy_upgrade_tool/src/Plugin/Action/ApplyOpenyVersionAction.php
+++ b/modules/custom/openy_upgrade_tool/src/Plugin/Action/ApplyOpenyVersionAction.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Drupal\openy_upgrade_tool\Plugin\Action;
+
+use Drupal\Core\Action\Plugin\Action\EntityActionBase;
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * Apply current active version for openy_upgrade_log entity.
+ *
+ * @Action(
+ *   id = "apply_openy_version",
+ *   action_label = @Translation("Apply Open Y version"),
+ *   type = "openy_upgrade_log"
+ * )
+ */
+class ApplyOpenyVersionAction extends EntityActionBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute($entity = NULL) {
+    $entity->applyOpenyVersion();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function access($object, AccountInterface $account = NULL, $return_as_object = FALSE) {
+    $key = $object->getEntityType()->getKey('status');
+
+    /** @var \Drupal\Core\Entity\EntityInterface $object */
+    $result = $object->access('update', $account, TRUE);
+
+    return $return_as_object ? $result : $result->isAllowed();
+  }
+
+}


### PR DESCRIPTION
Original Issue, this PR is going to fix: https://github.com/ymcatwincities/openy/issues/1566

## Steps for review

- [ ] login as admin
- [ ] go to /admin/structure/types
- [ ] modify several content types to get conflicts on the dashboard
- [ ] go to /admin/openy/development/upgrade-log/dashboard
- [ ] make sure you see conflicts list and checkbox and bulk action list "Apply current active version" and "Apply Open Y version"
- [ ] check any conflicts, select **Apply current active version** bulk action in dropdown at the top of list and click "Apply to selected items" button
- [ ] Selected conflict will be moved to Resolved section
- [ ] Expand resolved conflicts section
- [ ] Make sure you see only one bulk action "Apply Open Y version" 
- [ ] check any conflict and click "Apply to selected items" button
- [ ] make sure that config restored and no conflicts on Upgrade dashboard page