### PR TITLE
Initial step for the next release. Core 8.7+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -195,7 +195,7 @@
         "cweagans/composer-patches": "^1.5.0",
         "composer/installers": "^1.0",
         "drupal-composer/drupal-scaffold": "^2.4.0",
-        "drupal/core": "~8.6.10",
+        "drupal/core": "~8.7.6",
         "drupal/features": "3.8",
         "drupal/confi": "1.4",
         "drupal/config_update": "^1.6",


### PR DESCRIPTION
Let's update to 8.7
We are going to lost `entup` functionality from drush with this release. SO everything related to updating entities now should be covered by hook_update_N