### PR TITLE
Program Search: Put progress header into block to allow its content's…

### DIFF
--- a/modules/custom/openy_activity_finder/templates/openy-activity-finder-program-search-page.html.twig
+++ b/modules/custom/openy_activity_finder/templates/openy-activity-finder-program-search-page.html.twig
@@ -16,6 +16,7 @@
     <div class="activity-finder__step_header--progress">
       <div class="container">
         <div class="activity-finder__step_header--progress-inner">
+          {% block header_progress %}
           <div class="d-inline-flex">
             <span v-if="loading">
               {% include '@openy_system/openy-system--ajax-spinner.html.twig' with { 'size': 'small', 'flow': 'inline' } %}
@@ -27,6 +28,7 @@
           <div class="d-inline-flex ml-auto text-right">
             <a v-bind:href="afPageRef" class="start_over">{{ 'Start Over'|t }}</a>
           </div>
+          {% endblock %}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Actually, it's more like a feature request.
[See describing image](http://tinyurl.com/y3tpayfz)
On the program search page, we had to add an additional element to the header shown on the screenshot. In order to keep OpenY maintainable and at the same time to have the ability to extend its functionality, we decided to wrap the header with a new twig block.
We hope you'll find this reasonable and useful too.
Thank you!