### PR TITLE
[YGBWSLA-71] Check config existing before import

### DIFF
--- a/modules/custom/openy_activity_finder/openy_activity_finder.install
+++ b/modules/custom/openy_activity_finder/openy_activity_finder.install
@@ -8,12 +8,16 @@
 /**
 * Update configs.
 */
-function openy_activity_finder_update_8002() {
+function openy_activity_finder_update_8001() {
   $openy_activity_finder_dir = drupal_get_path('module', 'openy_activity_finder');
   $cim = \Drupal::service('config_import.importer');
   $cim->setDirectory($openy_activity_finder_dir . '/config/install');
   $cim->importConfigs(['openy_activity_finder.settings']);
 
   $cim->setDirectory($openy_activity_finder_dir . '/config/optional');
-  $cim->importConfigs(['search_api.index.default']);
+  $config = \Drupal::config('search_api.index.default');
+  if (!$config->isNew()) {
+    // Import config only in case it already exist.
+    $cim->importConfigs(['search_api.index.default']);
+  }
 }


### PR DESCRIPTION
Small fix for this PR - https://github.com/ymcatwincities/openy/pull/1651

`search_api.index.default` is optional, so it's better to check if this config exists before importing.
Also no need to change the update number here.

