### PR TITLE
[YGBWHB-14] Alerts Refactoring + new custom hook

### DIFF
--- a/modules/openy_features/openy_node/modules/openy_node_alert/config/install/core.entity_form_display.node.alert.default.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_alert/config/install/core.entity_form_display.node.alert.default.yml
@@ -22,7 +22,6 @@ third_party_settings:
   field_group:
     group_visibility_pages:
       children:
-        - field_alert_belongs
         - field_alert_visibility_pages
         - field_alert_visibility_state
       parent_name: ''
@@ -188,4 +187,5 @@ content:
     settings: {  }
     third_party_settings: {  }
     region: content
-hidden: {  }
+hidden:
+  field_alert_belongs: true

--- a/modules/openy_features/openy_node/modules/openy_node_alert/config/install/core.entity_view_display.node.alert.default.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_alert/config/install/core.entity_view_display.node.alert.default.yml
@@ -81,6 +81,7 @@ content:
     third_party_settings: {  }
 hidden:
   addthis: true
+  field_alert_belongs: true
   field_alert_visibility_pages: true
   field_alert_visibility_state: true
   langcode: true

--- a/modules/openy_features/openy_node/modules/openy_node_alert/config/install/core.entity_view_display.node.alert.node_alert_footer.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_alert/config/install/core.entity_view_display.node.alert.node_alert_footer.yml
@@ -82,6 +82,7 @@ content:
     region: content
 hidden:
   addthis: true
+  field_alert_belongs: true
   field_alert_visibility_pages: true
   field_alert_visibility_state: true
   langcode: true

--- a/modules/openy_features/openy_node/modules/openy_node_alert/config/install/core.entity_view_display.node.alert.node_alert_header.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_alert/config/install/core.entity_view_display.node.alert.node_alert_header.yml
@@ -82,6 +82,7 @@ content:
     region: content
 hidden:
   addthis: true
+  field_alert_belongs: true
   field_alert_visibility_pages: true
   field_alert_visibility_state: true
   langcode: true

--- a/modules/openy_features/openy_node/modules/openy_node_alert/config/install/core.entity_view_display.node.alert.teaser.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_alert/config/install/core.entity_view_display.node.alert.teaser.yml
@@ -31,6 +31,7 @@ content:
     weight: 100
     region: content
 hidden:
+  field_alert_belongs: true
   field_alert_color: true
   field_alert_description: true
   field_alert_icon_color: true

--- a/modules/openy_features/openy_node/modules/openy_node_alert/config/install/field.field.node.alert.field_alert_belongs.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_alert/config/install/field.field.node.alert.field_alert_belongs.yml
@@ -14,8 +14,8 @@ id: node.alert.field_alert_belongs
 field_name: field_alert_belongs
 entity_type: node
 bundle: alert
-label: '[obsolete] Reference'
-description: 'Reference to node (branch, camp, landing page and etc.), where local alert will be displayed. DO NOT USE, will be removed in next release.'
+label: 'Reference'
+description: 'Reference to node (branch, camp, landing page and etc.)'
 required: false
 translatable: false
 default_value: {  }

--- a/modules/openy_features/openy_node/modules/openy_node_alert/openy_node_alert.api.php
+++ b/modules/openy_features/openy_node/modules/openy_node_alert/openy_node_alert.api.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @file
+ * Documents hooks provided by this module.
+ */
+
+/**
+ * Modify the alerts rest resource results.
+ *
+ * Example: you can add new alerts or remove existing before output.
+ *
+ * @see \Drupal\openy_node_alert\Plugin\rest\resource\AlertsRestResource
+ */
+function hook_openy_node_alert_get_alter(array &$sendAlerts, array $alerts) {
+  // Example code:
+  foreach ($alerts as $id => $alert) {
+    if ($alert->hasField('field_alert_belongs') && $alert->field_alert_belongs->target_id == '{Some node ID}') {
+      $sendAlerts[$alert->field_alert_place->value]['global'][] = \Drupal\openy_node_alert\Plugin\rest\resource\AlertsRestResource::formatAlert($alert);
+    }
+  }
+}

--- a/modules/openy_features/openy_node/modules/openy_node_alert/openy_node_alert.install
+++ b/modules/openy_features/openy_node/modules/openy_node_alert/openy_node_alert.install
@@ -188,7 +188,7 @@ function openy_node_alert_update_8010() {
   $config_importer = \Drupal::service('openy_upgrade_tool.importer');
   $config_importer->setDirectory($config_dir);
   $config_importer->importConfigs($configs);
-  
+
   $alerts = \Drupal::entityTypeManager()->getStorage('node')->loadByProperties(['type' => 'alert']);
   /** @var \Drupal\node\Entity\Node $alert */
   foreach ($alerts as $alert) {
@@ -229,19 +229,29 @@ function openy_node_alert_update_8010() {
       }
     }
   }
-  // Remove obsolete field.
-  if ($field_config = FieldConfig::loadByName('node', 'alert', 'field_alert_belongs')) {
+}
 
-    $field_storage = $field_config->getFieldStorageDefinition();
-    $bundles = \Drupal::entityManager()->getBundleInfo($field_config->getTargetEntityTypeId());
-    $bundle_label = $bundles[$field_config->getTargetBundle()]['label'];
+/**
+ * Restore field_alert_belongs if not exist.
+ */
+function openy_node_alert_update_8011() {
+  // Note: no need to check field existing, those configs anyway was changed
+  // and should be imported.
+  $config_dir = drupal_get_path('module', 'openy_node_alert') . '/config/install/';
+  $configs = [
+    'core.entity_form_display.node.alert.default',
+    'core.entity_view_display.node.alert.default',
+    'core.entity_view_display.node.alert.node_alert_footer',
+    'core.entity_view_display.node.alert.node_alert_header',
+    'core.entity_view_display.node.alert.teaser',
+    'core.entity_view_mode.node.node_alert_footer',
+    'core.entity_view_mode.node.node_alert_header',
+    'field.field.node.alert.field_alert_belongs',
+    'field.storage.node.field_alert_belongs',
+  ];
 
-    if ($field_storage && !$field_storage->isLocked()) {
-      $field_config->delete();
-      \Drupal::logger(__FUNCTION__)->info('The field %field has been deleted from the %type content type.', array('%field' => $field_config->label(), '%type' => $bundle_label));
-    }
-    else {
-      \Drupal::logger(__FUNCTION__)->error('There was a problem removing the %field from the %type content type.', array('%field' => $field_config->label(), '%type' => $bundle_label));
-    }
-  }
+  // Import updated configuration.
+  $config_importer = \Drupal::service('openy_upgrade_tool.importer');
+  $config_importer->setDirectory($config_dir);
+  $config_importer->importConfigs($configs);
 }


### PR DESCRIPTION
The PR fixes 2 problems:

1) The issue with `field_alert_belongs`. There is [an update hook](https://github.com/ymcatwincities/openy/blob/8.2.2.0/modules/openy_features/openy_node/modules/openy_node_alert/openy_node_alert.install#L240) that removes this field, but field configs still exist in the module, as result - all new OpenY installations contain `field_alert_belongs`, and for existing sites, it was removed. Our client wants to have this field on YGBW site, also we will use `field_alert_belongs` in Home Branch implementation for extending alerts.

*Proposed solution*: restore `field_alert_belongs` and hide on all view and form modes by default.

2) For Home Branch implementation we need to alter `AlertsRestResource` results. In the current implementation, this can't be easily done, so for more flexibility, I want to propose to invoke an alter hook before returning `ModifiedResourceResponse`.

Example, how we will use this in the home branch:

```php
/**
 * Implements hook_openy_node_alert_get_alter().
 *
 * In case selected Home Branch - add alerts with field_alert_belongs value
 * that equal to home branch ID to all pages.
 */
function openy_home_branch_openy_node_alert_get_alter(&$sendAlerts, $alerts) {
  if (empty($_COOKIE['home_branch'])) {
    return;
  }

  $hb_data = json_decode($_COOKIE['home_branch'], TRUE);

  if (empty($hb_data['id'])) {
    return;
  }

  foreach ($alerts as $id => $alert) {
    if ($alert->hasField('field_alert_belongs') && $alert->field_alert_belongs->target_id == $hb_data['id']) {
      if (_openy_hb_alert_alredy_exist($sendAlerts, $alert->field_alert_place->value, $hb_data['id'])) {
        // Skip if already exist.
        continue;
      }
      $sendAlerts[$alert->field_alert_place->value]['global'][] = AlertsRestResource::formatAlert($alert);
    }
  }
}
```

Also, I have provided some refactoring in `AlertsRestResource`.

**Please note:** the PR doesn't contain anything related to the Home Branch. The PR with Home Branch implementation will be presented later during this week.

## Steps for review

- [ ] Login as admin
- [ ] Check that alerts works like before this fix
- [ ] Go to `/admin/structure/types/manage/alert/fields`
- [ ] Check that `field_alert_belongs` exist in fields list
- [ ] Check that  `field_alert_belongs` hidden in all view and form modes
