### PR TITLE
Updated views_data_export & webform

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -174,9 +174,6 @@
             "drupal/plugin": {
                 "2647312 - Use SubFormState in plugin selectors": "https://www.drupal.org/files/issues/plugin_2647312_20.patch"
             },
-            "drupal/views_data_export": {
-                "2789531 - Support for batch operations": "https://www.drupal.org/files/issues/2789531-105.patch"
-            },
             "drupal/core": {
                 "1236098 - Notice: Undefined index in _color_rewrite_stylesheet()": "https://www.drupal.org/files/issues/undefined-index-in-_color_rewrite_stylesheet-1236098-37.patch",
                 "2484693 - Telephone Link field formatter InvalidArgumentException with 5 digits or fewer in the number": "https://www.drupal.org/files/issues/2484693-54.patch",
@@ -261,7 +258,7 @@
         "drupal/redirect": "~1.3",
         "drupal/metatag": "~1.8",
         "drupal/scheduler": "1.0",
-        "drupal/webform": "~5.0",
+        "drupal/webform": "~5.11",
         "drupal/captcha": "^1.0",
         "drupal/recaptcha": "~2.3",
         "drupal/rabbit_hole": "~1.0-beta4",
@@ -273,7 +270,7 @@
         "drupal/token_filter": "~1.1",
         "drupal/views_field_formatter": "~1.9",
         "drupal/tzfield": "1.x-dev",
-        "drupal/views_data_export": "1.0-beta1",
+        "drupal/views_data_export": "1.0-rc1",
         "doctrine/inflector": "1.2.*",
         "drupal/crop": "^2.0",
         "drupal/focal_point": "~1.0-beta6",


### PR DESCRIPTION
This PR contains important updates for
- webform (CRITICAL SECURITY ISSUE - https://www.drupal.org/sa-contrib-2020-011)
- views_data_export - they committed patch that we were using for many years and created stable release. 

## Steps for review

- [ ] Test webforms.
- [ ] Test views_data_export.


## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer. See [Code of Conduct](https://github.com/ymcatwincities/openy/wiki/Open-Y-Code-of-Conduct-and-Best-Practices).
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
