### PR TITLE
[INOYI-27] Config update after enable media folders

### DIFF
--- a/modules/openy_features/openy_media/config/install/taxonomy.vocabulary.media_tags.yml
+++ b/modules/openy_features/openy_media/config/install/taxonomy.vocabulary.media_tags.yml
@@ -4,5 +4,4 @@ dependencies: {  }
 name: 'Media Tags'
 vid: media_tags
 description: 'Tags for media objects.'
-hierarchy: 0
 weight: 0

--- a/modules/openy_features/openy_media/modules/openy_media_document/config/install/core.entity_form_display.media.document.default.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_document/config/install/core.entity_form_display.media.document.default.yml
@@ -16,6 +16,12 @@ targetEntityType: media
 bundle: document
 mode: default
 content:
+  directory:
+    type: options_select
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_media_document:
     weight: 3
     settings:
@@ -36,6 +42,7 @@ content:
       match_operator: CONTAINS
       size: 60
       placeholder: ''
+      match_limit: 10
     third_party_settings: {  }
     type: entity_reference_autocomplete_tags
     region: content
@@ -59,6 +66,13 @@ content:
     weight: 30
     region: content
     settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 100
+    region: content
     third_party_settings: {  }
 hidden:
   created: true

--- a/modules/openy_features/openy_media/modules/openy_media_document/config/install/core.entity_view_display.media.document.default.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_document/config/install/core.entity_view_display.media.document.default.yml
@@ -7,13 +7,9 @@ dependencies:
     - field.field.media.document.field_media_mime
     - field.field.media.document.field_media_size
     - field.field.media.document.field_media_tags
-    - image.style.thumbnail
     - media.type.document
   module:
-    - file
-    - image
     - openy_media_document
-    - user
 id: media.document.default
 targetEntityType: media
 bundle: document

--- a/modules/openy_features/openy_media/modules/openy_media_document/config/install/media.type.document.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_document/config/install/media.type.document.yml
@@ -1,8 +1,6 @@
 langcode: en
 status: true
-dependencies:
-  module:
-    - media
+dependencies: {  }
 id: document
 label: Document
 description: 'Use Document for uploading document files such as PDF.'

--- a/modules/openy_features/openy_media/modules/openy_media_document/config/install/views.view.documents_library.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_document/config/install/views.view.documents_library.yml
@@ -17,7 +17,6 @@ description: 'Provides images library for images_library entity browser.'
 tag: ''
 base_table: media_field_data
 base_field: mid
-core: 8.x
 display:
   default:
     display_plugin: default
@@ -214,6 +213,8 @@ display:
               authenticated: authenticated
               anonymous: '0'
               administrator: '0'
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -254,6 +255,8 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -294,6 +297,8 @@ display:
               authenticated: authenticated
               anonymous: '0'
               administrator: '0'
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -332,6 +337,8 @@ display:
             multiple: false
             remember_roles:
               authenticated: authenticated
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -371,6 +378,8 @@ display:
               anonymous: '0'
               administrator: '0'
             reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''

--- a/modules/openy_features/openy_media/modules/openy_media_document/openy_media_document.info.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_document/openy_media_document.info.yml
@@ -1,10 +1,11 @@
 name: 'Open Y Media Document'
-description: Provides a Document media entity and features.
+description: 'Provides a Document media entity and features.'
 type: module
 core: 8.x
 version: 8.x-1.0
-package: Open Y
+package: 'Open Y'
 dependencies:
+  - dropzonejs_eb_widget:dropzonejs_eb_widget
   - drupal:field
   - drupal:file
   - drupal:image
@@ -13,7 +14,6 @@ dependencies:
   - drupal:taxonomy
   - drupal:user
   - drupal:views
-  - dropzonejs_eb_widget:dropzonejs_eb_widget
   - embed:embed
   - entity_browser:entity_browser
   - entity_embed:entity_embed

--- a/modules/openy_features/openy_media/modules/openy_media_document/openy_media_document.install
+++ b/modules/openy_features/openy_media/modules/openy_media_document/openy_media_document.install
@@ -162,3 +162,24 @@ function openy_media_document_update_8005() {
     }
   }
 }
+
+/**
+ * Add media directories to config.
+ */
+function openy_media_document_update_8006() {
+  $config_dir = drupal_get_path('module', 'openy_media_document') . '/config/install/';
+  // Update multiple configurations.
+  $configs = [
+    'core.entity_form_display.media.document.default' => [
+      'content.directory',
+    ],
+  ];
+
+  $config_updater = \Drupal::service('openy_upgrade_tool.param_updater');
+  foreach ($configs as $config_name => $params) {
+    $config = $config_dir . $config_name . '.yml';
+    foreach ($params as $param) {
+      $config_updater->update($config, $config_name, $param);
+    }
+  }
+}

--- a/modules/openy_features/openy_media/modules/openy_media_image/config/install/core.entity_form_display.media.image.default.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_image/config/install/core.entity_form_display.media.image.default.yml
@@ -16,6 +16,12 @@ targetEntityType: media
 bundle: image
 mode: default
 content:
+  directory:
+    type: options_select
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_media_caption:
     weight: 3
     settings:
@@ -47,6 +53,7 @@ content:
       match_operator: CONTAINS
       size: 60
       placeholder: ''
+      match_limit: 10
     third_party_settings: {  }
     type: entity_reference_autocomplete_tags
     region: content

--- a/modules/openy_features/openy_media/modules/openy_media_image/config/install/media.type.image.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_image/config/install/media.type.image.yml
@@ -1,8 +1,6 @@
 langcode: en
 status: true
-dependencies:
-  module:
-    - media
+dependencies: {  }
 id: image
 label: Image
 description: 'Use Image for uploading locally hosted images.'

--- a/modules/openy_features/openy_media/modules/openy_media_image/config/install/views.view.images_library.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_image/config/install/views.view.images_library.yml
@@ -20,7 +20,6 @@ description: 'Provides images library for images_library entity browser.'
 tag: ''
 base_table: media_field_data
 base_field: mid
-core: 8.x
 display:
   default:
     display_plugin: default
@@ -232,6 +231,8 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -270,6 +271,8 @@ display:
             multiple: false
             remember_roles:
               authenticated: authenticated
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -308,6 +311,8 @@ display:
               authenticated: authenticated
               anonymous: '0'
               administrator: '0'
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -348,6 +353,8 @@ display:
               authenticated: authenticated
               anonymous: '0'
               administrator: '0'
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: true
           group_info:
             label: Published
@@ -397,6 +404,8 @@ display:
               anonymous: '0'
               administrator: '0'
             reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -444,6 +453,8 @@ display:
               contributor: '0'
               editor: '0'
             reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''

--- a/modules/openy_features/openy_media/modules/openy_media_image/openy_media_image.install
+++ b/modules/openy_features/openy_media/modules/openy_media_image/openy_media_image.install
@@ -25,7 +25,8 @@ function openy_media_image_update_dependencies() {
     8008 => [
       'openy' => 8042,
     ],
-    8012 => [
+    8011 => [
+      'openy' => 8080,
       'openy_media' => 8005,
     ],
   ];
@@ -291,4 +292,25 @@ function openy_media_image_update_8012() {
     'entity_browser.browser.images_library_embed',
     'views.view.images_library',
   ]);
+}
+
+/**
+ * Add media directories to config.
+ */
+function openy_media_image_update_8013() {
+  $config_dir = drupal_get_path('module', 'openy_media_image') . '/config/install/';
+  // Update multiple configurations.
+  $configs = [
+    'core.entity_form_display.media.image.default' => [
+      'content.directory',
+    ],
+  ];
+
+  $config_updater = \Drupal::service('openy_upgrade_tool.param_updater');
+  foreach ($configs as $config_name => $params) {
+    $config = $config_dir . $config_name . '.yml';
+    foreach ($params as $param) {
+      $config_updater->update($config, $config_name, $param);
+    }
+  }
 }

--- a/modules/openy_features/openy_media/modules/openy_media_local_video/config/install/core.entity_form_display.media.video_local.default.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_local_video/config/install/core.entity_form_display.media.video_local.default.yml
@@ -13,6 +13,12 @@ targetEntityType: media
 bundle: video_local
 mode: default
 content:
+  directory:
+    type: options_select
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_media_local_video:
     weight: 3
     settings:
@@ -32,6 +38,7 @@ content:
       match_operator: CONTAINS
       size: 60
       placeholder: ''
+      match_limit: 10
     third_party_settings: {  }
   langcode:
     type: language_select
@@ -53,6 +60,13 @@ content:
     weight: 4
     region: content
     settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 100
+    region: content
     third_party_settings: {  }
 hidden:
   created: true

--- a/modules/openy_features/openy_media/modules/openy_media_local_video/config/install/media.type.video_local.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_local_video/config/install/media.type.video_local.yml
@@ -3,7 +3,7 @@ status: true
 dependencies:
   module:
     - crop
-    - media
+    - media_entity_video
 third_party_settings:
   crop:
     image_field: null

--- a/modules/openy_features/openy_media/modules/openy_media_local_video/config/install/views.view.local_videos_library.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_local_video/config/install/views.view.local_videos_library.yml
@@ -17,7 +17,6 @@ description: 'Provides videos library for local_video_library entity browser.'
 tag: ''
 base_table: media_field_data
 base_field: mid
-core: 8.x
 display:
   default:
     display_plugin: default
@@ -214,6 +213,8 @@ display:
               authenticated: authenticated
               anonymous: '0'
               administrator: '0'
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -254,6 +255,8 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -294,6 +297,8 @@ display:
               authenticated: authenticated
               anonymous: '0'
               administrator: '0'
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -335,6 +340,8 @@ display:
               anonymous: '0'
               administrator: '0'
             reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''

--- a/modules/openy_features/openy_media/modules/openy_media_local_video/openy_media_local_video.info.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_local_video/openy_media_local_video.info.yml
@@ -1,9 +1,9 @@
 name: 'Open Y Media Local Video'
-description: Provides a Local video media entity and features.
+description: 'Provides a Local video media entity and features.'
 type: module
 core: 8.x
 version: 8.x-1.0
-package: Open Y
+package: 'Open Y'
 dependencies:
   - drupal:field
   - drupal:file
@@ -23,3 +23,4 @@ dependencies:
   - openy_media:openy_media
   - video:video
   - media_entity_video:media_entity_video
+core_incompatible: false

--- a/modules/openy_features/openy_media/modules/openy_media_local_video/openy_media_local_video.install
+++ b/modules/openy_features/openy_media/modules/openy_media_local_video/openy_media_local_video.install
@@ -13,3 +13,24 @@ use Drupal\openy_media\EmbedButtonIconHelper;
 function openy_media_local_video_install() {
   EmbedButtonIconHelper::setEmbedButtonIcon('openy_media_local_video', 'local_video.png', 'embed_local_video');
 }
+
+/**
+ * Add media directories to config.
+ */
+function openy_media_local_video_update_8001() {
+  $config_dir = drupal_get_path('module', 'openy_media_local_video') . '/config/install/';
+  // Update multiple configurations.
+  $configs = [
+    'core.entity_form_display.media.video_local.default' => [
+      'content.directory',
+    ],
+  ];
+
+  $config_updater = \Drupal::service('openy_upgrade_tool.param_updater');
+  foreach ($configs as $config_name => $params) {
+    $config = $config_dir . $config_name . '.yml';
+    foreach ($params as $param) {
+      $config_updater->update($config, $config_name, $param);
+    }
+  }
+}

--- a/modules/openy_features/openy_media/modules/openy_media_video/config/install/core.entity_form_display.media.video.default.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_video/config/install/core.entity_form_display.media.video.default.yml
@@ -16,6 +16,12 @@ targetEntityType: media
 bundle: video
 mode: default
 content:
+  directory:
+    type: options_select
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_media_in_library:
     weight: 2
     settings:
@@ -29,6 +35,7 @@ content:
       match_operator: CONTAINS
       size: 60
       placeholder: ''
+      match_limit: 10
     third_party_settings: {  }
     type: entity_reference_autocomplete_tags
     region: content
@@ -58,6 +65,13 @@ content:
     weight: 30
     region: content
     settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 100
+    region: content
     third_party_settings: {  }
 hidden:
   created: true

--- a/modules/openy_features/openy_media/modules/openy_media_video/config/install/core.entity_view_display.media.video.default.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_video/config/install/core.entity_view_display.media.video.default.yml
@@ -7,11 +7,8 @@ dependencies:
     - field.field.media.video.field_media_tags
     - field.field.media.video.field_media_video_embed_field
     - field.field.media.video.field_media_video_id
-    - image.style.thumbnail
     - media.type.video
   module:
-    - image
-    - user
     - video_embed_field
 id: media.video.default
 targetEntityType: media

--- a/modules/openy_features/openy_media/modules/openy_media_video/config/install/views.view.videos_library.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_video/config/install/views.view.videos_library.yml
@@ -17,7 +17,6 @@ description: 'Provides images library for images_library entity browser.'
 tag: ''
 base_table: media_field_data
 base_field: mid
-core: 8.x
 display:
   default:
     display_plugin: default
@@ -214,6 +213,8 @@ display:
               authenticated: authenticated
               anonymous: '0'
               administrator: '0'
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -254,6 +255,8 @@ display:
             remember_roles:
               authenticated: authenticated
             reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -294,6 +297,8 @@ display:
               authenticated: authenticated
               anonymous: '0'
               administrator: '0'
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -332,6 +337,8 @@ display:
             multiple: false
             remember_roles:
               authenticated: authenticated
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''
@@ -371,6 +378,8 @@ display:
               anonymous: '0'
               administrator: '0'
             reduce: false
+            operator_limit_selection: false
+            operator_list: {  }
           is_grouped: false
           group_info:
             label: ''

--- a/modules/openy_features/openy_media/modules/openy_media_video/openy_media_video.info.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_video/openy_media_video.info.yml
@@ -1,9 +1,9 @@
 name: 'Open Y Media Video'
-description: Provides a Video media entity and features.
+description: 'Provides a Video media entity and features.'
 type: module
 core: 8.x
 version: 8.x-1.0
-package: Open Y
+package: 'Open Y'
 dependencies:
   - drupal:field
   - drupal:image
@@ -20,3 +20,4 @@ dependencies:
   - openy_media:openy_media
   - video_embed_field:video_embed_field
   - video_embed_media:video_embed_media
+core_incompatible: false

--- a/modules/openy_features/openy_media/modules/openy_media_video/openy_media_video.install
+++ b/modules/openy_features/openy_media/modules/openy_media_video/openy_media_video.install
@@ -138,3 +138,24 @@ function openy_media_video_update_8005() {
     }
   }
 }
+
+/**
+ * Add media directories to config.
+ */
+function openy_media_video_update_8006() {
+  $config_dir = drupal_get_path('module', 'openy_media_video') . '/config/install/';
+  // Update multiple configurations.
+  $configs = [
+    'core.entity_form_display.media.video.default' => [
+      'content.directory',
+    ],
+  ];
+
+  $config_updater = \Drupal::service('openy_upgrade_tool.param_updater');
+  foreach ($configs as $config_name => $params) {
+    $config = $config_dir . $config_name . '.yml';
+    foreach ($params as $param) {
+      $config_updater->update($config, $config_name, $param);
+    }
+  }
+}

--- a/modules/openy_features/openy_media/openy_media.info.yml
+++ b/modules/openy_features/openy_media/openy_media.info.yml
@@ -1,10 +1,11 @@
-name:  Open Y Media
-description: Stores media entity modules and shared configuration.
+name: 'Open Y Media'
+description: 'Stores media entity modules and shared configuration.'
 type: module
 core: 8.x
-package: Open Y
+package: 'Open Y'
 version: 8.x-1.0
 dependencies:
+  - blazy:blazy
   - drupal:field
   - drupal:image
   - drupal:media (>= 8.6)
@@ -12,3 +13,4 @@ dependencies:
   - drupal:user
   - rabbit_hole:rabbit_hole
   - media_directories:media_directories
+core_incompatible: false


### PR DESCRIPTION
https://github.com/ymcatwincities/openy/issues/1982


Actualize configs for media modules after enable media folder feature and fix issues with config update appeared during OpenY upgrade at YMCA Seattle website

Steps for review

- [ ] login as admin 
- [ ] open admin/config/development/features (if page not found enable Features module)
- [ ] locate media features (Open Y Media Document, Open Y Media Image, Open Y Media Video, Open Y Media Local Video) and make sure that their state is empty

