### PR TITLE
[NOT PASSED] Check 8.7.0 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -195,7 +195,7 @@
         "cweagans/composer-patches": "^1.5.0",
         "composer/installers": "^1.0",
         "drupal-composer/drupal-scaffold": "^2.4.0",
-        "drupal/core": "~8.6.10",
+        "drupal/core": "~8.7.0",
         "drupal/features": "3.8",
         "drupal/confi": "1.4",
         "drupal/config_update": "^1.6",


### PR DESCRIPTION
- [x] OpenY with Drupal core 8.7.0 is pixel perfect(669 pages of the site with Demo content) in comparison to Drupal core 8.6.x
We need to spend some time for the investigation regarding https://www.drupal.org/node/3034742