### PR TITLE
[YGBWCDA-56] Disable map scrolling on Location Page

### DIFF
--- a/modules/custom/openy_map/js/map.js
+++ b/modules/custom/openy_map/js/map.js
@@ -914,7 +914,7 @@
       init_map: function () {
         this.map = L.map(this.map_el[0]).setView([51.505, -0.09], 13);
         L.tileLayer(this.baseLayer.tilePattern, this.baseLayer.options).addTo(this.map);
-
+        this.map.scrollWheelZoom.disable();
         this.init_map_center();
       },
 


### PR DESCRIPTION
##  Original Issue, this PR is going to fix: 
On the YGBW project client reported: "When scrolling down on the locations page the map zooms out instead of scrolling down the page."

Thing is related to the fact the prod env is currently using Leaflet instead of Google Maps. So we need to disable Leaflet map scroll to make it be like in the Google maps.

## Steps for review

- [ ] Go to `/locations`
- [ ] Check that scroll wheel zoom is disabled
- [ ] Compare with http://sandbox.openymca.org/locations