### PR TITLE
ActivityFinder: Expected ':' JS error fix for IE-11

### DIFF
--- a/modules/custom/openy_activity_finder/js/programs_search.js
+++ b/modules/custom/openy_activity_finder/js/programs_search.js
@@ -780,7 +780,7 @@
         this.runAjaxRequest(false);
         $('html, body').animate( { scrollTop: $('.schedule-dashboard__wrapper').offset().top - 200 }, 500 );
       },
-      totalGroupCounter() {
+      totalGroupCounter: function() {
         // Returns count of of applied filters.
         return this.ages.length + this.days.length + this.categories.length + this.locations.length;
       }


### PR DESCRIPTION
This issue is similar to https://github.com/ymcatwincities/openy/pull/1735

## Steps for review

- [ ] Test ActivityFinder 2.0 in the IE-11
- [ ] Check that error with `Expected ':'` not exist in the console