### PR TITLE
Os 482 prev and next buttons

### DIFF
--- a/themes/openy_themes/openy_carnation/templates/paragraph/paragraph--gallery--default.html.twig
+++ b/themes/openy_themes/openy_carnation/templates/paragraph/paragraph--gallery--default.html.twig
@@ -66,13 +66,13 @@ set classes = [
       {% endfor %}
     </div>
     {% if content.field_prgf_images['#items']|length > 1 %}
-    <a class="carousel-control-prev" href=".carousel" role="button" data-slide="prev">
+    <a class="carousel-control-prev" href=".carousel" data-slide="prev" aria-hidden="true" tabindex="-1">
       <span class="carousel-control-prev-icon" aria-hidden="true"></span>
-      <span class="sr-only">{{ 'Previous'|t }}</span>
+      <span class="sr-only" aria-hidden="true">{{ 'Previous'|t }}</span>
     </a>
-    <a class="carousel-control-next" href=".carousel" role="button" data-slide="next">
+    <a class="carousel-control-next" href=".carousel" data-slide="next" aria-hidden="true" tabindex="-1">
       <span class="carousel-control-next-icon" aria-hidden="true"></span>
-      <span class="sr-only">{{ 'Next'|t }}</span>
+      <span class="sr-only" aria-hidden="true">{{ 'Next'|t }}</span>
     </a>
     {% endif %}
   </div>


### PR DESCRIPTION
Description

Steps to Reproduce

At the top of both the accelerator page and the join page are a set of buttons labelled "previous" and "next" they are right after the skip to main content link. It appears they may be hidden visually but still present for screen reader users.

Actual Results

There are elements on screen present only for screen reader users.

Expected Results
There are elements on screen present only for screen reader users.