### PR TITLE
Hide prev page pager link on first page of activity finder result page.

### DIFF
--- a/modules/custom/openy_activity_finder/templates/openy-activity-finder-program-search-page.html.twig
+++ b/modules/custom/openy_activity_finder/templates/openy-activity-finder-program-search-page.html.twig
@@ -312,8 +312,8 @@
 
 
               <div  v-if="pager_info.total_pages > 1" class="pager-controls">
-                <a v-if="current_page > 0" href="#" v-on:click.stop.prevent="loadPageNumber(1)" class="btn btn-primary">{{ '|<'|t }}</a>
-                <a v-if="current_page > 0" href="#" v-on:click.stop.prevent="loadPrevPage()" class="btn btn-primary">{{ '<'|t }}</a>
+                <a v-if="current_page > 1" href="#" v-on:click.stop.prevent="loadPageNumber(1)" class="btn btn-primary">{{ '|<'|t }}</a>
+                <a v-if="current_page > 1" href="#" v-on:click.stop.prevent="loadPrevPage()" class="btn btn-primary">{{ '<'|t }}</a>
 
                 <div class="page-of">Page ${ current_page } of ${ pager_info.total_pages }</div>
 


### PR DESCRIPTION
This fixes/hides link to the previous page on the first page of activity finder results. 

## Steps for review

- [ ] Open activity finder results page.
- [ ] See that previous pager link exists and it's clickable.

The bug was reported here #1810 