### PR TITLE
[YGO-24] Carnation theme fixes for event page

### DIFF
--- a/modules/openy_features/openy_node/modules/openy_node_event/openy_node_event.module
+++ b/modules/openy_features/openy_node/modules/openy_node_event/openy_node_event.module
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\datetime\Plugin\Field\FieldType\DateTimeItemInterface;
 use Drupal\node\Entity\Node;
 use Drupal\Core\Link;
 use Drupal\Core\Url;
@@ -55,10 +56,10 @@ function openy_node_event_preprocess_field__node__field_event_location__event(&$
   if (empty($datesField[0])) {
     return;
   }
-  $timezone = drupal_get_user_timezone();
-  $startDt = DrupalDateTime::createFromFormat(DATETIME_DATETIME_STORAGE_FORMAT, $datesField[0]['value'], DATETIME_STORAGE_TIMEZONE);
+  $timezone = date_default_timezone_get();
+  $startDt = DrupalDateTime::createFromFormat(DateTimeItemInterface::DATETIME_STORAGE_FORMAT, $datesField[0]['value'], DateTimeItemInterface::STORAGE_TIMEZONE);
   $startDt->setTimezone(timezone_open($timezone));
-  $endDt = DrupalDateTime::createFromFormat(DATETIME_DATETIME_STORAGE_FORMAT, $datesField[0]['end_value'], DATETIME_STORAGE_TIMEZONE);
+  $endDt = DrupalDateTime::createFromFormat(DateTimeItemInterface::DATETIME_STORAGE_FORMAT, $datesField[0]['end_value'], DateTimeItemInterface::STORAGE_TIMEZONE);
   $endDt->setTimezone(timezone_open($timezone));
   $datesInfo = [
     'date_start' => $startDt,
@@ -150,11 +151,11 @@ function openy_node_event_preprocess_node(&$variables) {
   if ($variables['view_mode'] == 'teaser' && $variables['node']->getType() == 'event') {
     // Get dates.
     $datesField = $variables['node']->get('field_event_dates')->getValue();
-    $timezone = drupal_get_user_timezone();
-    $startDt = DrupalDateTime::createFromFormat(DATETIME_DATETIME_STORAGE_FORMAT, $datesField[0]['value'], DATETIME_STORAGE_TIMEZONE);
+    $timezone = date_default_timezone_get();
+    $startDt = DrupalDateTime::createFromFormat(DateTimeItemInterface::DATETIME_STORAGE_FORMAT, $datesField[0]['value'], DateTimeItemInterface::STORAGE_TIMEZONE);
     $startDt->setTimezone(timezone_open($timezone));
-    $endDt = DrupalDateTime::createFromFormat(DATETIME_DATETIME_STORAGE_FORMAT, $datesField[0]['end_value'], DATETIME_STORAGE_TIMEZONE);
-    $endDt->setTimezone(timezone_open($timezone)); 
+    $endDt = DrupalDateTime::createFromFormat(DateTimeItemInterface::DATETIME_STORAGE_FORMAT, $datesField[0]['end_value'], DateTimeItemInterface::STORAGE_TIMEZONE);
+    $endDt->setTimezone(timezone_open($timezone));
     $variables['content']['event_converted_dates'] = [
       'date_start' => $startDt->format('g:i a'),
       'date_end' => $endDt->format('g:i a'),

--- a/modules/openy_features/openy_node/modules/openy_node_event/templates/event-date-info.html.twig
+++ b/modules/openy_features/openy_node/modules/openy_node_event/templates/event-date-info.html.twig
@@ -5,8 +5,8 @@
  *
  * Available variables:
  * - info: The info array with access to event date info.
- *   - info.date_start will return formated "j M g:i a" event start date.
- *   - info.date_end will return formated "g:i a" event end date.
+ *   - info.date_start will return event start date.
+ *   - info.date_end will return event end date.
  * - atc: The atc array of additional calendar info.
  *   - atc_date_start will return formated "Y-m-d H:i:s" event start date.
  *   - atc_date_end will return formated "Y-m-d H:i:s" event end date.

--- a/themes/openy_themes/openy_carnation/templates/node/event/event-contact-info.html.twig
+++ b/themes/openy_themes/openy_carnation/templates/node/event/event-contact-info.html.twig
@@ -15,7 +15,7 @@
  */
 #}
 <div class="d-inline-block w-100">
-  <h5><i class="far fa-question-circle text-gray-300"></i>{{ 'Contact Information'|t }}</h5>
+  <h5><i class="far fa-question-circle text-gray-300"></i> {{ 'Contact Information'|t }}</h5>
 
   {% if info.phone is not empty %}
     <div class="contact-phone"><i class="fa fa-phone text-gray-300"></i> {{ info.phone }}</div>

--- a/themes/openy_themes/openy_carnation/templates/node/event/event-date-info.html.twig
+++ b/themes/openy_themes/openy_carnation/templates/node/event/event-date-info.html.twig
@@ -5,8 +5,8 @@
  *
  * Available variables:
  * - info: The info array with access to event date info.
- *   - info.date_start will return formated "j M g:i a" event start date.
- *   - info.date_end will return formated "g:i a" event end date.
+ *   - info.date_start will return event start date.
+ *   - info.date_end will return event end date.
  * - atc: The atc array of additional calendar info.
  *   - atc_date_start will return formated "Y-m-d H:i:s" event start date.
  *   - atc_date_end will return formated "Y-m-d H:i:s" event end date.
@@ -23,7 +23,7 @@
 #}
 <div class="d-inline-block w-100 pb-4 mb-4 border-light border-bottom">
   <h5><i class="far fa-clock text-gray-300"></i> {{ 'Event Details'|t }}</h5>
-  <div class="date-start">{{ info.date_start }} - {{ info.date_end }}</div>
+  <div class="date-start">{{ info.date_start|date('M j, g:i a') }} - {{ info.date_end|date('M j, g:i a') }}</div>
   <div class="addtocalendar atc-style-blue mt-2">
     <var class="atc_event">
       <var class="atc_date_start">{{ atc.atc_date_start }}</var>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16559938/78258170-81b9a380-7503-11ea-9b12-705066452867.png)
example of buggy page  https://sandbox-carnation-cus.openy.org/events/ymca-event
TODO
Remove timezone and change date format to Apr 14, 10:45 pm - Apr 14, 11:45 pm
(it was fixed globally in module but left in Carnation theme template)
Add space between icon and Contact information label.

Steps for review

- [ ] login as admin
- [ ] visit Appearance page and switch to Carnation theme
- [ ] open page events/ymca-event
- [ ] make sure that start/end date format is correct
- [ ] make sure that added space between icon and _Contact information_ label
