### PR TITLE
To make OpenY Focal Point work with Grid Columns

### DIFF
--- a/modules/custom/openy_focal_point/src/Plugin/Field/FieldWidget/OpenYFocalPointImageWidget.php
+++ b/modules/custom/openy_focal_point/src/Plugin/Field/FieldWidget/OpenYFocalPointImageWidget.php
@@ -216,6 +216,22 @@ class OpenYFocalPointImageWidget extends FocalPointImageWidget {
             && isset($subform_field_item['entity_browser_widget_paragraph_info'])) {
             return $subform_field_item['entity_browser_widget_paragraph_info'];
           }
+
+          if (is_array($subform_field_item)) {
+            foreach ($subform_field_item as $third_level_item) {
+              if (!isset($third_level_item['subform'])) {
+                continue;
+              }
+
+              foreach ($third_level_item['subform'] as $subform_field_name => $subform_field_item) {
+                if (isset($subform_field_item['target_id'])
+                  && in_array($subform_field_item['target_id'], $media_names)
+                  && isset($subform_field_item['entity_browser_widget_paragraph_info'])) {
+                  return $subform_field_item['entity_browser_widget_paragraph_info'];
+                }
+              }
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
If we want to use OpenY Focal Point with Grid content and Grid Columns paragraphs we need to apply this patch, which helps to search entity_browser_widget_paragraph_info in third level subforms.