### PR TITLE
[VAY-26] - Fix styles in openy_carnation theme

### DIFF
--- a/themes/openy_themes/openy_carnation/dist/css/style.css
+++ b/themes/openy_themes/openy_carnation/dist/css/style.css
@@ -11361,6 +11361,14 @@ article .node--view-mode-flexible-content h2 {
       content: "";
       opacity: .3;
       z-index: 1; }
+  .banner-zone-node .banner {
+    min-height: 70px; }
+    @media (min-width: 576px) {
+      .banner-zone-node .banner {
+        min-height: 225px; } }
+    @media (min-width: 768px) {
+      .banner-zone-node .banner {
+        min-height: 350px; } }
   .banner-zone-node .banner-cta {
     position: relative; }
     @media (min-width: 992px) {
@@ -11998,6 +12006,9 @@ a[href="#step2"] {
     .camp-menu__wrapper a:last-child,
     .microsites-menu__wrapper a:last-child {
       margin-right: 0; }
+  .camp-menu__wrapper .wrapper-field-menu-block-links,
+  .microsites-menu__wrapper .wrapper-field-menu-block-links {
+    justify-content: normal !important; }
 
 /*
 ** Mobile menu

--- a/themes/openy_themes/openy_carnation/dist/css/style.css
+++ b/themes/openy_themes/openy_carnation/dist/css/style.css
@@ -11995,14 +11995,11 @@ a[href="#step2"] {
     color: inherit;
     text-transform: uppercase;
     font-size: 16px;
-    margin: 10px 15px; }
+    margin: 10px 30px 10px 0; }
     .camp-menu__wrapper a:hover,
     .microsites-menu__wrapper a:hover {
       color: inherit;
       text-decoration: underline; }
-    .camp-menu__wrapper a:first-child,
-    .microsites-menu__wrapper a:first-child {
-      margin-left: 0; }
     .camp-menu__wrapper a:last-child,
     .microsites-menu__wrapper a:last-child {
       margin-right: 0; }

--- a/themes/openy_themes/openy_carnation/src/scss/modules/_headerbanner.scss
+++ b/themes/openy_themes/openy_carnation/src/scss/modules/_headerbanner.scss
@@ -36,6 +36,17 @@
       z-index: 1;
     }
   }
+  .banner {
+    min-height: 70px;
+
+    @include media-breakpoint-up(sm) {
+      min-height: 225px;
+    }
+
+    @include media-breakpoint-up(md) {
+      min-height: 350px;
+    }
+  }
 
   .banner-cta {
     position: relative;

--- a/themes/openy_themes/openy_carnation/src/scss/modules/_microsites.scss
+++ b/themes/openy_themes/openy_carnation/src/scss/modules/_microsites.scss
@@ -11,15 +11,11 @@
     color: inherit;
     text-transform: uppercase;
     font-size: 16px;
-    margin: 10px 15px;
+    margin: 10px 30px 10px 0;
 
     &:hover {
       color: inherit;
       text-decoration: underline;
-    }
-
-    &:first-child {
-      margin-left: 0;
     }
 
     &:last-child {

--- a/themes/openy_themes/openy_carnation/src/scss/modules/_microsites.scss
+++ b/themes/openy_themes/openy_carnation/src/scss/modules/_microsites.scss
@@ -26,4 +26,8 @@
       margin-right: 0;
     }
   }
+
+  .wrapper-field-menu-block-links {
+    justify-content: normal !important;
+  }
 }


### PR DESCRIPTION
Contains css styles fixes to correct displaying of banner blocks and microsites menu in the openy_carnation theme.

## Steps for review

- [ ] Switch to openy_carnation theme.
- [ ] Create or change a landing page.
- [ ] Add microsites menu after a small banner block with an image.
- [ ] Ensure the microsites menu block looks fine on a frontend.