### PR TITLE
[YGBWSLA-80] Allow other modules to alter the activity finder process results.

### DIFF
--- a/modules/custom/openy_activity_finder/README.md
+++ b/modules/custom/openy_activity_finder/README.md
@@ -1,0 +1,36 @@
+# Examples
+
+### How to override processResults in ActivityFinder
+
+See `openy_activity_finder.api.php`
+```php
+/**
+ * Implements hook_activity_finder_program_process_results_alter().
+ */
+function custom_module_activity_finder_program_process_results_alter(&$data, NodeInterface $entity) {
+  // Get formatted session data from some custom service.
+  $formatted_session = \Drupal::service('ymca_class_page.data_provider')
+    ->formatSessions([$entity], FALSE);
+  $formatted_session = reset($formatted_session);
+
+  // Fix pricing according to YMCA price customization.
+  $data['price'] = '';
+  if (!empty($formatted_session['prices'])) {
+    foreach ($formatted_session['prices'] as $price) {
+      $data['price'] .= implode(' ', $price) . '<br>';
+    }
+  }
+
+  // Fix availability and registration according to YMCA customization.
+  $messages = [
+    'begun' => t('This class has begun.'),
+    'will_open' => t('Registration for this class opens shortly. Please check back.'),
+    'inperson' => t('Online registration is closed. Visit a YMCA branch to register.'),
+    'included_in_membership' => t('Included in Membership'),
+  ];
+
+  if (isset($messages[$formatted_session['reg_state']])) {
+    $data['availability_note'] = $messages[$formatted_session['reg_state']];
+  }
+}
+```

--- a/modules/custom/openy_activity_finder/openy_activity_finder.api.php
+++ b/modules/custom/openy_activity_finder/openy_activity_finder.api.php
@@ -1,10 +1,31 @@
 <?php
 
 /**
+ * @file
+ * Hooks specific to the openy_activity_finder module.
+ */
+
+use Drupal\node\NodeInterface;
+
+/**
  * Alter the search results.
  */
 function hook_activity_finder_program_search_results_alter(&$data) {
 
+}
+
+/**
+ * Alter the process results.
+ *
+ * @param array $data
+ *   The array of processed result item for program search.
+ * @param \Drupal\node\NodeInterface $entity
+ *   The node that has just been processed.
+ *
+ * @see Drupal\openy_activity_finder\OpenyActivityFinderSolrBackend
+ */
+function hook_activity_finder_program_process_results_alter(array &$data, NodeInterface $entity) {
+  $data['description'] = t('Test session description');
 }
 
 /**

--- a/modules/custom/openy_activity_finder/openy_activity_finder.services.yml
+++ b/modules/custom/openy_activity_finder/openy_activity_finder.services.yml
@@ -1,4 +1,4 @@
 services:
   openy_activity_finder.solr_backend:
     class: Drupal\openy_activity_finder\OpenyActivityFinderSolrBackend
-    arguments: ['@config.factory', '@cache.default', '@database', '@entity.query', '@entity_type.manager', '@date.formatter', '@datetime.time', '@logger.channel.default']
+    arguments: ['@config.factory', '@cache.default', '@database', '@entity.query', '@entity_type.manager', '@date.formatter', '@datetime.time', '@logger.channel.default', '@module_handler']


### PR DESCRIPTION
On projects like YGBW and YGS, we have some customizations for session prices and availability statuses, so we need to display this in the same way on the Activity Finder schedule.
Let's add hook alter for the OpenyActivityFinderSolrBackend::processResults.

Example of my use case in custom hook:

```php
/**
 * Implements hook_activity_finder_program_process_results_alter().
 */
function ybw_activity_finder_activity_finder_program_process_results_alter(&$data, NodeInterface $entity) {
  // @see \Drupal\ygbw_class_page\ClassPageDataProvider
  $formatted_session = \Drupal::service('ygbw_class_page.data_provider')
    ->formatSessions([$entity], FALSE);
  $formatted_session = reset($formatted_session);

  // Fix pricing according to YGBW price customization.
  // @see themes/custom/ymca_seattle/templates/custom/class-page-other-sessions.html.twig
  $data['price'] = '';
  if (!empty($formatted_session['prices'])) {
    foreach ($formatted_session['prices'] as $price) {
      $data['price'] .= implode(' ', $price) . '<br>';
    }
  }

  // Fix availability and registration according to YGBW customization.
  // @see themes/custom/ymca_seattle/templates/custom/class-page-other-sessions.html.twig
  $link = Link::createFromRoute(t('View registration info for our next session.'), '<ygbw-reg-info>');
  $messages = [
    'begun' => t('This class has begun. <br> @link', [
      '@link' => $link->toString(),
    ]),
    'will_open' => t('Registration for this class opens shortly. Please check back. <br> @link', [
      '@link' => $link->toString(),
    ]),
    'inperson' => t('Online registration is closed. <br> Visit a YMCA branch to register.'),
    'included_in_membership' => t('Included in Membership'),
  ];

  if (isset($messages[$formatted_session['reg_state']])) {
    $data['availability_note'] = $messages[$formatted_session['reg_state']];
  }
}
```

The result on page:
![Screenshot from 2019-07-23 17-41-01](https://user-images.githubusercontent.com/13733670/61721492-372b3900-ad71-11e9-9b1c-fc78bdd2158c.png)

