### PR TITLE
Add hook_update dependencies to fix upgrade path errors

### DIFF
--- a/openy.install
+++ b/openy.install
@@ -61,6 +61,12 @@ function openy_update_dependencies() {
       'simple_sitemap' => 8217,
     ],
   ];
+
+  $dependencies['openy_gtranslate'] = [
+    8001 => [
+      'openy' => 8077,
+    ],
+  ];
   return $dependencies;
 }
 


### PR DESCRIPTION
Fix for error during upgrade path
openy_gtranslate_update_8002 started before openy_install_8077
and caused missing module configuration error
![image](https://user-images.githubusercontent.com/16559938/73830219-f676a700-480c-11ea-8fea-b20bfbfebe56.png)
