### PR TITLE
Fix google translate select list option color

### DIFF
--- a/themes/openy_themes/openy_lily/css/style.css
+++ b/themes/openy_themes/openy_lily/css/style.css
@@ -7368,6 +7368,9 @@ article .node--view-mode-flexible-content h2 a span {
   font-size: 18px !important;
   font-weight: bold;
 }
+.nav .language .openy-google-translate select option {
+  color: #636466;
+}
 
 .paragraph-1c-wrapper {
   padding-bottom: 30px;

--- a/themes/openy_themes/openy_lily/sass/modules/_gtranslate.scss
+++ b/themes/openy_themes/openy_lily/sass/modules/_gtranslate.scss
@@ -21,6 +21,10 @@
         color: $white;
         font-size: 18px !important;
         font-weight: bold;
+
+        option {
+          color: $default-grey;
+        }
       }
     }
   }

--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -7860,10 +7860,14 @@ article .node--view-mode-flexible-content h2 a span {
 .openy-google-translate select {
   background: transparent;
   border: none;
+  max-width: 145px;
   text-transform: uppercase;
   color: #fff;
   font-size: 12px;
   margin-top: 6px;
+}
+.openy-google-translate select option {
+  color: #636466;
 }
 
 .nav .language .openy-google-translate select {

--- a/themes/openy_themes/openy_rose/scss/modules/_gtranslate.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_gtranslate.scss
@@ -7,10 +7,15 @@
 .openy-google-translate select {
   background: transparent;
   border: none;
+  max-width: 145px;
   text-transform: uppercase;
   color: $white;
   font-size: 12px;
   margin-top: 6px;
+
+  option {
+    color: $default-grey;
+  }
 }
 
 .nav {


### PR DESCRIPTION
In the latest Open Y version, we have some issues with google translate select list.
This can be reproduced on http://sandbox.openymca.org/

![g-translate-desctop-issue](https://user-images.githubusercontent.com/13733670/61543434-249cc100-aa4c-11e9-85c5-0786ca802da8.gif)

Tested on Google Chrome browser (Ubuntu)

## Steps for review

- [ ] Check that google translate options visible in the select list 
- [ ] Check that this works fine in other OpenY themes
