### PR TITLE
Fixed expanded ages and days filters on activity finder loading.

### DIFF
--- a/modules/custom/openy_activity_finder/templates/openy-activity-finder-program-search-page.html.twig
+++ b/modules/custom/openy_activity_finder/templates/openy-activity-finder-program-search-page.html.twig
@@ -111,7 +111,6 @@
                 expander_sections_config = '{{ expanderSectionsConfig|json_encode }}'
                 v-on:updated-values="ages = $event"
                 :default='$route.query.ages'
-                :loading="loading"
               ></sidebar-filter>
 
               <sidebar-filter
@@ -123,7 +122,6 @@
                 expander_sections_config = '{{ expanderSectionsConfig|json_encode }}'
                 :default='$route.query.days'
                 v-on:updated-values="days = $event"
-                :loading="loading"
               ></sidebar-filter>
               {% if collapse_group %}
                 </div>


### PR DESCRIPTION
Original Issue, this PR is going to fix: https://github.com/ymcatwincities/openy/issues/1795

## Steps for review

- [x] Open activity finder results page.
- [x] See if ages and days filters are collapsed during loading.

