### PR TITLE
OS-481: add alt attributes to images in listing.

### DIFF
--- a/themes/openy_themes/openy_carnation/openy_carnation.theme
+++ b/themes/openy_themes/openy_carnation/openy_carnation.theme
@@ -25,7 +25,7 @@ function openy_carnation_preprocess_html(array &$variables) {
  * Implements hook_preprocess_node().
  */
 function openy_carnation_preprocess_node(&$variables, $hook) {
-
+  $view_mode = $variables['elements']['#view_mode'];
   if ($node = \Drupal::routeMatch()->getParameter('node')) {
     switch ($node->getType()) {
       // Program pages.
@@ -45,6 +45,15 @@ function openy_carnation_preprocess_node(&$variables, $hook) {
         break;
     }
   }
+
+  // Add alt attributes to images in subprogram listings.
+  if ($view_mode == 'teaser') {
+    $entity = $variables['elements']['#node'];
+    if (!$entity->get('field_category_image')->isEmpty()) {
+      $entity->get('field_category_image')->entity->get('field_media_image')->alt = $entity->label();
+    }
+  }
+
 }
 
 /**


### PR DESCRIPTION
Steps to Reproduce
Programs > Health & Fitness the graphics for each category of service do not have an alt attribute added. Each category suchas as active older adults or group exercise classes has a link graphic and the filenam is reading because these images do not have an alt text value.

Actual Result
Link graphics for each service category do not have proper alt text

Expected REsults
Alt text (Example: alt="Active older adults" should be added to each service category. Currently the file name is reading because an alt value is not provided. The name of the service could be automatically applied as the value in the alt attribute