### PR TITLE
[YGBWSLA-121] Add cookies enabled checking and delay between HB popup appearance

### DIFF
--- a/modules/custom/openy_home_branch/js/hb-plugins/hb-loc-modal.js
+++ b/modules/custom/openy_home_branch/js/hb-plugins/hb-loc-modal.js
@@ -28,6 +28,7 @@
       modalDescription: drupalSettings.home_branch.hb_loc_modal.modalDescription,
       dontAskTitle: drupalSettings.home_branch.hb_loc_modal.dontAskTitle,
       learnMoreText: drupalSettings.home_branch.hb_loc_modal.learnMoreText,
+      delay: drupalSettings.home_branch.hb_loc_modal.modalDelay,
       init: function () {
         if (!this.element) {
           return;
@@ -83,7 +84,12 @@
         this.element.addClass('hidden');
       },
       show: function () {
-        this.element.removeClass('hidden');
+        var timestamp = Math.floor(Date.now() / 1000);
+        var lastShowTime = Drupal.homeBranch.getValue('lastShowTime');
+        if (this.areCookiesEnabled() && timestamp > lastShowTime + this.delay) {
+          this.element.removeClass('hidden');
+          Drupal.homeBranch.setValue('lastShowTime', timestamp);
+        }
       },
       addMarkup: function (context) {
         // Save created element in plugin.
@@ -133,6 +139,18 @@
         Drupal.homeBranch.showModal = function () {
           self.show();
         };
+      },
+      // Check that cookies enabled in browser.
+      areCookiesEnabled: function () {
+        try {
+          document.cookie = 'cookietest=1';
+          var cookiesEnabled = document.cookie.indexOf('cookietest=') !== -1;
+          document.cookie = 'cookietest=1; expires=Thu, 01-Jan-1970 00:00:01 GMT';
+          return cookiesEnabled;
+        }
+        catch (e) {
+          return false;
+        }
       },
     }
   });

--- a/modules/custom/openy_home_branch/js/hb_cookies_storage.js
+++ b/modules/custom/openy_home_branch/js/hb_cookies_storage.js
@@ -12,7 +12,8 @@
     // Home branch data.
     data: {
       id: null,
-      dontAsk: false
+      dontAsk: false,
+      lastShowTime: 0
     },
 
     // Locations list.
@@ -30,7 +31,6 @@
       // Get locations list.
       var self = this;
       self.locations = drupalSettings.home_branch.hb_menu_selector.locations;
-
       setTimeout(function() {
         self.attachPlugins();
       }, 0);

--- a/modules/custom/openy_home_branch/src/Plugin/HomeBranchLibrary/HBLocModal.php
+++ b/modules/custom/openy_home_branch/src/Plugin/HomeBranchLibrary/HBLocModal.php
@@ -41,6 +41,8 @@ class HBLocModal extends HomeBranchLibraryBase {
       'modalTitle' => $this->t('Home branch'),
       'modalDescription' => $this->t('Would you like to set a different location as your "home branch"?'),
       'dontAskTitle' => $this->t('Don\'t ask me again'),
+      // Delay until next window display 24h.
+      'modalDelay' => 86400,
       'learnMoreText' => $this->t('
         <h5>Why set your home branch?</h5>
         <p>Many YMCA members primarily visit one YMCA branch. Setting your home branch customizes your experience with schedules and programs for that branch. You are still able to view information for all other branches.</p>


### PR DESCRIPTION
Not show modal when cookies disabled
Show modal with delay after reload 

- [ ] open any page.
- [ ] make sure home branch popup appear
- [ ] reload page 
- [ ] make sure home branch not appeared
- [ ] check cookies, see home branch cookie with timestamp,
- [ ] remove cookie
- [ ] disable cookie in browser settings
- [ ] open site 
- [ ] make sure home branch not appeared

