### PR TITLE
PEF: Show second button only on mobile

### DIFF
--- a/modules/custom/openy_repeat/templates/openy-repeat-schedule-locations.html.twig
+++ b/modules/custom/openy_repeat/templates/openy-repeat-schedule-locations.html.twig
@@ -49,7 +49,7 @@
 
     {% if locations is not empty %}
       <div class="col col-xs-12 text-right">
-        <button class="btn-mobile btn btn-primary btn-lg submit-locations js-submit-locations disabled">{{ 'Next'|t }}</button>
+        <button class="btn-mobile visible-xs-block btn btn-primary btn-lg submit-locations js-submit-locations disabled">{{ 'Next'|t }}</button>
       </div>
     {% endif %}
   </div>


### PR DESCRIPTION
I think the second button should be visible only on mobile devices. Anyway `btn-mobile` class doesn't hide it, maybe this work on YGTC project, but in OpenY, or YGBW and YGS this not work. Let's add an additional `visible-xs-block` class from bootstrap, it shows block only on a mobile.

![Screenshot from 2019-07-17 14-23-15](https://user-images.githubusercontent.com/13733670/61372440-cb902a00-a89f-11e9-9b65-a24124863ec0.png)


## Steps for review

- [ ] Login as admin
- [ ] Create a landing page with `Repeat Schedules Locations` paragraph
- [ ] Check that on desktop you can see only one `Next` button
- [ ] Check that on mobile you can see 2 buttons (before and after locations list)
- [ ] Profit