### PR TITLE
Activity Finder: fix possible negative values come from Daxko when no…

### DIFF
--- a/modules/custom/openy_activity_finder/templates/openy-activity-finder-program-search-page.html.twig
+++ b/modules/custom/openy_activity_finder/templates/openy-activity-finder-program-search-page.html.twig
@@ -272,10 +272,12 @@
                     <div class="availability-wrapper">
                       {# if we know that registration is available #}
                       <div v-if="item.availability_status == 'open'">
-                        <div v-if="item.spots_available" v-bind:class="[item.spots_available <= 3 ? item.spots_available == 1 ? 'few-spots only-one' : 'few-spots' : '', 'spots-availability']">${ item.spots_available }
+                        <div v-if="item.spots_available >=1" v-bind:class="[item.spots_available <= 3 ? item.spots_available == 1 ? 'few-spots only-one' : 'few-spots' : '', 'spots-availability']">
+                          ${ item.spots_available }
                           <span v-if="item.spots_available == 1">spot</span>
                           <span v-if="item.spots_available > 1">spots</span>
-                          left</div>
+                          left
+                        </div>
                       </div>
                       {# if we know that registration is NOT available #}
                       <div v-if="item.availability_status == 'closed'">
@@ -377,10 +379,12 @@
                         <div class="spots-label">{{ 'Free for members'|t }}</div>
                       </div>
                       {% if not is_spots_available_disabled %}
-                        <div v-if="moreInfoPopup.spots_available"  v-bind:class="[moreInfoPopup.spots_available <= 3 ? moreInfoPopup.spots_available == 1 ? 'only-one' : 'few-spots' : '', 'spots_available']">${ moreInfoPopup.spots_available }
+                        <div v-if="moreInfoPopup.spots_available >= 1"  v-bind:class="[moreInfoPopup.spots_available <= 3 ? moreInfoPopup.spots_available == 1 ? 'only-one' : 'few-spots' : '', 'spots_available']">
+                          ${ moreInfoPopup.spots_available }
                           <span v-if="moreInfoPopup.spots_available == 1">spot</span>
                           <span v-if="moreInfoPopup.spots_available > 1">spots</span>
-                          left</div>
+                          left
+                        </div>
                       {% endif %}
                       <div v-if="moreInfoPopup.activity_type == 'group'" class="availability_status activity_type">
                         <div v-if="moreInfoPopup.atc_info != ''" class="addtocalendar">


### PR DESCRIPTION
Daxko returns "-1" in some cases for "Spots Available", the PR fixes this issue, we don't need to show negative values, they mean there are no registration limits.

before https://take.ms/p6xLp
after https://take.ms/TlTLL
daxko session https://take.ms/qZoGm
