### PR TITLE
PEF: get rid of the time part in date query param

### DIFF
--- a/modules/custom/openy_repeat/js/repeat.js
+++ b/modules/custom/openy_repeat/js/repeat.js
@@ -155,7 +155,9 @@
 
       var dateGet = this.$route.query.date;
       if (dateGet) {
-        this.date = new Date(dateGet).toISOString();
+        var date = new Date(dateGet);
+        date.setMinutes(date.getTimezoneOffset());
+        this.date = date.toISOString();
       }
       else {
         this.date = moment().toISOString();
@@ -286,7 +288,7 @@
     methods: {
       runAjaxRequest: function() {
         var component = this;
-        var date = new Date(this.date).toISOString();
+        var date = moment(this.date).format('YYYY-MM-DD');
 
         var url = drupalSettings.path.baseUrl + 'schedules/get-event-data';
         url += this.locations.length > 0 ? '/' + encodeURIComponent(this.locations.join(',')) : '/0';
@@ -316,7 +318,6 @@
           $('.schedules-loading').addClass('hidden');
         });
 
-        var date = new Date(this.date).toISOString();
         router.push({ query: {
             date: date,
             locations: this.locations.join(','),

--- a/modules/custom/openy_repeat/src/Controller/RepeatController.php
+++ b/modules/custom/openy_repeat/src/Controller/RepeatController.php
@@ -101,7 +101,7 @@ class RepeatController extends ControllerBase {
    */
   public function getData($request, $location, $date, $category) {
     if (empty($date)) {
-      $date = date('F j, l 00:00:00');
+      $date = date('Y-m-d');
     }
     $date = strtotime($date);
 


### PR DESCRIPTION
Original Issue, this PR is going to fix: #1603

The intention of the PR is to remove the time part of the date parameter for the PEF schedules.

## Steps for review

- [ ] go to `/group-exercise-classes`
- [ ] verify the page URL is automatically changed (e.g., to `/group-exercise-classes?date=2019-05-28&locations=&categories=`) after the page loads
- [ ] verify arrow date navigation works and keeps the date parameter clean (compare to `/group-exercise-classes?date=2019-05-28T16%3A08%3A02.979Z&locations=&categories=`)
- [ ] verify picking the date via 'Date' filter also results in the url changed to some expected value and the proper page contents.
- [ ] verify the result is the same no matter how you reached the page and what timezone you are in
- [ ] reload the page using the browser reload button
- [ ] verify the schedule shown is for the same date and the listing of classes hasn't changed

