### PR TITLE
Fixed non-closing message in modal

### DIFF
--- a/themes/openy_themes/openy_carnation/dist/js/openy_carnation.js
+++ b/themes/openy_themes/openy_carnation/dist/js/openy_carnation.js
@@ -20,4 +20,16 @@
       });
     }
   };
+
+  /**
+   * Alert Modals close
+   */
+  Drupal.behaviors.openyAlertModalsClose = {
+    attach: function (context, settings) {
+      $('.alert-modal .close').on('click', function (e) {
+        e.preventDefault();
+        $(this).closest('.alert-modal').remove();
+      });
+    }
+  };
 })(jQuery);


### PR DESCRIPTION
It was impossible to close a message in the modal window when it comes to DOM via ajax. This PR fixes the issue for openy_carnation theme.

## Steps for review

- [ ] Open join page (membership calculation, first step).
- [ ] Click 'Next' button without making any choice.
- [ ] Error message appears in the modal.
- [ ] Try to close the modal.

See #1816 for details.