### PR TITLE
[CIYMCA-47] - Added groupex sync drush 9 command

### DIFF
--- a/modules/custom/openy_pef_gxp_sync/composer.json
+++ b/modules/custom/openy_pef_gxp_sync/composer.json
@@ -1,0 +1,15 @@
+{
+    "name": "org/openy_pef_gxp_sync",
+    "description": "This extension provides new commands for Drush.",
+    "type": "drupal-drush",
+    "require": {
+        "php": ">=5.6.0"
+    },
+    "extra": {
+        "drush": {
+            "services": {
+                "drush.services.yml": "^9"
+            }
+        }
+    }
+}

--- a/modules/custom/openy_pef_gxp_sync/drush.services.yml
+++ b/modules/custom/openy_pef_gxp_sync/drush.services.yml
@@ -1,0 +1,7 @@
+services:
+  openy_pef_gxp_sync.commands:
+    class: \Drupal\openy_pef_gxp_sync\Commands\OpenyPefGxpSyncCommands
+    arguments:
+      - '@logger.factory'
+    tags:
+      - { name: drush.command }

--- a/modules/custom/openy_pef_gxp_sync/src/Commands/OpenyPefGxpSyncCommands.php
+++ b/modules/custom/openy_pef_gxp_sync/src/Commands/OpenyPefGxpSyncCommands.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Drupal\openy_pef_gxp_sync\Commands;
+
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
+use Drush\Commands\DrushCommands;
+
+/**
+ * Groupex sync drush commands.
+ */
+class OpenyPefGxpSyncCommands extends DrushCommands {
+
+  /**
+   * The logger channel factory.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelFactoryInterface
+   */
+  protected $logger;
+
+  /**
+   * Constructs a new OpenyPefGxpSyncCommands.
+   *
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger
+   *   The logger channel factory.
+   */
+  public function __construct(LoggerChannelFactoryInterface $logger) {
+    parent::__construct();
+    $this->logger = $logger;
+  }
+
+  /**
+   * Run syncer.
+   *
+   * @command openy:pef-gxp-sync
+   * @aliases openy-pef-gxp-sync
+   */
+  public function pefGxpSync() {
+    try {
+      ymca_sync_run("openy_pef_gxp_sync.syncer", "proceed");
+    }
+    catch (\Exception $e) {
+      $this->logger->get('openy_pef_gxp_sync')
+        ->error('Failed to run syncer with message: %message', ['%message' => $e->getMessage()]);
+    }
+  }
+
+}


### PR DESCRIPTION
Port 'openy-pef-gxp-sync' drush command to drush 9 format
## Steps for review

- [ ] Enable openy_pef_gxp_sync module
- [ ] Run `drush openy-pef-gxp-sync` 
- [ ] Command should be runned (but error may appear, if module is not configured)
