### PR TITLE
[YGO-38] fix prev/next buttons for multiple gallery.

### DIFF
--- a/themes/openy_themes/openy_carnation/templates/paragraph/paragraph--gallery--default.html.twig
+++ b/themes/openy_themes/openy_carnation/templates/paragraph/paragraph--gallery--default.html.twig
@@ -66,11 +66,11 @@ set classes = [
       {% endfor %}
     </div>
     {% if content.field_prgf_images['#items']|length > 1 %}
-    <a class="carousel-control-prev" href=".carousel" data-slide="prev" aria-hidden="true" tabindex="-1">
+    <a class="carousel-control-prev carousel-control" href="#carousel" data-slide="prev" aria-hidden="true" tabindex="-1">
       <span class="carousel-control-prev-icon" aria-hidden="true"></span>
       <span class="sr-only" aria-hidden="true">{{ 'Previous'|t }}</span>
     </a>
-    <a class="carousel-control-next" href=".carousel" data-slide="next" aria-hidden="true" tabindex="-1">
+    <a class="carousel-control-next carousel-control" href="#carousel" data-slide="next" aria-hidden="true" tabindex="-1">
       <span class="carousel-control-next-icon" aria-hidden="true"></span>
       <span class="sr-only" aria-hidden="true">{{ 'Next'|t }}</span>
     </a>


### PR DESCRIPTION
This PR is going to fix prev/next buttons for multiple gallery paragraphs on a page in Carnation theme.
## Steps for reproduce
- add 2 Gallery paragraphs on a page
- the second one, will change slides for first gallery

## Steps for review
- [ ] create page and place few Gallery paragraphs
- [ ] make sure prev/next buttons change slides in correct gallery.

## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer. See [Code of Conduct](https://github.com/ymcatwincities/openy/wiki/Open-Y-Code-of-Conduct-and-Best-Practices).
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
