### PR TITLE
[YGBWHB-37] Show spinner instead locations in PEF when HB selected

### DIFF
--- a/modules/custom/openy_home_branch/README.md
+++ b/modules/custom/openy_home_branch/README.md
@@ -88,4 +88,6 @@ Or you can attach to page your custom js file and override plugin here. Example:
 
 More examples with override cases you can find in `openy_hb_override_example` sub-module.
 
+For back-end plugins we need this in Drupal core - https://www.drupal.org/project/drupal/issues/2958184
+
 

--- a/modules/custom/openy_home_branch/js/hb-plugins/hb-pef-location.js
+++ b/modules/custom/openy_home_branch/js/hb-plugins/hb-pef-location.js
@@ -5,6 +5,16 @@
 
 (function ($, Drupal, drupalSettings) {
 
+  // By default hide locations list.
+  $(drupalSettings.home_branch.hb_loc_selector_pef.locationsWrapper).hide();
+  $(drupalSettings.home_branch.hb_loc_selector_pef.locationsWrapper).after(`
+    <div style="height: 50px; margin: 30px;">
+      <svg class="spinner" viewBox="0 0 50 50" data-size="normal" data-flow="centered">
+        <circle class="path" cx="25" cy="25" r="20" fill="none" stroke-width="5" stroke="#93bfec"></circle>
+      </svg>
+    </div>
+  `);
+
   /**
    * Adds plugin related to PEF Schedules locations paragraph.
    */
@@ -17,6 +27,7 @@
     },
     settings: {
       selector: null,
+      locationsWrapper: drupalSettings.home_branch.hb_loc_selector_pef.locationsWrapper,
       inputSelector: drupalSettings.home_branch.hb_loc_selector_pef.inputSelector,
       linkSelector: drupalSettings.home_branch.hb_loc_selector_pef.linkSelector,
       event: null,
@@ -24,6 +35,9 @@
       init: function () {
         var selected = Drupal.homeBranch.getValue('id');
         if (!selected) {
+          // Show locations list in case Home Branch not selected.
+          $(this.locationsWrapper).show();
+          $('.spinner').hide();
           return;
         }
         var locations = Drupal.homeBranch.getLocations();

--- a/modules/custom/openy_home_branch/openy_home_branch.libraries.yml
+++ b/modules/custom/openy_home_branch/openy_home_branch.libraries.yml
@@ -60,6 +60,7 @@ pef_location:
   dependencies:
     - core/drupalSettings
     - openy_home_branch/cookies_storage
+    - openy_system/openy_system.ajax_spinner
 
 loc_selector_branch_page:
   version: 0.1

--- a/modules/custom/openy_home_branch/src/Plugin/HomeBranchLibrary/HBLocSelectorPEF.php
+++ b/modules/custom/openy_home_branch/src/Plugin/HomeBranchLibrary/HBLocSelectorPEF.php
@@ -36,6 +36,7 @@ class HBLocSelectorPEF extends HomeBranchLibraryBase {
    */
   public function getLibrarySettings() {
     return [
+      'locationsWrapper' => '.schedule-locations__wrapper',
       'inputSelector' => '.paragraph--type--repeat-schedules-loc',
       'linkSelector' => '.field-prgf-repeat-lschedules-prf a',
     ];


### PR DESCRIPTION
This is a small improvement requested by YGBW, so it can wait for the next OpenY release.

**Some details:** On locations select step user redirected by Home Branch to the PEF schedule, but sometimes the location select screen hangs long enough that people might try to interact with it. In case when we have selected home branch location - we need to hide locations list and show spinner instead of it.

## Steps for review

- [ ] Login as admin
- [ ] Enable home branch module
- [ ] Create a Landing page with Repeat Event locations paragraph
- [ ] Configure the paragraph so that it refers to `/swim` page
- [ ] Open the created Landing page
- [ ] Verify that you are automatically redirected to `/swim` page with the Location filter set if you have selected your Home branch
- [ ] Verify that you can see spinner if you have selected your Home branch
- [ ] Deselect Home branch
- [ ] Open the created Landing page
- [ ] Check that you can select the location and click next
