### PR TITLE
OS-480: add aria-label to links

### DIFF
--- a/themes/openy_themes/openy_carnation/templates/node/extends/post-teaser--default.html.twig
+++ b/themes/openy_themes/openy_carnation/templates/node/extends/post-teaser--default.html.twig
@@ -47,7 +47,7 @@
       </div>
 
       {% block link %}
-      <a href="{{ title_url }}" rel="bookmark" class="btn-link h5">
+      <a href="{{ title_url }}" rel="bookmark" class="btn-link h5" aria-label="{{ 'Continue Reading'|t ~ " " ~ label|render|striptags }}">
         <span class="text-uppercase font-weight-bold pr-1">{{ 'Continue Reading'|t }}</span>
         <i class="fa fa-arrow-right text-pink"></i>
       </a>

--- a/themes/openy_themes/openy_carnation/templates/node/news/node--news--teaser.html.twig
+++ b/themes/openy_themes/openy_carnation/templates/node/news/node--news--teaser.html.twig
@@ -87,7 +87,7 @@
 {% endblock %}
 
 {% block link %}
-  <a href="{{ url }}" rel="bookmark" class="btn-link h5">
+  <a href="{{ url }}" rel="bookmark" class="btn-link h5" aria-label="{{ 'Continue Reading'|t ~ " " ~ label|render|striptags }}">
     <span class="text-uppercase font-weight-bold pr-1">{{ 'Continue Reading'|t }}</span>
     <i class="fa fa-arrow-right text-pink"></i>
   </a>


### PR DESCRIPTION
Steps to Reproduce
On the home page there are a series of articles, each has a "continue reading" link, make these unique by adding a aria-label of aria-label="Continue reading article_title" so when viewing a list of links on the page it will be clear what link takes the user to what article, this will help screen reader users and will not mess with the visual presentation of the link text.

Actual Results
Multiple "continue reading" links are present on the homepage and they should be made unique.

Expected REsults
Add an aria-label on the links to make them unique without effecting the visual presentation. Example: aria-label="Continue reading article_title" 