### PR TITLE
Fixing Link Field on Grid Column Template

### DIFF
--- a/themes/openy_themes/openy_lily/templates/paragraphs/paragraph--grid-columns.html.twig
+++ b/themes/openy_themes/openy_lily/templates/paragraphs/paragraph--grid-columns.html.twig
@@ -57,7 +57,7 @@ set classes = [
         <h2>{{ content.field_prgf_clm_headline }}</h2>
       {% endif %}
       <div class="text">{{ content.field_prgf_grid_clm_description }}</div>
-      {% if content.field_prgf_link|render|trim is not empty %}
+      {% if content.field_prgf_clm_link|render|trim is not empty %}
         <div class="more-link">{{ content.field_prgf_clm_link }}</div>
       {% endif %}
     </div>


### PR DESCRIPTION
Original Issue, this PR is going to fix:
https://github.com/ymcatwincities/openy/issues/1951

Make sure these boxes are checked before asking for review of your pull request - thank you!

If there is a new feature or this is a bug fix - use 8.x-2.x branch. We'll tag for release if the bug is critical asap or tag for release next bug fix release until critical issue arrived.

## Steps for review

- After applying commit
- Add Grid Content to any page in the Lily Theme
- Fill out Link Field in Grid Column & Save
- Link Field should display correctly in the grid column
