### PR TITLE
[OYS-74]: Add notification about changes in Image entity browser configs

### DIFF
--- a/modules/openy_features/openy_media/modules/openy_media_image/openy_media_image.install
+++ b/modules/openy_features/openy_media/modules/openy_media_image/openy_media_image.install
@@ -291,4 +291,12 @@ function openy_media_image_update_8012() {
     'entity_browser.browser.images_library_embed',
     'views.view.images_library',
   ]);
+
+  $message = "Image Library entity browser doesn't use 'images_library' view anymore. Custom changes may be lost.";
+  if (function_exists('drush_print')) {
+    drush_print(dt($message));
+  }
+  else {
+    \Drupal::messenger()->addMessage($message);
+  }
 }


### PR DESCRIPTION
Steps for review:

- [ ] Install any version of Open Y before `8.2.4.0`
- [ ] Run database updates with drush.
- [ ] Verify the message `Image Library entity browser doesn't use 'images_library' view anymore. Custom changes may be lost.` is printed.

## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer. See [Code of Conduct](https://github.com/ymcatwincities/openy/wiki/Open-Y-Code-of-Conduct-and-Best-Practices).
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
