### PR TITLE
Perform the update if openy_carnation theme is active only

### DIFF
--- a/modules/custom/openy_upgrade_tool/openy_upgrade_tool.install
+++ b/modules/custom/openy_upgrade_tool/openy_upgrade_tool.install
@@ -209,8 +209,10 @@ function openy_upgrade_tool_update_8008() {
  * Add matchheight default classes
  */
 function openy_upgrade_tool_update_8009() {
-  $config = Drupal::service('config.factory')->getEditable('openy_carnation.settings');
-  $config->set('matchheight_css_classes', '.viewport .page-head__main-menu .nav-level-3 > a
+  $activeTheme = \Drupal::service('theme.manager')->getActiveTheme()->getName();
+  if ($activeTheme == 'openy_carnation') {
+    $config = Drupal::service('config.factory')->getEditable('openy_carnation.settings');
+    $config->set('matchheight_css_classes', '.viewport .page-head__main-menu .nav-level-3 > a
 .blog-up
 .blog-heading
 .inner-wrapper
@@ -221,7 +223,8 @@ function openy_upgrade_tool_update_8009() {
 .block-description--text > h2
 .block-description--text > div
 .table-class');
-  $config->save();
+    $config->save();
+  }
 }
 
 /**

--- a/modules/custom/openy_upgrade_tool/openy_upgrade_tool.install
+++ b/modules/custom/openy_upgrade_tool/openy_upgrade_tool.install
@@ -209,8 +209,10 @@ function openy_upgrade_tool_update_8008() {
  * Add matchheight default classes
  */
 function openy_upgrade_tool_update_8009() {
+  $carnation = 'openy_carnation';
   $activeTheme = \Drupal::service('theme.manager')->getActiveTheme()->getName();
-  if ($activeTheme == 'openy_carnation') {
+  $baseThemes = \Drupal::service('theme_handler')->listInfo()[$activeTheme]->base_themes;
+  if ($activeTheme == $carnation || (is_array($baseThemes) && isset($baseThemes[$carnation]))) {
     $config = Drupal::service('config.factory')->getEditable('openy_carnation.settings');
     $config->set('matchheight_css_classes', '.viewport .page-head__main-menu .nav-level-3 > a
 .blog-up


### PR DESCRIPTION
When we try to update Openy to the latest (8.x-2.3.2), we get the following:

`Failed: Configuration openy_carnation.settings depends on the Open Y Carnation theme that will not be installed after import.
`
As we've figured out, it happens when openy_carnation theme is not active.

## Steps for review

- [ ] get a site with disable/not used openy_carnation theme.
- [ ] run recent updates.
