### PR TITLE
[OYS-91] Remove obsolete patch for drupal/crop module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -175,9 +175,6 @@
                 "2484693 - Telephone Link field formatter InvalidArgumentException with 5 digits or fewer in the number": "https://www.drupal.org/files/issues/2484693-54.patch",
                 "2862702 - PrepareModulesEntityUninstallForm::formTitle does not exist": "https://www.drupal.org/files/issues/2862702-3.patch"
             },
-            "drupal/crop": {
-                "3025005 - The Crop requirements is NOK is media_entity 8.x-2.0 installed via composer": "https://www.drupal.org/files/issues/2019-01-10/requirements-is-NOK-3025005-2.patch"
-            },
             "drupal/media_entity": {
                 "2918172 - Media Entity upgrade -> add revision fields": "https://www.drupal.org/files/issues/2918172-5.patch",
                 "2918172 - Media Entity upgrade -> core fails on absent column revision_uid": "https://www.drupal.org/files/issues/2918172-6-8.4.4.patch"

--- a/composer.lock
+++ b/composer.lock
@@ -2065,9 +2065,6 @@
                         "status": "not-covered",
                         "message": "RC releases are not covered by Drupal security advisories."
                     }
-                },
-                "patches_applied": {
-                    "3025005 - The Crop requirements is NOK is media_entity 8.x-2.0 installed via composer": "https://www.drupal.org/files/issues/2019-01-10/requirements-is-NOK-3025005-2.patch"
                 }
             },
             "notification-url": "https://packages.drupal.org/8/downloads",


### PR DESCRIPTION
## Steps for review

- [ ] check install log
- [ ] make sure no error with patch for crop module with message 
```
Applying patches for drupal/crop
    https://www.drupal.org/files/issues/2019-01-10/requirements-is-NOK-3025005-2.patch (3025005 - The Crop requirements is NOK is media_entity 8.x-2.0 ins
   Could not apply patch! Skipping. The error was: Cannot apply patch https://www.drupal.org/files/issues/2019-01-10/requirements-is-NOK-3025005-2.patch
```


