### PR TITLE
[YGBWSLA-71] Fix type hinting for batch context in upgrade tool

### DIFF
--- a/modules/custom/openy_upgrade_tool/src/OpenyUpgradeLogManager.php
+++ b/modules/custom/openy_upgrade_tool/src/OpenyUpgradeLogManager.php
@@ -533,10 +533,10 @@ class OpenyUpgradeLogManager implements OpenyUpgradeLogManagerInterface {
    *
    * @param string $openy_upgrade_log
    *   OpenyUpgradeLog item name.
-   * @param array $context
+   * @param object $context
    *   The batch context.
    */
-  public static function setConflictResolvedBatchProcess($openy_upgrade_log, array &$context) {
+  public static function setConflictResolvedBatchProcess($openy_upgrade_log, &$context) {
     $entity = \Drupal::service('openy_upgrade_log.manager')
       ->loadByName($openy_upgrade_log);
     $entity->setStatus(TRUE)->save();
@@ -547,10 +547,10 @@ class OpenyUpgradeLogManager implements OpenyUpgradeLogManagerInterface {
    *
    * @param string $openy_upgrade_log
    *   OpenyUpgradeLog item name.
-   * @param array $context
+   * @param object $context
    *   The batch context.
    */
-  public static function deleteOpenyUpgradeLogItemBatchProcess($openy_upgrade_log, array &$context) {
+  public static function deleteOpenyUpgradeLogItemBatchProcess($openy_upgrade_log, &$context) {
     $entity = \Drupal::service('openy_upgrade_log.manager')
       ->loadByName($openy_upgrade_log);
     $entity->delete();


### PR DESCRIPTION
Fix for error: `TypeError: Argument 2 passed to Drupal\openy_upgrade_tool\OpenyUpgradeLogManager::setConflictResolvedBatchProcess() must be of the type array, object given`

https://www.drupal.org/node/2689939 removed the array type hinting for batch context from IndexBatchHelper. So, this should be refactored according to this issue.

## Steps for review

- [ ] Create a hook update with OpenY configs conflicts resolving. Example:

```
/**
 * OpenY update conflicts resolving.
 */
function test_update_8001() {
  $openy_upgrade_log_manager = \Drupal::service('openy_upgrade_log.manager');
  $conflict_configs_list = [
    'leave current version' => [
      'views.view.latest_event_posts',
      'views.view.listing_event_posts',
    ],
    'force update to openy version' => [
      'field.field.node.alert.field_alert_belongs',
      'field.field.paragraph.webform.field_prgf_webform',
    ],
  ];

  foreach ($conflict_configs_list as $action => $config_list) {
    foreach ($config_list as $config_name) {
      if ($action == 'leave current version') {
        $openy_upgrade_log_manager->loadByName($config_name)->applyCurrentActiveVersion();
      }
      else {
        $openy_upgrade_log_manager->loadByName($config_name)->applyOpenyVersion();
      }
    }
  }
}
```

- [ ] Check that on `drush updb -y` this hook update work without errors
