### PR TITLE
Fix incorrect hook name in OpenY Lily theme

### DIFF
--- a/themes/openy_themes/openy_lily/openy_lily.theme
+++ b/themes/openy_themes/openy_lily/openy_lily.theme
@@ -911,7 +911,7 @@ function openy_lily_preprocess_field__node__field_location_directions(array &$va
  *
  * @param $variables
  */
-function openy_rose_preprocess_paragraph_social_list(&$variables) {
+function openy_lily_preprocess_paragraph_social_list(&$variables) {
   $block = $variables['content']['field_prgrf_sl_block'];
   if (isset($block[0]['#name']) && isset($block[0]['#display_id'])) {
     $variables['content']['posts'] = \Drupal::service('renderer')


### PR DESCRIPTION
Original Issue, this PR is going to fix: REPLACE WITH A LINK TO ISSUE ( publicly available )


## Steps for review

- [x] login as admin
- [x] go to Appearance admin menu and click Set as default link for Open Y Lily theme
- [x] go to Configuration->Social Feed Fetcher Settings (/admin/config/social_feed_fetcher_settings) and provide settings for each social networks. If you have some test account for FB, Twitter and Instagram please use them. Run Cron.
- [x] add Social List paragraph for any Landing page. Set Title and Description. Save node. On this page you can see the list of imported posts.


## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer. See [Code of Conduct](https://github.com/ymcatwincities/openy/wiki/Open-Y-Code-of-Conduct-and-Best-Practices).
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
