### PR TITLE
[ROY-20] Backport ymca_sync from YGTC

### DIFF
--- a/modules/custom/ymca_sync/src/Form/SettingsForm.php
+++ b/modules/custom/ymca_sync/src/Form/SettingsForm.php
@@ -39,11 +39,11 @@ class SettingsForm extends ConfigFormBase {
    * SettingsForm constructor.
    *
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
-   *   Parameter \Drupal\Core\Config\ConfigFactoryInterface.
+   *   The configuration factory.
    * @param \Drupal\ymca_sync\SyncRepository $syncers
-   *   Parameter \Drupal\ymca_sync\SyncRepository.
+   *   The syncers repository.
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
-   *   Parameter \Drupal\Core\Extension\ModuleHandlerInterface.
+   *   The module handler.
    */
   public function __construct(ConfigFactoryInterface $config_factory, SyncRepository $syncers, ModuleHandlerInterface $module_handler) {
     parent::__construct($config_factory);

--- a/modules/custom/ymca_sync/src/Form/SettingsForm.php
+++ b/modules/custom/ymca_sync/src/Form/SettingsForm.php
@@ -24,7 +24,7 @@ class SettingsForm extends ConfigFormBase {
   /**
    * Module handler.
    *
-   * @var ModuleHandlerInterface
+   * @var \Drupal\Core\Extension\ModuleHandlerInterface
    */
   protected $moduleHandler;
 
@@ -38,12 +38,12 @@ class SettingsForm extends ConfigFormBase {
   /**
    * SettingsForm constructor.
    *
-   * @param ConfigFactoryInterface $config_factory
-   *   Config Factory.
-   * @param SyncRepository $syncers
-   *   Sync Repo.
-   * @param ModuleHandlerInterface $module_handler
-   *   Sync Repo.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   Parameter \Drupal\Core\Config\ConfigFactoryInterface.
+   * @param \Drupal\ymca_sync\SyncRepository $syncers
+   *   Parameter \Drupal\ymca_sync\SyncRepository.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   Parameter \Drupal\Core\Extension\ModuleHandlerInterface.
    */
   public function __construct(ConfigFactoryInterface $config_factory, SyncRepository $syncers, ModuleHandlerInterface $module_handler) {
     parent::__construct($config_factory);
@@ -86,7 +86,7 @@ class SettingsForm extends ConfigFormBase {
       '#title' => $this->t('Active syncers'),
       '#type' => 'checkboxes',
       '#options' => array_combine($this->syncers->getSyncers(), $this->syncers->getSyncers()),
-      '#description' => $this->t('If the syncer is selected it\'s ready to run. Remove selection to disable any syncer.'),
+      '#description' => $this->t("If the syncer is selected it's ready to run. Remove selection to disable any syncer."),
       '#default_value' => $default_value,
     ];
 

--- a/modules/custom/ymca_sync/src/Syncer.php
+++ b/modules/custom/ymca_sync/src/Syncer.php
@@ -21,7 +21,8 @@ class Syncer implements SyncerInterface {
    */
   public function proceed(array $options = []) {
     foreach ($this->steps as $step) {
-      $step['plugin']->{$step['method']}($options);
+      $args = array_merge($options, $step['args']);
+      $step['plugin']->{$step['method']}($args);
     }
   }
 

--- a/modules/custom/ymca_sync/src/Syncer.php
+++ b/modules/custom/ymca_sync/src/Syncer.php
@@ -19,9 +19,9 @@ class Syncer implements SyncerInterface {
   /**
    * {@inheritdoc}
    */
-  public function proceed() {
-    foreach ($this->steps as $id => $step) {
-      $step['plugin']->{$step['method']}($step['args']);
+  public function proceed(array $options = []) {
+    foreach ($this->steps as $step) {
+      $step['plugin']->{$step['method']}($options);
     }
   }
 

--- a/modules/custom/ymca_sync/src/SyncerInterface.php
+++ b/modules/custom/ymca_sync/src/SyncerInterface.php
@@ -11,8 +11,11 @@ interface SyncerInterface {
 
   /**
    * Run the sync process.
+   *
+   * @param array $options
+   *   Options from drush.
    */
-  public function proceed();
+  public function proceed(array $options);
 
   /**
    * Add task.

--- a/modules/custom/ymca_sync/src/SyncerRunner.php
+++ b/modules/custom/ymca_sync/src/SyncerRunner.php
@@ -30,13 +30,6 @@ class SyncerRunner {
   protected $logger;
 
   /**
-   * ConfigFactory.
-   *
-   * @var \Drupal\Core\Config\ConfigFactory
-   */
-  protected $configFactory;
-
-  /**
    * YMCA sync config.
    *
    * @var \Drupal\Core\Config\Config|\Drupal\Core\Config\ImmutableConfig
@@ -67,8 +60,7 @@ class SyncerRunner {
   public function __construct(LockBackendInterface $lock, LoggerChannelInterface $logger, ConfigFactory $configFactory, ContainerInterface $container) {
     $this->lock = $lock;
     $this->logger = $logger;
-    $this->configFactory = $configFactory;
-    $this->config = $this->configFactory->get('ymca_sync.settings');
+    $this->config = $configFactory->get('ymca_sync.settings');
     $this->container = $container;
   }
 

--- a/modules/custom/ymca_sync/src/SyncerRunner.php
+++ b/modules/custom/ymca_sync/src/SyncerRunner.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Drupal\ymca_sync;
+
+use Drupal\Core\Config\ConfigFactory;
+use Drupal\Core\Lock\LockBackendInterface;
+use Drupal\Core\Logger\LoggerChannelInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class SyncerRunner.
+ *
+ * @package Drupal\ymca_sync.
+ */
+class SyncerRunner {
+
+  /**
+   * The used lock backend instance.
+   *
+   * @var \Drupal\Core\Lock\LockBackendInterface
+   */
+  protected $lock;
+
+  /**
+   * LoggerChannelInterface.
+   *
+   * @var Drupal\Core\Logger\LoggerChannelInterface
+   *   LoggerChannelInterface.
+   */
+  protected $logger;
+
+  /**
+   * ConfigFactory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactory
+   */
+  protected $configFactory;
+
+  /**
+   * YMCA sync config.
+   *
+   * @var \Drupal\Core\Config\Config|\Drupal\Core\Config\ImmutableConfig
+   */
+  protected $config;
+
+
+  /**
+   * ContainerInterface.
+   *
+   * @var \Symfony\Component\DependencyInjection\ContainerInterface
+   *   ContainerInterface.
+   */
+  protected $container;
+
+  /**
+   * Implement construct method.
+   *
+   * @param \Drupal\Core\Lock\LockBackendInterface $lock
+   *   Lock.
+   * @param \Drupal\Core\Logger\LoggerChannelInterface $logger
+   *   LoggerChannelInterface.
+   * @param \Drupal\Core\Config\ConfigFactory $configFactory
+   *   ConfigFactory.
+   * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+   *   ContainerInterface.
+   */
+  public function __construct(LockBackendInterface $lock, LoggerChannelInterface $logger, ConfigFactory $configFactory, ContainerInterface $container) {
+    $this->lock = $lock;
+    $this->logger = $logger;
+    $this->configFactory = $configFactory;
+    $this->config = $this->configFactory->get('ymca_sync.settings');
+    $this->container = $container;
+  }
+
+  /**
+   * Run sync.
+   *
+   * @param string $name
+   *   Service name.
+   * @param string $method
+   *   Method name.
+   * @param array $options
+   *   Options.
+   *
+   * @throws \Exception
+   */
+  public function run($name, $method, array $options = []) {
+    $active = $this->config->get('active_syncers');
+
+    // Run only active syncers.
+    if (!in_array($name, $active)) {
+      $msg = 'Syncer "%name" is not activate or found. Exit. ';
+      $msg .= 'Active syncers: %syncers';
+      $this->logger->info(
+        $msg,
+        [
+          '%name' => $name,
+          '%syncers' => implode(", ", $active),
+        ]);
+      return;
+    }
+
+    $service = $this->container->get($name);
+    if (!$service) {
+      throw new \Exception('Failed to load specified service');
+    }
+
+    if ($this->lock->acquire($name, 250.0)) {
+      $service->{$method}($options);
+      $this->lock->release($name);
+      return;
+    }
+
+    $msg = 'Lock syncer "%name" is still working. Exit.';
+    $this->logger->info($msg, ['%name' => $name]);
+  }
+
+}

--- a/modules/custom/ymca_sync/src/SyncerRunner.php
+++ b/modules/custom/ymca_sync/src/SyncerRunner.php
@@ -89,13 +89,13 @@ class SyncerRunner {
 
     // Run only active syncers.
     if (!in_array($name, $active)) {
-      $msg = 'Syncer "%name" is not activate or found. Exit. ';
+      $msg = 'Syncer "%name" is not activated or found. Exit. ';
       $msg .= 'Active syncers: %syncers';
       $this->logger->info(
         $msg,
         [
           '%name' => $name,
-          '%syncers' => implode(", ", $active),
+          '%syncers' => implode(', ', $active),
         ]);
       return;
     }

--- a/modules/custom/ymca_sync/ymca_sync.module
+++ b/modules/custom/ymca_sync/ymca_sync.module
@@ -12,33 +12,11 @@
  *   Service name.
  * @param string $method
  *   Method name.
+ * @param array $options
+ *   Options.
  *
  * @throws \Exception
  */
-function ymca_sync_run($name, $method) {
-  $active = \Drupal::config('ymca_sync.settings')->get('active_syncers');
-  // Run only active syncers.
-  if (!in_array($name, $active)) {
-    return;
-  }
-
-  $service = \Drupal::service($name);
-  if (!$service) {
-    throw new Exception('Failed to load specified service');
-  }
-
-  $lock = \Drupal::lock();
-  if ($lock->acquire($name, 250.0)) {
-    $service->{$method}();
-    $lock->release($name);
-  }
-  else {
-    $msg = 'Lock "%name" is still working. Exit.';
-    Drupal::logger('ymca_sync')->info(
-      $msg,
-      [
-        '%name' => $name,
-      ]
-    );
-  }
+function ymca_sync_run($name, $method, array $options = []) {
+  \Drupal::service('ymca_sync.syncer')->run($name, $method, $options);
 }

--- a/modules/custom/ymca_sync/ymca_sync.services.yml
+++ b/modules/custom/ymca_sync/ymca_sync.services.yml
@@ -1,0 +1,13 @@
+services:
+  logger.channel.ymca_sync:
+    parent: logger.channel_base
+    arguments: ['ymca_sync.syncer']
+  ymca_sync.syncer:
+    class: \Drupal\ymca_sync\SyncerRunner
+    arguments:
+      - '@lock'
+      - '@logger.channel.ymca_sync'
+      - '@config.factory'
+      - '@service_container'
+    tags:
+      - { name: ymca_sync.syncer }


### PR DESCRIPTION
### Motivation
 - Add ability to pass arguments to synced Drush commands. Example: `drush my-syncer --test`
 - Make the code more object oriented to be close to Drush 10 and Drupal 9
### Changes:
- Dependency Injection for `ymca_sync`
- Code style fixes.
- Logger improvements (Example: notification about inactive synced)
- Passing options to the syncer steps
The changes are not breaking existing syncers. Backwards compatible.
## Steps for review
- [ ] Run any of your syncers
- [ ] Make sure it works as expected