### PR TITLE
[OYS-76]: [Search] Link to main repository

### DIFF
--- a/modules/custom/openy_search/openy_google_search/openy_google_search.module
+++ b/modules/custom/openy_search/openy_google_search/openy_google_search.module
@@ -73,6 +73,6 @@ function openy_google_search_entity_view_alter(&$build, EntityInterface $entity,
  */
 function openy_google_search_help($route_name, RouteMatchInterface $route_match) {
   if ($route_name == 'help.page.openy_google_search' || $route_name == 'openy_google_search.settings') {
-    return '<p>' . t('Read <a href="https://github.com/fivejars/openy/blob/google-search-documentation/docs/Development/GoogleCustomSearchConfiguration.md">this topic</a> in Open Y online documentation to get information about Google Custom Search configuration.') . '</p>';
+    return '<p>' . t('Read <a href="https://github.com/ymcatwincities/openy/blob/8.x-2.x/docs/Development/GoogleCustomSearchConfiguration.md">this topic</a> in Open Y online documentation to get information about Google Custom Search configuration.') . '</p>';
   }
 }


### PR DESCRIPTION
Steps for review:

- [ ] check code changes
- [ ] updated openy_google_search_help() and replaced the link from https://github.com/fivejars/openy/blob/google-search-documentation/docs/Development/GoogleCustomSearchConfiguration.md
to https://github.com/ymcatwincities/openy/blob/8.x-2.x/docs/Development/GoogleCustomSearchConfiguration.md