### PR TITLE
 [YGBWSLA-71] Restore session param in PEF class link

### DIFF
--- a/modules/custom/openy_repeat/src/Controller/RepeatController.php
+++ b/modules/custom/openy_repeat/src/Controller/RepeatController.php
@@ -190,6 +190,7 @@ class RepeatController extends ControllerBase {
 
       if (isset($classes_info[$item->class]['path'])) {
         $query = UrlHelper::buildQuery([
+          'session' => $item->session,
           'location' => $locations_info[$item->location]['nid'],
         ]);
         if (!in_array($item->name, $class_name)) {


### PR DESCRIPTION
In this commit was removed the session parameter from the link to the class page.

![Screenshot from 2019-07-17 13-26-57](https://user-images.githubusercontent.com/13733670/61368959-ab5c6d00-a897-11e9-8996-1f7c66047315.png)

This parameter required for correct work of the class page, after redirect from PEF class page should display the correct session that was selected in the schedule.

## Steps for review

- [ ] Go to http://sandbox.openymca.org/group-exercise-classes?date=2019-07-17&locations=&categories=
- [ ] Click on class
- [ ] Check that `View more` link contain session
- [ ] Profit
