### PR TITLE
#1638 Fix-for-gtranslate: update google translate for mobile.

### DIFF
--- a/modules/custom/openy_gtranslate/js/openy_gtranslate.js
+++ b/modules/custom/openy_gtranslate/js/openy_gtranslate.js
@@ -29,13 +29,16 @@
 
     Drupal.behaviors.openy_gtranslate_mobile = {
         attach: function (context, settings) {
-            var el = $('#google_translate_element');
-            setTimeout(function () {
-                $(".navbar-toggler, .navbar-toggle").on('click', function () {
-                    $('.navbar-nav > li.language a').hide();
-                    el.removeClass('hidden-xs').removeClass('hidden-sm').appendTo('.navbar-nav > li.language');
-                });
-            }, 100);
+            // Emulate mobile width.
+            if ($(window).width() < 768) {
+                setTimeout(function() {
+                    if ($('.navbar-nav > li.language .openy-google-translate').length == 0) {
+                        $('.navbar-nav > li.language a').hide();
+                        jQuery('#g_translater').detach().appendTo('.navbar-nav > li.language');
+                    }
+                }, 100);
+            }
+
         }
     };
 

--- a/modules/custom/openy_gtranslate/templates/openy-gtranslate.html.twig
+++ b/modules/custom/openy_gtranslate/templates/openy-gtranslate.html.twig
@@ -4,17 +4,18 @@
  * Template for the OpenY Google Translate block
  */
 #}
-
-<div class="openy-google-translate hidden-xs hidden-sm" id="google_translate_element"></div>
-<script type="text/javascript">
+<div class="translate" id="g_translater">
+  <div class="openy-google-translate" id="google_translate_element"></div>
+  <script type="text/javascript">
     function googleTranslateElementInit() {
-        new google.translate.TranslateElement(
-            {pageLanguage: drupalSettings.path.currentLanguage, layout: google.translate.TranslateElement.InlineLayout.VERTICAL},
-            'google_translate_element');
-        if(typeof(document.querySelector) == 'function') {
-            document.querySelector('.goog-logo-link').setAttribute('style', 'display: none');
-            document.querySelector('.goog-te-gadget').setAttribute('style', 'font-size: 0');
-        }
+      new google.translate.TranslateElement(
+          {pageLanguage: drupalSettings.path.currentLanguage, layout: google.translate.TranslateElement.InlineLayout.VERTICAL},
+          'google_translate_element');
+      if(typeof(document.querySelector) == 'function') {
+        document.querySelector('.goog-logo-link').setAttribute('style', 'display: none');
+        document.querySelector('.goog-te-gadget').setAttribute('style', 'font-size: 0');
+      }
     }
-</script>
-<script async type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
+  </script>
+  <script async type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
+</div>


### PR DESCRIPTION
Fix for https://github.com/ymcatwincities/openy/issues/1638.
To test the functionality you need to switch to the mobile view and reload the page. Otherwise, the handlers will not attach.