### PR TITLE
[INOYI-17] Don't render empty sidebar if empty.

### DIFF
--- a/themes/openy_themes/openy_carnation/templates/node/event/node--event--full.html.twig
+++ b/themes/openy_themes/openy_carnation/templates/node/event/node--event--full.html.twig
@@ -79,9 +79,18 @@
   ]
 %}
 
-{% set main_class = '' %}
-{% if content.field_sidebar_content|render|trim is not empty %}
-  {% set main_class = 'col-sm-8' %}
+{%
+  set main_class = [
+    'copy',
+    'col-12',
+    'mb-5',
+    'mb-lg-0',
+  ]
+%}
+{% set hide_sidebar = true %}
+{% if not node.field_sidebar_content.isEmpty() or not node.field_event_location.isEmpty() %}
+  {% set hide_sidebar = false %}
+  {% set main_class = main_class|merge(['col-md-8', 'col-lg-9'])  %}
 {% endif %}
 
 {# default header #}
@@ -89,15 +98,14 @@
 
 <div class="container mt-5">
   <div class="row">
-
-    <div class="copy col-12 col-md-8 col-lg-9 mb-5 mb-lg-0">
+    <div {{ attributes.addClass(main_class) }}>
       <article{{ attributes.addClass(classes) }}>
         <div{{ content_attributes.addClass('node__content') }}>
 
-          {% if content.field_event_image|render|trim is not empty %}
-          <figure class="mb-4">
-            {{ content.field_event_image }}
-          </figure>
+          {% if not node.field_event_image.isEmpty() %}
+            <figure class="mb-4">
+              {{ content.field_event_image }}
+            </figure>
           {% endif %}
 
           {{ content.field_event_description }}
@@ -110,23 +118,25 @@
       </article>
     </div>
 
-    <div class="col-12 col-md-4 col-lg-3 side-col">
-      <div class="card mb-3">
-        <div class="card-body">
+    {% if not hide_sidebar %}
+      <div class="col-12 col-md-4 col-lg-3 side-col">
+        <div class="card mb-3">
+          <div class="card-body">
 
-          {% if content.field_sidebar_content|render|striptags is not empty %}
-          <div class="d-inline-block w-100 pb-4 mb-4 border-light border-bottom">
-            {{ content.field_sidebar_content }}
+            {% if not node.field_sidebar_content.isEmpty() %}
+              <div class="d-inline-block w-100 pb-4 mb-4 border-light border-bottom">
+                {{ content.field_sidebar_content }}
+              </div>
+            {% endif %}
+
+            {% if not node.field_event_location.isEmpty() %}
+              {{ content.field_event_location }}
+            {% endif %}
+
           </div>
-          {% endif %}
-
-          {% if content.field_event_location|render|striptags is not empty %}
-            {{ content.field_event_location }}
-          {% endif %}
-
         </div>
       </div>
-    </div>
+    {% endif %}
 
   </div>
 </div>


### PR DESCRIPTION
This PR is going to enhance event page layout in Carnation theme (hide sidebar if it is empty).

## Steps for review
- [ ] Log in as admin
- [ ] Create an event.
- [ ] Don’t assign the event to any branch.
- [ ] Don’t add anything to the sidebar section
- [ ] Enter text in Description field in the content region http://i.imgur.com/wn3Ap6n.png
- [ ] Save and visit created page
- [ ] Verify that sidebar region is hidden and  text take all width on container.

## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer. See [Code of Conduct](https://github.com/ymcatwincities/openy/wiki/Open-Y-Code-of-Conduct-and-Best-Practices).
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
