### PR TITLE
Focal point is not saved for images existed before enabling the feature

### DIFF
--- a/modules/custom/openy_focal_point/src/Form/OpenYFocalPointEditForm.php
+++ b/modules/custom/openy_focal_point/src/Form/OpenYFocalPointEditForm.php
@@ -215,6 +215,12 @@ class OpenYFocalPointEditForm extends FormBase {
 
     /** @var \Drupal\focal_point\FocalPointManagerInterface $focal_point_manager */
     $focal_point_manager = \Drupal::service('focal_point.manager');
+
+    // If image has no crop info.
+    if (!$crop) {
+      $crop = $focal_point_manager->getCropEntity($file, $crop_type);
+    }
+
     list($x, $y) = explode(',', $form_state->getValue('focal_point'));
     $image = \Drupal::service('image.factory')->get($file->getFileUri());
     $width = $image->getWidth();


### PR DESCRIPTION
We've noticed, that it's not possible to set a focal point for images that already existed before enabling the feature. The reason is that the images have no crop info that the feature gives when a file is being saved.
This PR is fixing this issue.

## Steps for review

- [ ] Try to set a focal point for an image that existed before the feature.
- [ ] Save a focal point.
- [ ] As a result you will see image preview above updated.
