### PR TITLE
[#1612]: Fix predefined color for alert icon to none

### DIFF
--- a/modules/openy_features/openy_node/modules/openy_node_alert/src/Plugin/rest/resource/AlertsRestResource.php
+++ b/modules/openy_features/openy_node/modules/openy_node_alert/src/Plugin/rest/resource/AlertsRestResource.php
@@ -146,7 +146,7 @@ class AlertsRestResource extends ResourceBase {
       }
       else {
         if ($this->checkVisibility($alert)) {
-          $iconColor = 'white';
+          $iconColor = '';
           if ($alert->field_alert_icon_color && $alert->field_alert_icon_color->entity && $alert->field_alert_icon_color->entity->field_color && $alert->field_alert_icon_color->entity->field_color->value) {
             $iconColor = $alert->field_alert_icon_color->entity->field_color->value;
           }


### PR DESCRIPTION
There is not possible to hide icon in Alert. The "Icon color" has description like - "Leave empty to hide icon." but in code it it field has predifined "white" value and icon can't be hidden.

## Steps for review

- [ ] Go to alert node.
- [ ] select Icon Color value "None".
- [ ] now alert displaying without icon
