### PR TITLE
In Teaser paragraph, do not display link field if empty.

### DIFF
--- a/themes/openy_themes/openy_carnation/templates/paragraph/paragraph--teaser--default.html.twig
+++ b/themes/openy_themes/openy_carnation/templates/paragraph/paragraph--teaser--default.html.twig
@@ -51,6 +51,8 @@ set classes = [
   <div class="col-md-7 content">
     <h2>{{ content.field_prgf_title }}</h2>
     {{ content.field_prgf_description }}
+    {% if content.field_prgf_link|render|trim is not empty %}
     <a href="{{ content.field_prgf_link.0['#url'] }}" class="btn btn-outline-primary d-block d-lg-inline-block" aria-label="{{ 'Learn more about'|t }} {{ paragraph.field_prgf_title.value }}" title="{{ content.field_prgf_link.0['#title'] }}">{{ content.field_prgf_link.0['#title'] }}</a>
+    {% endif %}
   </div>
 </article>

--- a/themes/openy_themes/openy_carnation/templates/paragraph/paragraph--teaser--default.html.twig
+++ b/themes/openy_themes/openy_carnation/templates/paragraph/paragraph--teaser--default.html.twig
@@ -52,7 +52,7 @@ set classes = [
     <h2>{{ content.field_prgf_title }}</h2>
     {{ content.field_prgf_description }}
     {% if content.field_prgf_link|render|trim is not empty %}
-    <a href="{{ content.field_prgf_link.0['#url'] }}" class="btn btn-outline-primary d-block d-lg-inline-block" aria-label="{{ 'Learn more about'|t }} {{ paragraph.field_prgf_title.value }}" title="{{ content.field_prgf_link.0['#title'] }}">{{ content.field_prgf_link.0['#title'] }}</a>
+      <a href="{{ content.field_prgf_link.0['#url'] }}" class="btn btn-outline-primary d-block d-lg-inline-block" aria-label="{{ 'Learn more about'|t }} {{ paragraph.field_prgf_title.value }}" title="{{ content.field_prgf_link.0['#title'] }}">{{ content.field_prgf_link.0['#title'] }}</a>
     {% endif %}
   </div>
 </article>


### PR DESCRIPTION
Original Issue, this PR is going to fix: No official issue created.  A user in Slack raised a concern that when creating a Teaser paragraph section in Carnation, the Button (link field) displays even if the fields are left blank.  This commit just adds a check in the the Teaser's template twig file, similar to what Rose & Lily are doing.

## Steps for review

- Using Carnation Theme, add a Teaser Paragraph Section to any page.
- Fill out Title, Description, but leave Link blank.  Save page.
- Button should _not_ be displayed.
- Edit the page and add a URL & Text in the Link field. Save page.
- Button should be displayed.
