### PR TITLE
[1610] - Add missed dependent library.

### DIFF
--- a/modules/openy_features/openy_node/modules/openy_node_alert/openy_node_alert.libraries.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_alert/openy_node_alert.libraries.yml
@@ -9,3 +9,4 @@ alert:
   dependencies:
     - core/drupal
     - core/jquery
+    - openy_system/jquery.matchHeight


### PR DESCRIPTION
Add missed dependent library to avoid console error when using custom theme not OpenY themes. As example see next OpenY site with error in browser console - https://www.ymcashr.org/