### PR TITLE
[YGO-99] Fix for full_without_blazy plugin does not exist

### DIFF
--- a/modules/openy_features/openy_media/modules/openy_media_image/config/install/embed.button.embed_image.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_image/config/install/embed.button.embed_image.yml
@@ -14,8 +14,8 @@ type_settings:
   bundles:
     - image
   display_plugins:
-    - 'view_mode:view_mode:media.full_without_blazy'
-    - 'view_mode:view_mode:media.half_without_blazy'
+    - 'view_mode:media.full_without_blazy'
+    - 'view_mode:media.half_without_blazy'
     - 'view_mode:media.embedded_link'
   entity_browser: images_library_embed
   entity_browser_settings:

--- a/modules/openy_features/openy_media/modules/openy_media_image/openy_media_image.install
+++ b/modules/openy_features/openy_media/modules/openy_media_image/openy_media_image.install
@@ -328,7 +328,7 @@ function openy_media_image_update_8013() {
  *
  * Blazy image styles don't work with image alignment in CKEditor, so we shouldn't use them.
  */
-function openy_media_image_update_8015() {
+function openy_media_image_update_8014() {
   $config = \Drupal::configFactory()->getEditable('embed.button.embed_image');
   $original_image_styles = $config->get('type_settings.display_plugins');
   $blazy_image_styles = [

--- a/modules/openy_features/openy_media/modules/openy_media_image/openy_media_image.install
+++ b/modules/openy_features/openy_media/modules/openy_media_image/openy_media_image.install
@@ -328,7 +328,7 @@ function openy_media_image_update_8013() {
  *
  * Blazy image styles don't work with image alignment in CKEditor, so we shouldn't use them.
  */
-function openy_media_image_update_8014() {
+function openy_media_image_update_8015() {
   $config = \Drupal::configFactory()->getEditable('embed.button.embed_image');
   $original_image_styles = $config->get('type_settings.display_plugins');
   $blazy_image_styles = [


### PR DESCRIPTION
## Original issue:

Error during installation
```
You are about to DROP all tables in your 'default' database. Do you want to continue? (y/n): y
Starting Drupal installation. This takes a while.                                                                                                                                                                           [ok]
Drupal\Component\Plugin\Exception\PluginNotFoundException: The "view_mode:view_mode:media.full_without_blazy" plugin does not exist. Valid plugin IDs for Drupal\entity_embed\EntityEmbedDisplay\EntityEmbedDisplayManager  [error]
are: image:blazy, image:openy_image_link, image:image, image:image_url, view_mode:advanced_help_block.t
```

## Steps for review

- [ ] Verify that OpenY install works without errors
- [ ] Check that fix from https://github.com/ymcatwincities/openy/pull/2013 also works as expected
