### PR TITLE
Updated BTButton package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,7 @@
                 "source": {
                     "url": "https://github.com/smonetti/btbutton",
                     "type": "git",
-                    "reference": "1620254d294a209bdf18cc0bc7b131d2ffaa10db"
+                    "reference": "e98f4d74338e7183c8b5e4902a1a91968705d066"
                 }
             }
         },


### PR DESCRIPTION
@podarok we found that BTButton package is too old at Openy and udpdated it to latest version.
Last version has fixes some bugs at our clients websites.
Since, this project dont have releases, we updated hash with the last version.
https://github.com/smonetti/btbutton/commit/e98f4d74338e7183c8b5e4902a1a91968705d066

## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/ci-errors.png" width="200" alt="CI code sniffer errors">
- [ ] All tests are running and there are no failed tests reported by CI. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/behat.png" width="200" alt="Behat test results">
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
