### PR TITLE
[YGBWSLA-90] Fix home branch plugin for ActivityFinder 2.0

### DIFF
--- a/modules/custom/openy_home_branch/js/hb-plugins/hb-activity-finder-location.js
+++ b/modules/custom/openy_home_branch/js/hb-plugins/hb-activity-finder-location.js
@@ -20,12 +20,6 @@
       locationStep: drupalSettings.home_branch.hb_loc_selector_activity_finder.locationStep,
       event: null,
       element: null,
-      getQueryParam: function (name) {
-        // Get url query param by name.
-        var results = new RegExp('[\?&]' + name + '=([^&#]*)')
-          .exec(window.location.search);
-        return (results !== null) ? results[1] || 0 : false;
-      },
       replaceQueryParam: function (param, newval, search) {
         // Set url query param by name.
         var regex = new RegExp("([?;&])" + param + "[^&;]*[;&]?");
@@ -33,7 +27,7 @@
         return (query.length > 2 ? query + "&" : "?") + (newval ? param + "=" + newval : '');
       },
       checkStep: function (self) {
-        if (self.getQueryParam('step') != self.locationStep) {
+        if (window.location.hash.indexOf(self.locationStep) === -1) {
           // Skip if we not on location select step.
           return;
         }

--- a/modules/custom/openy_home_branch/js/hb-plugins/hb-activity-finder-location.js
+++ b/modules/custom/openy_home_branch/js/hb-plugins/hb-activity-finder-location.js
@@ -45,7 +45,8 @@
 
         // Redirect to results page with selected Home Branch in filters.
         var resultsUrl = window.OpenY.field_prgf_af_results_ref[0]['url'];
-        window.location = resultsUrl + self.replaceQueryParam('locations', selected, window.location.search);
+        var queryString = window.location.hash.replace(self.locationStep, '');
+        window.location = resultsUrl + self.replaceQueryParam('locations', selected, queryString);
       },
       init: function () {
         window.setInterval(this.checkStep, 2000, this);

--- a/modules/custom/openy_home_branch/src/Plugin/HomeBranchLibrary/HBLocSelectorActivityFinder.php
+++ b/modules/custom/openy_home_branch/src/Plugin/HomeBranchLibrary/HBLocSelectorActivityFinder.php
@@ -36,7 +36,8 @@ class HBLocSelectorActivityFinder extends HomeBranchLibraryBase {
    */
   public function getLibrarySettings() {
     return [
-      'locationStep' => '3',
+      // @see VueRouter in openy_activity_finder/openy_af_vue_app/js/script.js
+      'locationStep' => '#/location',
       'selector' => '.paragraph--type--activity-finder',
     ];
   }


### PR DESCRIPTION
Home branch plugin for Activity Finder was developed for 1.0 version, so we need to provide a small fix to make it work with 2.0 version.

## Steps for review

- [ ] Setup activity finder
- [ ] Enable home branch module
- [ ] Select location in the home branch modal or on the locations page
- [ ] Check that in Activity Finder on the locations select step - page redirected to results with selected home branch in the filters

