### PR TITLE
Notice: Only variables should be passed by reference

### DIFF
--- a/modules/custom/openy_activity_finder/src/OpenyActivityFinderSolrBackend.php
+++ b/modules/custom/openy_activity_finder/src/OpenyActivityFinderSolrBackend.php
@@ -327,7 +327,8 @@ class OpenyActivityFinderSolrBackend extends OpenyActivityFinderBackend {
       if ($sub_category && $sub_category->hasField('field_learn_more')) {
         $link = $sub_category->field_learn_more->getValue();
         if (!empty($link[0]['uri'])) {
-          $learn_more = render($sub_category->field_learn_more->view())->__toString();
+          $learn_more_view = $sub_category->field_learn_more->view();
+          $learn_more = render($learn_more_view)->__toString();
         }
       }
 


### PR DESCRIPTION
PHP 7.2 - ActivityFinder:

```
Notice: Only variables should be passed by reference in 
Drupal\openy_activity_finder\OpenyActivityFinderSolrBackend->processResults()
(line 330)
```

## Steps for review

- [ ] Login as admin
- [ ] Setup ActivityFinder
- [ ] Run search api indexing
- [ ] Check that you can't see this error in logs
