### PR TITLE
[YGBWSLA-92] Fix appearing of unpublished locations/categories in AF

### DIFF
--- a/modules/custom/openy_activity_finder/openy_activity_finder.module
+++ b/modules/custom/openy_activity_finder/openy_activity_finder.module
@@ -5,6 +5,10 @@
  * Contains openy_activity_finder module hooks.
  */
 
+use Drupal\Core\Cache\Cache;
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\openy_activity_finder\OpenyActivityFinderSolrBackend;
+
 /**
  * Implements hook_theme().
  */
@@ -35,4 +39,42 @@ function openy_activity_finder_theme() {
       ],
     ],
   ];
+}
+
+/**
+ * Implements hook_entity_insert().
+ */
+function openy_activity_finder_entity_insert(EntityInterface $entity) {
+  _openy_activity_finder_invalidate_cache($entity);
+}
+
+/**
+ * Implements hook_entity_update().
+ */
+function openy_activity_finder_entity_update(EntityInterface $entity) {
+  _openy_activity_finder_invalidate_cache($entity);
+}
+
+/**
+ * Implements hook_entity_delete().
+ */
+function openy_activity_finder_entity_delete(EntityInterface $entity) {
+  _openy_activity_finder_invalidate_cache($entity);
+}
+
+/**
+ * Helper function for Activity Finder cache invalidation.
+ */
+function _openy_activity_finder_invalidate_cache($entity) {
+  if ($entity->getEntityTypeId() != 'node') {
+    return;
+  }
+
+  $bundle = $entity->bundle();
+  if (!in_array($bundle, ['program_subcategory', 'branch', 'camp', 'facility'])) {
+    return;
+  }
+
+  // Invalidate activity finder cache.
+  Cache::invalidateTags([OpenyActivityFinderSolrBackend::ACTIVITY_FINDER_CACHE_TAG]);
 }

--- a/modules/custom/openy_activity_finder/src/Controller/ActivityFinderController.php
+++ b/modules/custom/openy_activity_finder/src/Controller/ActivityFinderController.php
@@ -9,6 +9,7 @@ use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\openy_activity_finder\Entity\ProgramSearchLog;
 use Drupal\openy_activity_finder\OpenyActivityFinderBackendInterface;
 use Drupal\openy_activity_finder\Entity\ProgramSearchCheckLog;
+use Drupal\openy_activity_finder\OpenyActivityFinderSolrBackend;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -104,7 +105,7 @@ class ActivityFinderController extends ControllerBase {
 
       // Cache for 5 minutes.
       $expire = $this->time->getRequestTime() + self::CACHE_LIFETIME;
-      $this->cacheBackend->set($cid, $data, $expire);
+      $this->cacheBackend->set($cid, $data, $expire, [OpenyActivityFinderSolrBackend::ACTIVITY_FINDER_CACHE_TAG]);
     }
 
     return new JsonResponse($data);
@@ -154,9 +155,10 @@ class ActivityFinderController extends ControllerBase {
 
       // Cache for 5 minutes.
       $expire = $this->time->getRequestTime() + self::CACHE_LIFETIME;
-      $this->cacheBackend->set($cid, $data, $expire);
+      $this->cacheBackend->set($cid, $data, $expire, [OpenyActivityFinderSolrBackend::ACTIVITY_FINDER_CACHE_TAG]);
     }
 
     return new JsonResponse($data);
   }
+
 }

--- a/modules/custom/openy_activity_finder/src/OpenyActivityFinderSolrBackend.php
+++ b/modules/custom/openy_activity_finder/src/OpenyActivityFinderSolrBackend.php
@@ -27,6 +27,9 @@ class OpenyActivityFinderSolrBackend extends OpenyActivityFinderBackend {
   // Number of results to retrieve per page.
   const TOTAL_RESULTS_PER_PAGE = 25;
 
+  // Cache ID for locations info.
+  const ACTIVITY_FINDER_CACHE_TAG = 'openy_activity_finder:default';
+
   /**
    * Cache default.
    *
@@ -499,7 +502,7 @@ class OpenyActivityFinderSolrBackend extends OpenyActivityFinderBackend {
     else {
       $nids = $this->entityQuery
         ->get('node')
-        ->condition('type','program_subcategory')
+        ->condition('type', 'program_subcategory')
         ->execute();
       $nids_chunked = array_chunk($nids, 20, TRUE);
       foreach ($nids_chunked as $chunked) {
@@ -520,7 +523,7 @@ class OpenyActivityFinderSolrBackend extends OpenyActivityFinderBackend {
       }
 
       $expire = $this->time->getRequestTime() + self::CACHE_TTL;
-      $this->cache->set($cid, $data, $expire);
+      $this->cache->set($cid, $data, $expire, [self::ACTIVITY_FINDER_CACHE_TAG]);
     }
 
     return $data;
@@ -589,7 +592,7 @@ class OpenyActivityFinderSolrBackend extends OpenyActivityFinderBackend {
         }
       }
       $expire = $this->time->getRequestTime() + self::CACHE_TTL;
-      $this->cache->set($cid, $data, $expire);
+      $this->cache->set($cid, $data, $expire, [self::ACTIVITY_FINDER_CACHE_TAG]);
     }
 
     return $data;

--- a/modules/custom/openy_activity_finder/src/Plugin/Block/ActivityFinderBlock.php
+++ b/modules/custom/openy_activity_finder/src/Plugin/Block/ActivityFinderBlock.php
@@ -3,8 +3,8 @@
 namespace Drupal\openy_activity_finder\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
-use Drupal\Core\Url;
-use Drupal\node\NodeInterface;
+use Drupal\Core\Cache\Cache;
+use Drupal\openy_activity_finder\OpenyActivityFinderSolrBackend;
 
 /**
  * Provides a 'Activity Finder' block.
@@ -44,10 +44,22 @@ class ActivityFinderBlock extends BlockBase {
           'activityFinder' => [
             'alias' => $alias,
             'is_search_box_disabled' => $config->get('disable_search_box'),
-          ]
-        ]
-      ]
+          ],
+        ],
+      ],
+      '#cache' => [
+        'tags' => $this->getCacheTags(),
+        'contexts' => $this->getCacheContexts(),
+        'max-age' => $this->getCacheMaxAge(),
+      ],
     ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheTags() {
+    return Cache::mergeTags(parent::getCacheTags(), [OpenyActivityFinderSolrBackend::ACTIVITY_FINDER_CACHE_TAG]);
   }
 
 }

--- a/modules/custom/openy_activity_finder/src/Plugin/Block/ActivityFinderSearchBlock.php
+++ b/modules/custom/openy_activity_finder/src/Plugin/Block/ActivityFinderSearchBlock.php
@@ -3,6 +3,8 @@
 namespace Drupal\openy_activity_finder\Plugin\Block;
 
 use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Cache\Cache;
+use Drupal\openy_activity_finder\OpenyActivityFinderSolrBackend;
 
 /**
  * Provides a 'PEF Programs' block.
@@ -14,6 +16,7 @@ use Drupal\Core\Block\BlockBase;
  * )
  */
 class ActivityFinderSearchBlock extends BlockBase {
+
   /**
    * {@inheritdoc}
    */
@@ -37,10 +40,22 @@ class ActivityFinderSearchBlock extends BlockBase {
           'activityFinder' => [
             'is_search_box_disabled' => $config->get('disable_search_box'),
             'is_spots_available_disabled' => $config->get('disable_spots_available'),
-          ]
-        ]
-      ]
+          ],
+        ],
+      ],
+      '#cache' => [
+        'tags' => $this->getCacheTags(),
+        'contexts' => $this->getCacheContexts(),
+        'max-age' => $this->getCacheMaxAge(),
+      ],
     ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCacheTags() {
+    return Cache::mergeTags(parent::getCacheTags(), [OpenyActivityFinderSolrBackend::ACTIVITY_FINDER_CACHE_TAG]);
   }
 
 }


### PR DESCRIPTION
## Original Issue

We need to invalidate activity finder cache on any `location` or `program_subcategory` update, otherwise, we can't see any changes in filters (For example - title update, content unpublish/deleting or new content)

## Steps for review

- [ ] Login as admin
- [ ] Create page with Activity Finder
- [ ] Go to this page
- [ ] Open `/admin/content?status=All&type=branch&title=&langcode=All in new tab`
- [ ] Unpublish any branch
- [ ] Return to the tab with activity finder
- [ ] Reload page
- [ ] Check that unpublished location not exist in filters
- [ ] Try this with other locations (Publish/unpublish, update title)
- [ ] Check that any update displayed on activity finder page
- [ ] Check this with `program_subcategory`
