### PR TITLE
[CIYMCA-132] Make not show the icon if the email is empty

### DIFF
--- a/themes/openy_themes/openy_carnation/templates/node/event/event-contact-info.html.twig
+++ b/themes/openy_themes/openy_carnation/templates/node/event/event-contact-info.html.twig
@@ -25,5 +25,7 @@
     <div class="contact-fax"><i class="fa fa-fax text-gray-300"></i> <a href="tel:{{ info.fax }}">{{ info.fax }}</a></div>
   {% endif %}
 
-  <div class="contact-email"><i class="fa fa-envelope text-gray-300"></i> {{ info.email }}</div>
+  {% if info.email is not empty %}
+    <div class="contact-email"><i class="fa fa-envelope text-gray-300"></i> {{ info.email }}</div>
+  {% endif %}
 </div>


### PR DESCRIPTION
Steps for review:

- turn on theme carnation
- visit any page event (Content Type "Event")
- verify the email icon is not shown