### PR TITLE
[INOYI-10] hide map marker for empty branch in event

### DIFF
--- a/themes/openy_themes/openy_carnation/templates/node/event/node--event--teaser.html.twig
+++ b/themes/openy_themes/openy_carnation/templates/node/event/node--event--teaser.html.twig
@@ -104,7 +104,7 @@ set classes = [
       {{ title_suffix }}
     </div>
 
-    {% if content.field_event_location|render|trim is not empty %}
+    {% if not node.field_event_location.isEmpty() %}
       <div class="event-location">
         <i class="fas fa-map-marker-alt mr-2 text-primary"></i> {{ content.field_event_location }}
       </div>

--- a/themes/openy_themes/openy_carnation/templates/node/event/node--event--teaser.html.twig
+++ b/themes/openy_themes/openy_carnation/templates/node/event/node--event--teaser.html.twig
@@ -104,9 +104,11 @@ set classes = [
       {{ title_suffix }}
     </div>
 
-    <div class="event-location">
-      <i class="fas fa-map-marker-alt mr-2 text-primary"></i> {{ content.field_event_location }}
-    </div>
+    {% if content.field_event_location|render|trim is not empty %}
+      <div class="event-location">
+        <i class="fas fa-map-marker-alt mr-2 text-primary"></i> {{ content.field_event_location }}
+      </div>
+    {% endif %}
 
     <div class="event-date__event-time">
       <i class="far fa-clock"></i>


### PR DESCRIPTION
This PR is going to fix an empty map marker for event teaser in case if branch is not specified http://i.imgur.com/Xd9W2xV.png

## Steps for review
- [ ] log in as admin
- [ ] Add **Upcoming events** paragraph to any landing node
- [ ] visit created page -> choose some event from created paragraph -> edit this event
- [ ] on event edit page set **-none-** in location field -> save
- [ ] return back to the previously created landing page
- [ ] make sure that map icon is hidden http://i.imgur.com/IWxjtX8.png


## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer. See [Code of Conduct](https://github.com/ymcatwincities/openy/wiki/Open-Y-Code-of-Conduct-and-Best-Practices).
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
