### PR TITLE
Trimmed Class (room) metadata on sync.

### DIFF
--- a/modules/custom/openy_pef_gxp_sync/src/syncer/FetcherEmbed.php
+++ b/modules/custom/openy_pef_gxp_sync/src/syncer/FetcherEmbed.php
@@ -231,20 +231,20 @@ class FetcherEmbed implements FetcherInterface {
    */
   private function createClassItem(array $data) {
     $classItem = [
-      'class_id' => $data['id'],
-      'category' => $data['category'],
-      'location' => $data['location'],
-      'title' => $data['title'],
-      'description' => $this->getDescription($data),
+      'class_id' => trim($data['id']),
+      'category' => trim($data['category']),
+      'location' => trim($data['location']),
+      'title' => trim($data['title']),
+      'description' => trim($this->getDescription($data)),
       'start_date' => $this->getStartDate($data),
       'end_date' => $this->getEndDate($data),
       'recurring' => 'weekly',
-      'studio' => $data['studio'],
-      'instructor' => strip_tags($data['instructor']),
+      'studio' => trim($data['studio']),
+      'instructor' => trim(strip_tags($data['instructor'])),
       'patterns' => [
-        'day' => $this->getDay($data),
-        'start_time' => $this->getStartTime($data),
-        'end_time' => $this->getEndTime($data),
+          'day' => $this->getDay($data),
+          'start_time' => $this->getStartTime($data),
+          'end_time' => $this->getEndTime($data),
       ],
     ];
 


### PR DESCRIPTION
This bug is related to data that comes from GroupExPro. We found this bug on /group-exercise-classes page, in filter block: there were duplicates in the 'Location; checkbox group. And we figured out that the reason for these duplicates is extra space at the end class (room) name. We got rid of these duplicates by running fixing SQL queries, but to avoid this issue in the future, data that comes from GroupExPro needs to be trimmed.
It's hard to reproduce because it depends on GroupExPro data you're importing in.