### PR TITLE
[YGBWSLA-71] Fix wrong config dir in activity_finder

### DIFF
--- a/modules/custom/openy_activity_finder/config/optional/search_api.index.default.yml
+++ b/modules/custom/openy_activity_finder/config/optional/search_api.index.default.yml
@@ -19,8 +19,6 @@ dependencies:
     - node
     - paragraphs
     - search_api
-_core:
-  default_config_hash: jeqriDXA-iNZIZ0eP_1GU_RRKOemook1aL46CEIqKZA
 id: default
 name: Default
 description: ''

--- a/modules/custom/openy_activity_finder/openy_activity_finder.install
+++ b/modules/custom/openy_activity_finder/openy_activity_finder.install
@@ -8,11 +8,12 @@
 /**
 * Update configs.
 */
-function openy_activity_finder_update_8001() {
+function openy_activity_finder_update_8002() {
+  $openy_activity_finder_dir = drupal_get_path('module', 'openy_activity_finder');
   $cim = \Drupal::service('config_import.importer');
-  $cim->setDirectory(drupal_get_path('module', 'openy_activity_finder') . '/config/install');
-  $cim->importConfigs([
-    'openy_activity_finder.settings',
-    'search_api.index.default'
-  ]);
+  $cim->setDirectory($openy_activity_finder_dir . '/config/install');
+  $cim->importConfigs(['openy_activity_finder.settings']);
+
+  $cim->setDirectory($openy_activity_finder_dir . '/config/optional');
+  $cim->importConfigs(['search_api.index.default']);
 }


### PR DESCRIPTION
`search_api.index.default` located in `optional` directory, so during `openy_activity_finder_update_8001` it doesn't updated. This can't be tested on fresh installation or on the manual module enabling.

## Steps for review

- [ ] Check that after `openy_activity_finder_update_8002` execution you can see correct `search_api.index.default` configuration on `/admin/config/search/search-api` page
- [ ] Profit.
