### PR TITLE
Fix branch hours field style in branch teaser at location list page of Lily and Rose themes

### DIFF
--- a/themes/openy_themes/openy_lily/css/style.css
+++ b/themes/openy_themes/openy_lily/css/style.css
@@ -3969,20 +3969,20 @@ html.js .branch__updates_queue__button {
 .node--type-camp.node--view-mode-teaser .location-item--title ~ .field-location-state {
   margin: 20px 0 33px;
 }
-.node--location-content-type.node--view-mode-teaser .branch-hours,
-.node--type-facility.node--view-mode-teaser .branch-hours,
-.node--type-branch.node--view-mode-teaser .branch-hours,
-.node--type-branch.node--view-mode-sidebar-teaser .branch-hours,
-.node--type-branch.node--view-mode-class-location .branch-hours,
-.node--type-camp.node--view-mode-teaser .branch-hours {
+.node--location-content-type.node--view-mode-teaser .field-branch-hours,
+.node--type-facility.node--view-mode-teaser .field-branch-hours,
+.node--type-branch.node--view-mode-teaser .field-branch-hours,
+.node--type-branch.node--view-mode-sidebar-teaser .field-branch-hours,
+.node--type-branch.node--view-mode-class-location .field-branch-hours,
+.node--type-camp.node--view-mode-teaser .field-branch-hours {
   margin-top: 15px;
 }
-.node--location-content-type.node--view-mode-teaser .branch-hours td:first-child,
-.node--type-facility.node--view-mode-teaser .branch-hours td:first-child,
-.node--type-branch.node--view-mode-teaser .branch-hours td:first-child,
-.node--type-branch.node--view-mode-sidebar-teaser .branch-hours td:first-child,
-.node--type-branch.node--view-mode-class-location .branch-hours td:first-child,
-.node--type-camp.node--view-mode-teaser .branch-hours td:first-child {
+.node--location-content-type.node--view-mode-teaser .field-branch-hours td:first-child,
+.node--type-facility.node--view-mode-teaser .field-branch-hours td:first-child,
+.node--type-branch.node--view-mode-teaser .field-branch-hours td:first-child,
+.node--type-branch.node--view-mode-sidebar-teaser .field-branch-hours td:first-child,
+.node--type-branch.node--view-mode-class-location .field-branch-hours td:first-child,
+.node--type-camp.node--view-mode-teaser .field-branch-hours td:first-child {
   padding-right: 10px;
 }
 .node--location-content-type.node--view-mode-teaser .field-location-area,

--- a/themes/openy_themes/openy_lily/sass/modules/_branch.scss
+++ b/themes/openy_themes/openy_lily/sass/modules/_branch.scss
@@ -960,7 +960,7 @@ html.js {
       margin: 20px 0 33px;
     }
   }
-  .branch-hours {
+  .field-branch-hours {
     margin-top: 15px;
     td:first-child {
       padding-right: 10px;

--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -4023,20 +4023,20 @@ html.js .branch__updates_queue__button {
 .node--type-camp.node--view-mode-teaser .location-item--title ~ .field-location-state {
   margin: 20px 0 33px;
 }
-.node--location-content-type.node--view-mode-teaser .branch-hours,
-.node--type-facility.node--view-mode-teaser .branch-hours,
-.node--type-branch.node--view-mode-teaser .branch-hours,
-.node--type-branch.node--view-mode-sidebar-teaser .branch-hours,
-.node--type-branch.node--view-mode-class-location .branch-hours,
-.node--type-camp.node--view-mode-teaser .branch-hours {
+.node--location-content-type.node--view-mode-teaser .field-branch-hours,
+.node--type-facility.node--view-mode-teaser .field-branch-hours,
+.node--type-branch.node--view-mode-teaser .field-branch-hours,
+.node--type-branch.node--view-mode-sidebar-teaser .field-branch-hours,
+.node--type-branch.node--view-mode-class-location .field-branch-hours,
+.node--type-camp.node--view-mode-teaser .field-branch-hours {
   margin-top: 15px;
 }
-.node--location-content-type.node--view-mode-teaser .branch-hours td:first-child,
-.node--type-facility.node--view-mode-teaser .branch-hours td:first-child,
-.node--type-branch.node--view-mode-teaser .branch-hours td:first-child,
-.node--type-branch.node--view-mode-sidebar-teaser .branch-hours td:first-child,
-.node--type-branch.node--view-mode-class-location .branch-hours td:first-child,
-.node--type-camp.node--view-mode-teaser .branch-hours td:first-child {
+.node--location-content-type.node--view-mode-teaser .field-branch-hours td:first-child,
+.node--type-facility.node--view-mode-teaser .field-branch-hours td:first-child,
+.node--type-branch.node--view-mode-teaser .field-branch-hours td:first-child,
+.node--type-branch.node--view-mode-sidebar-teaser .field-branch-hours td:first-child,
+.node--type-branch.node--view-mode-class-location .field-branch-hours td:first-child,
+.node--type-camp.node--view-mode-teaser .field-branch-hours td:first-child {
   padding-right: 10px;
 }
 .node--location-content-type.node--view-mode-teaser .field-location-area,

--- a/themes/openy_themes/openy_rose/scss/modules/_branch.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_branch.scss
@@ -851,7 +851,7 @@ html.js {
       margin: 20px 0 33px;
     }
   }
-  .branch-hours {
+  .field-branch-hours {
     margin-top: 15px;
     td:first-child {
       padding-right: 10px;


### PR DESCRIPTION
The incorrect class used for Branch hours field rendering in the branch teasers at the location list page. There are should be added padding after weekdays before hours that missing
Incorrect class `.branch-hours `used that not exist in teasers at this moment
## Steps for review

- [ ] visit /location page.
- [ ] check hours table style in the branch teasers. `Mon-Sun:Closed`
BEFORE
![image](https://user-images.githubusercontent.com/16559938/74154958-56f65180-4c1c-11ea-8c3b-b926cacb07a1.png)
AFTER
![image](https://user-images.githubusercontent.com/16559938/74155078-8e64fe00-4c1c-11ea-887e-88ffcb945848.png)

## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer. See [Code of Conduct](https://github.com/ymcatwincities/openy/wiki/Open-Y-Code-of-Conduct-and-Best-Practices).
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
