### PR TITLE
[YGO-27] Fix events listing paragraph teaser in Carnation

### DIFF
--- a/modules/openy_features/openy_node/modules/openy_node_event/openy_node_event.module
+++ b/modules/openy_features/openy_node/modules/openy_node_event/openy_node_event.module
@@ -154,10 +154,17 @@ function openy_node_event_preprocess_node(&$variables) {
     $startDt = DrupalDateTime::createFromFormat(DATETIME_DATETIME_STORAGE_FORMAT, $datesField[0]['value'], DATETIME_STORAGE_TIMEZONE);
     $startDt->setTimezone(timezone_open($timezone));
     $endDt = DrupalDateTime::createFromFormat(DATETIME_DATETIME_STORAGE_FORMAT, $datesField[0]['end_value'], DATETIME_STORAGE_TIMEZONE);
-    $endDt->setTimezone(timezone_open($timezone)); 
+    $endDt->setTimezone(timezone_open($timezone));
+    $formatted_start_date = $startDt->format('g:i a');
+    $formatted_end_date = $endDt->format('g:i a');
+    // Display month and day if the event lasts several days.
+    if ($startDt->format("Y-m-d") != $endDt->format("Y-m-d")) {
+      $formatted_start_date = $startDt->format(('M j, g:i a') );
+      $formatted_end_date = $endDt->format(('M j, g:i a') );
+    }
     $variables['content']['event_converted_dates'] = [
-      'date_start' => $startDt->format('g:i a'),
-      'date_end' => $endDt->format('g:i a'),
+      'date_start' => $formatted_start_date,
+      'date_end' => $formatted_end_date,
     ];
   }
 }

--- a/themes/openy_themes/openy_carnation/templates/node/event/node--event--teaser.html.twig
+++ b/themes/openy_themes/openy_carnation/templates/node/event/node--event--teaser.html.twig
@@ -112,7 +112,7 @@ set classes = [
 
     <div class="event-date__event-time">
       <i class="far fa-clock"></i>
-      {% if content.event_converted_dates|render|trim is not empty %}
+      {% if content.event_converted_dates is not empty %}
         {{ content.event_converted_dates.date_start }}
       {% else %}
         {{ content.field_event_dates }}

--- a/themes/openy_themes/openy_carnation/templates/node/event/node--event--teaser.html.twig
+++ b/themes/openy_themes/openy_carnation/templates/node/event/node--event--teaser.html.twig
@@ -113,7 +113,7 @@ set classes = [
     <div class="event-date__event-time">
       <i class="far fa-clock"></i>
       {% if content.event_converted_dates is not empty %}
-        {{ content.event_converted_dates.date_start }}
+        {{ content.event_converted_dates.date_start }} - {{ content.event_converted_dates.date_end }}
       {% else %}
         {{ content.field_event_dates }}
       {% endif %}

--- a/themes/openy_themes/openy_carnation/templates/node/event/node--event--teaser.html.twig
+++ b/themes/openy_themes/openy_carnation/templates/node/event/node--event--teaser.html.twig
@@ -92,7 +92,7 @@ set classes = [
 
     {# event image #}
     <div class="event-image">
-      {{ content.field_event_image }}
+      <a href="{{ url }}">{{ content.field_event_image }}</a>
     </div>
 
     {# event title (linked) #}

--- a/themes/openy_themes/openy_lily/templates/node/node--event--teaser.html.twig
+++ b/themes/openy_themes/openy_lily/templates/node/node--event--teaser.html.twig
@@ -97,7 +97,7 @@ view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
     {{ content.field_event_location }}
     <div class="event-start-date event-time">
       {% if content.event_converted_dates is not empty %}
-        {{ content.event_converted_dates.date_start }}
+        {{ content.event_converted_dates.date_start }} - {{ content.event_converted_dates.date_end }}
       {% else %}
         {{ content.field_event_dates }}
       {% endif %}

--- a/themes/openy_themes/openy_rose/templates/node/node--event--teaser.html.twig
+++ b/themes/openy_themes/openy_rose/templates/node/node--event--teaser.html.twig
@@ -99,7 +99,7 @@ view_mode ? 'node--view-mode-' ~ view_mode|clean_class,
     {{ content.field_event_location }}
     <div class="event-start-date event-time">
       {% if content.event_converted_dates is not empty %}
-        {{ content.event_converted_dates.date_start }}
+        {{ content.event_converted_dates.date_start }} - {{ content.event_converted_dates.date_end }}
       {% else %}
         {{ content.field_event_dates }}
       {% endif %}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16559938/78291796-b4c55c80-752e-11ea-85ad-666484d70e72.png)
Fix date under image
Make image clickable

Steps for review 

- [ ] Login as admin
- [ ] Visit Appearance and switch to Carnation theme
- [ ] Visit node/add/landing_page
- [ ] Add paragraph Upcoming Events to content
- [ ] Save page
- [ ] Make sure that image clickable
- [ ] Make sure that date formatted  like 11:00 am - 12:00 pm  for one-day event (the same day). 
- [ ] Make sure that date formatted  like Apr 22, 11:00 am - Apr 23, 12:00 pm if the event lasts several days (start and end date are different)

![image](https://user-images.githubusercontent.com/16559938/78357788-b63c6680-75ba-11ea-9261-7e4f648e09b2.png)