### PR TITLE
Reset GXP migration after rollback/import.

### DIFF
--- a/modules/custom/openy_gxp/src/Form/ImportForm.php
+++ b/modules/custom/openy_gxp/src/Form/ImportForm.php
@@ -8,6 +8,8 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\migrate\MigrateExecutable;
 use Drupal\migrate\MigrateMessage;
 
+use Drupal\migrate_plus\Entity\MigrationInterface;
+
 use GuzzleHttp\Client;
 
 /**
@@ -83,6 +85,7 @@ class ImportForm extends FormBase {
     $migration = \Drupal::service('plugin.manager.migration')->createInstance('gxp_offerings_import');
     $executable = new MigrateExecutable($migration, new MigrateMessage());
     $executable->rollback();
+    $migration->setStatus(\Drupal\migrate\Plugin\MigrationInterface::STATUS_IDLE);
   }
 
   /**
@@ -220,6 +223,7 @@ class ImportForm extends FormBase {
 
     $executable = new MigrateExecutable($migration, new MigrateMessage());
     $executable->import();
+    $migration->setStatus(\Drupal\migrate\Plugin\MigrationInterface::STATUS_IDLE);
   }
 
 }


### PR DESCRIPTION
I have faced an issue while was setting up client GroupExPro integration that not all sessions got migrated. They have pretty large sets of data. It appeared that problem was because migration was still in "progress" with previous operation and skipped import of some locations.

This change makes sure that migration is in IDLE state i.e. ready for next operation.