### PR TITLE
[YGBWSLA-71] Add sort value to ActivityFinder cache hash

### DIFF
--- a/modules/custom/openy_activity_finder/src/Controller/ActivityFinderController.php
+++ b/modules/custom/openy_activity_finder/src/Controller/ActivityFinderController.php
@@ -74,6 +74,7 @@ class ActivityFinderController extends ControllerBase {
       'page' => $request->get('page'),
       'day' => $request->get('days'),
       'age' => $request->get('ages'),
+      'sort' => $request->get('sort'),
     ];
     $record['hash'] = md5(json_encode($record));
 


### PR DESCRIPTION
## Issue details:

Sorting doesn't work in ActivityFinder because of the caching issue. Any sort value modifying is useless if the ActivityFinder search result cached, so we need to include `sort` parameter to the hash.

## Steps for review

- [ ] Enable all ActivityFinder modules + solr
- [ ] Create pages with ActivityFinder paragraphs
- [ ] check that sorting works fine

![Screenshot from 2019-07-16 18-59-03](https://user-images.githubusercontent.com/13733670/61309912-d85b4200-a7fb-11e9-9e42-0c729512e30b.png)
