### PR TITLE
[RGTC-1103] Fix deprecated function drupal_set_message()

### DIFF
--- a/modules/custom/advanced_help_block/advanced_help_block.module
+++ b/modules/custom/advanced_help_block/advanced_help_block.module
@@ -16,7 +16,7 @@ use Drupal\Core\Link;
 function advanced_help_block_help($path, $arg) {
   $query = \Drupal::entityQuery('advanced_help_block');
   $entity_ids = $query->execute();
-
+  $messenger = \Drupal::messenger();
   $output = [];
 
   $config_factory = \Drupal::configFactory();
@@ -58,7 +58,7 @@ function advanced_help_block_help($path, $arg) {
         ];
 
         if ($render_type == 'message') {
-          drupal_set_message(t('<h3>%title</h3>%description @link', [
+          $messenger->addMessage(t('<h3>%title</h3>%description @link', [
             '@link' => $link,
             '%title' => $block->field_ahb_title->value,
             '%description' => check_markup($block->field_ahb_description->value, $block->field_ahb_description->format),

--- a/modules/custom/advanced_help_block/src/Form/AdvancedHelpBlockForm.php
+++ b/modules/custom/advanced_help_block/src/Form/AdvancedHelpBlockForm.php
@@ -29,6 +29,7 @@ class AdvancedHelpBlockForm extends ContentEntityForm {
    */
   public function save(array $form, FormStateInterface $form_state) {
     $status = parent::save($form, $form_state);
+    $messenger = \Drupal::messenger();
 
     $entity = $this->entity;
     if ($entity instanceof EntityChangedInterface) {
@@ -36,7 +37,7 @@ class AdvancedHelpBlockForm extends ContentEntityForm {
     }
 
     if ($status == SAVED_UPDATED) {
-      drupal_set_message(
+      $messenger->addMessage(
         $this->t(
           'The Advanced Help Block %feed has been updated.', [
             '%feed' => $entity->toLink()
@@ -46,7 +47,7 @@ class AdvancedHelpBlockForm extends ContentEntityForm {
       );
     }
     else {
-      drupal_set_message(
+      $messenger->addMessage(
         $this->t(
           'The Advanced Help Block %feed has been added.', [
             '%feed' => $entity->toLink()

--- a/modules/custom/embedded_groupexpro_schedule/src/Plugin/Block/EmbeddedGroupExProScheduleBlock.php
+++ b/modules/custom/embedded_groupexpro_schedule/src/Plugin/Block/EmbeddedGroupExProScheduleBlock.php
@@ -21,11 +21,12 @@ class EmbeddedGroupExProScheduleBlock extends BlockBase {
    */
   public function build() {
     $account = \Drupal::config('embedded_groupexpro_schedule.settings')->get('account');
+    $messenger = \Drupal::messenger();
 
     if (empty($account)) {
       // If the account id is not set, set an error and return empty.
       $link = Link::createFromRoute(t('Set the id'), 'embeddedgroupexpro.settings');
-      drupal_set_message(t('The GroupEx Pro account id is not set. @link.', ['@link' => $link->toString()]), 'error', TRUE);
+      $messenger->addMessage(t('The GroupEx Pro account id is not set. @link.', ['@link' => $link->toString()]), 'error', TRUE);
       return [];
     }
 

--- a/modules/custom/logger_entity/src/Form/LoggerEntityForm.php
+++ b/modules/custom/logger_entity/src/Form/LoggerEntityForm.php
@@ -36,16 +36,17 @@ class LoggerEntityForm extends ContentEntityForm {
   public function save(array $form, FormStateInterface $form_state) {
     $entity = $this->entity;
     $status = parent::save($form, $form_state);
+    $messenger = \Drupal::messenger();
 
     switch ($status) {
       case SAVED_NEW:
-        drupal_set_message($this->t('Created the %label Logger Entity.', [
+        $messenger->addMessage($this->t('Created the %label Logger Entity.', [
           '%label' => $entity->label(),
         ]));
         break;
 
       default:
-        drupal_set_message($this->t('Saved the %label Logger Entity.', [
+        $messenger->addMessage($this->t('Saved the %label Logger Entity.', [
           '%label' => $entity->label(),
         ]));
     }

--- a/modules/custom/logger_entity/src/Form/LoggerEntityTypeDeleteForm.php
+++ b/modules/custom/logger_entity/src/Form/LoggerEntityTypeDeleteForm.php
@@ -37,8 +37,9 @@ class LoggerEntityTypeDeleteForm extends EntityConfirmFormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $this->entity->delete();
+    $messenger = \Drupal::messenger();
 
-    drupal_set_message(
+    $messenger->addMessage(
       $this->t('content @type: deleted @label.',
         [
           '@type' => $this->entity->bundle(),

--- a/modules/custom/logger_entity/src/Form/LoggerEntityTypeForm.php
+++ b/modules/custom/logger_entity/src/Form/LoggerEntityTypeForm.php
@@ -48,16 +48,17 @@ class LoggerEntityTypeForm extends EntityForm {
   public function save(array $form, FormStateInterface $form_state) {
     $logger_entity_type = $this->entity;
     $status = $logger_entity_type->save();
+    $messenger = \Drupal::messenger();
 
     switch ($status) {
       case SAVED_NEW:
-        drupal_set_message($this->t('Created the %label Logger Entity type.', [
+        $messenger->addMessage($this->t('Created the %label Logger Entity type.', [
           '%label' => $logger_entity_type->label(),
         ]));
         break;
 
       default:
-        drupal_set_message($this->t('Saved the %label Logger Entity type.', [
+        $messenger->addMessage($this->t('Saved the %label Logger Entity type.', [
           '%label' => $logger_entity_type->label(),
         ]));
     }

--- a/modules/custom/openy_addthis/src/Form/PrepareUninstallForm.php
+++ b/modules/custom/openy_addthis/src/Form/PrepareUninstallForm.php
@@ -93,6 +93,7 @@ class PrepareUninstallForm extends ConfirmFormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $tables_to_update = [];
+    $messenger = \Drupal::messenger();
 
     foreach ($this->entityTypeManager->getDefinitions() as $entity_type) {
       if ($entity_type->id() == 'node') {
@@ -108,7 +109,7 @@ class PrepareUninstallForm extends ConfirmFormBase {
           ->execute();
       }
     }
-    drupal_set_message(t('All values have been deleted.'));
+    $messenger->addMessage(t('All values have been deleted.'));
 
     $form_state->setRedirect('system.modules_uninstall');
   }

--- a/modules/custom/openy_calc/src/Form/CalcBlockForm.php
+++ b/modules/custom/openy_calc/src/Form/CalcBlockForm.php
@@ -253,13 +253,15 @@ class CalcBlockForm extends FormBase {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $storage = $form_state->getStorage();
     $url = $this->dataWrapper->getRedirectUrl($storage['location'], $storage['type']);
+    $messenger = \Drupal::messenger();
+
     if ($url) {
       // Redirect to membership registration path.
       $response = new TrustedRedirectResponse($url->toString());
       $form_state->setResponse($response);
     }
     else {
-      drupal_set_message($this->t('Unfortunately, selected branch doesn`t provide needed membership type. Please select other membership type or branch.'), 'error');
+      $messenger->addMessage($this->t('Unfortunately, selected branch doesn`t provide needed membership type. Please select other membership type or branch.'), 'error');
     }
   }
 

--- a/modules/custom/openy_campaign/src/Controller/MembersController.php
+++ b/modules/custom/openy_campaign/src/Controller/MembersController.php
@@ -69,12 +69,14 @@ class MembersController extends ControllerBase {
    *   Redirect response.
    */
   public static function deleteAllMembersFinishBatch($success, $results, $operations) {
+    $messenger = \Drupal::messenger();
     $message = t('Finished with an error.');
+
     if ($success) {
       $message = \Drupal::translation()
         ->formatPlural(count($results), 'Removed one item.', 'Removed @count items.');
     }
-    drupal_set_message($message);
+    $messenger->addMessage($message);
 
     $url = Url::fromRoute('entity.openy_campaign_member.collection');
 

--- a/modules/custom/openy_campaign/src/Form/MemberEmailEditForm.php
+++ b/modules/custom/openy_campaign/src/Form/MemberEmailEditForm.php
@@ -112,9 +112,10 @@ class MemberEmailEditForm extends FormBase {
 
     $member->setEmail($membershipEmail);
     $member->save();
+    $messenger = \Drupal::messenger();
 
     // If the member has not previously registered, there will be a basic message "This member is now registered".
-    drupal_set_message(t('This member is updated'), 'status', TRUE);
+    $messenger->addMessage(t('This member is updated'), 'status', TRUE);
 
     $form_state->setRedirect('openy_campaign.team_member.list');
   }

--- a/modules/custom/openy_campaign/src/Form/MemberRegistrationPortalForm.php
+++ b/modules/custom/openy_campaign/src/Form/MemberRegistrationPortalForm.php
@@ -353,6 +353,7 @@ class MemberRegistrationPortalForm extends FormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
+    $messenger = \Drupal::messenger();
     $step = $form_state->getValue('step');
     $email = $form_state->get('membership_email');
 
@@ -467,7 +468,7 @@ class MemberRegistrationPortalForm extends FormBase {
       $this->regularUpdater->createQueue($dateFrom, $dateTo, $membersData);
 
       // If the member has not previously registered, there will be a basic message "This member is now registered".
-      drupal_set_message(t('This member is now registered'), 'status', TRUE);
+      $messenger->addMessage(t('This member is now registered'), 'status', TRUE);
     }
   }
 

--- a/modules/custom/openy_campaign/src/Form/WinnersCalculateForm.php
+++ b/modules/custom/openy_campaign/src/Form/WinnersCalculateForm.php
@@ -408,13 +408,15 @@ class WinnersCalculateForm extends FormBase {
    * Finish batch.
    */
   public static function finishBatch($success, $results, $operations) {
+    $messenger = \Drupal::messenger();
+
     if ($success) {
       $message = \Drupal::translation()->formatPlural(count($results), 'Created one winner.', 'Created @count winners.');
     }
     else {
       $message = t('Finished with an error.');
     }
-    drupal_set_message($message);
+    $messenger->addMessage($message);
   }
 
 }

--- a/modules/custom/openy_campaign/src/Plugin/Block/CampaignActivityStatisticsBlock.php
+++ b/modules/custom/openy_campaign/src/Plugin/Block/CampaignActivityStatisticsBlock.php
@@ -113,6 +113,8 @@ class CampaignActivityStatisticsBlock extends BlockBase implements ContainerFact
    * {@inheritdoc}
    */
   public function build() {
+    $messenger = \Drupal::messenger();
+
     // The block is rendered for each user separately.
     // It should be invalidated when user tracks the activity.
     $block['#cache'] = [
@@ -165,7 +167,7 @@ class CampaignActivityStatisticsBlock extends BlockBase implements ContainerFact
     $end = $campaign->field_campaign_end_date->date;
 
     if (empty($start) || empty($end)) {
-      drupal_set_message('Start or End dates are not set for campaign.', 'error');
+      $messenger->addMessage('Start or End dates are not set for campaign.', 'error');
       return [
         'message' => [
           '#markup' => '[ Placeholder for Activity Tracking block ]',

--- a/modules/custom/openy_group_schedules/modules/groupex_form_cache/src/Form/GroupexFormCacheForm.php
+++ b/modules/custom/openy_group_schedules/modules/groupex_form_cache/src/Form/GroupexFormCacheForm.php
@@ -27,18 +27,19 @@ class GroupexFormCacheForm extends ContentEntityForm {
    * {@inheritdoc}
    */
   public function save(array $form, FormStateInterface $form_state) {
+    $messenger = \Drupal::messenger();
     $entity = $this->entity;
     $status = parent::save($form, $form_state);
 
     switch ($status) {
       case SAVED_NEW:
-        drupal_set_message($this->t('Created the %label GroupEx Pro Form Cache.', [
+        $messenger->addMessage($this->t('Created the %label GroupEx Pro Form Cache.', [
           '%label' => $entity->label(),
         ]));
         break;
 
       default:
-        drupal_set_message($this->t('Saved the %label GroupEx Pro Form Cache.', [
+        $messenger->addMessage($this->t('Saved the %label GroupEx Pro Form Cache.', [
           '%label' => $entity->label(),
         ]));
     }

--- a/modules/custom/openy_group_schedules/src/Form/GroupexFormBase.php
+++ b/modules/custom/openy_group_schedules/src/Form/GroupexFormBase.php
@@ -170,6 +170,8 @@ abstract class GroupexFormBase extends FormBase {
    *   Redirect parameters.
    */
   protected function getRedirectParams(array $form, FormStateInterface $form_state) {
+    $messenger = \Drupal::messenger();
+
     $params = [
       'location' => array_filter($form_state->getValue('location')),
       'class' => $form_state->getValue('class_name'),
@@ -191,7 +193,7 @@ abstract class GroupexFormBase extends FormBase {
     // Toggle filter_length if user has selected more than 1 location and week period.
     if ($params['filter_length'] == 'week' && count($params['location']) > 1) {
       $params['filter_length'] = 'day';
-      drupal_set_message(t('Search results across multiple locations are limited to a single day.'), 'warning');
+      $messenger->addMessage(t('Search results across multiple locations are limited to a single day.'), 'warning');
     }
 
     return $params;

--- a/modules/custom/openy_mappings/src/Form/MappingForm.php
+++ b/modules/custom/openy_mappings/src/Form/MappingForm.php
@@ -27,18 +27,19 @@ class MappingForm extends ContentEntityForm {
    * {@inheritdoc}
    */
   public function save(array $form, FormStateInterface $form_state) {
+    $messenger = \Drupal::messenger();
     $entity = $this->entity;
     $status = parent::save($form, $form_state);
 
     switch ($status) {
       case SAVED_NEW:
-        drupal_set_message($this->t('Created the %label Mapping.', [
+        $messenger->addMessage($this->t('Created the %label Mapping.', [
           '%label' => $entity->label(),
         ]));
         break;
 
       default:
-        drupal_set_message($this->t('Saved the %label Mapping.', [
+        $messenger->addMessage($this->t('Saved the %label Mapping.', [
           '%label' => $entity->label(),
         ]));
     }

--- a/modules/custom/openy_mappings/src/Form/MappingTypeDeleteForm.php
+++ b/modules/custom/openy_mappings/src/Form/MappingTypeDeleteForm.php
@@ -36,9 +36,10 @@ class MappingTypeDeleteForm extends EntityConfirmFormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
+    $messenger = \Drupal::messenger();
     $this->entity->delete();
 
-    drupal_set_message(
+    $messenger->addMessage(
       $this->t('content @type: deleted @label.',
         [
           '@type' => $this->entity->bundle(),

--- a/modules/custom/openy_mappings/src/Form/MappingTypeForm.php
+++ b/modules/custom/openy_mappings/src/Form/MappingTypeForm.php
@@ -46,18 +46,19 @@ class MappingTypeForm extends EntityForm {
    * {@inheritdoc}
    */
   public function save(array $form, FormStateInterface $form_state) {
+    $messenger = \Drupal::messenger();
     $mapping_type = $this->entity;
     $status = $mapping_type->save();
 
     switch ($status) {
       case SAVED_NEW:
-        drupal_set_message($this->t('Created the %label Mapping type.', [
+        $messenger->addMessage($this->t('Created the %label Mapping type.', [
           '%label' => $mapping_type->label(),
         ]));
         break;
 
       default:
-        drupal_set_message($this->t('Saved the %label Mapping type.', [
+        $messenger->addMessage($this->t('Saved the %label Mapping type.', [
           '%label' => $mapping_type->label(),
         ]));
     }

--- a/modules/custom/openy_redirect/openy_redirect.module
+++ b/modules/custom/openy_redirect/openy_redirect.module
@@ -37,7 +37,7 @@ function openy_redirect_entity_base_field_info(EntityTypeInterface $entity_type)
  * Implements hook_form_FORM_ID_alter() for node_form().
  */
 function openy_redirect_form_node_form_alter(&$form, FormStateInterface $form_state) {
-  
+
   $node = \Drupal::routeMatch()->getParameter('node');
   // Create the group for the redirect fields.
   $form['redirect_settings'] = [
@@ -51,17 +51,17 @@ function openy_redirect_form_node_form_alter(&$form, FormStateInterface $form_st
 
   // Add custom submit to create redirects.
   $form['actions']['submit']['#submit'][] = 'openy_redirect_submit';
-  
+
   if ($node instanceof \Drupal\node\NodeInterface) {
     $language = $node->language()->getId();
-    
+
 
     // Set default values.
     $nid = $node->id();
     $redirect_url = 'internal:/' . $node->toUrl()->getInternalPath();
 
     $redirects = openy_redirect_load_redirects_by_redirect_uri($redirect_url, $language);
-    
+
     $i = 0;
     /** @var Redirect $item */
     foreach ($redirects as $item) {
@@ -91,11 +91,12 @@ function openy_redirect_form_node_form_alter(&$form, FormStateInterface $form_st
  * Custom submit to create redirects.
  */
 function openy_redirect_submit($form, FormStateInterface $form_state) {
+  $messenger = \Drupal::messenger();
   $node = \Drupal::routeMatch()->getParameter('node');
   $language = Language::LANGCODE_NOT_SPECIFIED;
   if ($node instanceof \Drupal\node\NodeInterface) {
     $language = $node->language()->getId();
-  } 
+  }
   else {
     $nid = $form_state->getStorage()['nid'];
     $node_storage = \Drupal::entityManager()->getStorage('node');
@@ -106,7 +107,7 @@ function openy_redirect_submit($form, FormStateInterface $form_state) {
   }
 
   $redirectSources = $form_state->getValue('redirect');
-  
+
   $node_url = $node->toUrl()->getInternalPath();
   $redirect_url = 'internal:/' . $node_url;
   // Delete all redirects for this node to save it from scratch later.
@@ -133,7 +134,7 @@ function openy_redirect_submit($form, FormStateInterface $form_state) {
       $redirect->setStatusCode(\Drupal::config('redirect.settings')->get('default_status_code'));
       $redirect->save();
     } else {
-      drupal_set_message(t('Redirect for "@source" already exists', ['@source' => $item['value']]));
+      $messenger->addMessage(t('Redirect for "@source" already exists', ['@source' => $item['value']]));
     }
   }
 }

--- a/modules/custom/openy_repeat/src/Batch/RepeatActualizeBatch.php
+++ b/modules/custom/openy_repeat/src/Batch/RepeatActualizeBatch.php
@@ -48,9 +48,11 @@ class RepeatActualizeBatch {
      *   If $success is FALSE, contains the operations that remained unprocessed.
      */
     public static function finished($success, $results, $operations) {
+      $messenger = \Drupal::messenger();
+
         if ($success) {
             $message = t('@count sessions were processed.', ['@count' => count($results)]);
-            drupal_set_message($message);
+          $messenger->addMessage($message);
         }
         else {
             // An error occurred.
@@ -60,7 +62,7 @@ class RepeatActualizeBatch {
                     '%error_operation' => $error_operation[0],
                     '@arguments' => print_r($error_operation[1], TRUE)
                 ));
-            drupal_set_message($message, 'error');
+          $messenger->addMessage($message, 'error');
         }
     }
 

--- a/modules/custom/openy_session_instance/src/Batch/SessionInstanceActualizeBatch.php
+++ b/modules/custom/openy_session_instance/src/Batch/SessionInstanceActualizeBatch.php
@@ -48,9 +48,11 @@ class SessionInstanceActualizeBatch {
    *   If $success is FALSE, contains the operations that remained unprocessed.
    */
   public static function finished($success, $results, $operations) {
+    $messenger = \Drupal::messenger();
+
     if ($success) {
       $message = t('@count sessions were processed.', ['@count' => count($results)]);
-      drupal_set_message($message);
+      $messenger->addMessage($message);
     }
     else {
       // An error occurred.
@@ -60,7 +62,7 @@ class SessionInstanceActualizeBatch {
           '%error_operation' => $error_operation[0],
           '@arguments' => print_r($error_operation[1], TRUE)
         ));
-      drupal_set_message($message, 'error');
+      $messenger->addMessage($message, 'error');
     }
   }
 

--- a/modules/custom/openy_session_instance/src/Form/SessionInstanceForm.php
+++ b/modules/custom/openy_session_instance/src/Form/SessionInstanceForm.php
@@ -28,19 +28,20 @@ class SessionInstanceForm extends ContentEntityForm {
    * {@inheritdoc}
    */
   public function save(array $form, FormStateInterface $form_state) {
+    $messenger = \Drupal::messenger();
     $entity = &$this->entity;
 
     $status = parent::save($form, $form_state);
 
     switch ($status) {
       case SAVED_NEW:
-        drupal_set_message($this->t('Created the %label Session Instance.', [
+        $messenger->addMessage($this->t('Created the %label Session Instance.', [
           '%label' => $entity->label(),
         ]));
         break;
 
       default:
-        drupal_set_message($this->t('Saved the %label Session Instance.', [
+        $messenger->addMessage($this->t('Saved the %label Session Instance.', [
           '%label' => $entity->label(),
         ]));
     }

--- a/modules/custom/openy_system/src/Form/OpenyModulesListForm.php
+++ b/modules/custom/openy_system/src/Form/OpenyModulesListForm.php
@@ -127,6 +127,7 @@ class OpenyModulesListForm extends ModulesListForm {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
+    $messenger = \Drupal::messenger();
     $packages = $this->getPackages();
     $modules_to_install = [];
     $packages_to_install = [];
@@ -149,13 +150,13 @@ class OpenyModulesListForm extends ModulesListForm {
     if (!empty($modules_to_install)) {
       try {
         $this->moduleInstaller->install($modules_to_install);
-        drupal_set_message($this->formatPlural(count($packages_to_install), 'Package %name has been enabled.', '@count packages have been enabled: %names.', [
+        $messenger->addMessage($this->formatPlural(count($packages_to_install), 'Package %name has been enabled.', '@count packages have been enabled: %names.', [
           '%name' => $packages_to_install[0],
           '%names' => implode(', ', $packages_to_install),
         ]));
       } catch (PreExistingConfigException $e) {
         $config_objects = $e->flattenConfigObjects($e->getConfigObjects());
-        drupal_set_message(
+        $messenger->addMessage(
           $this->formatPlural(
             count($config_objects),
             'Unable to install @extension, %config_names already exists in active configuration.',
@@ -168,7 +169,7 @@ class OpenyModulesListForm extends ModulesListForm {
         );
         return;
       } catch (UnmetDependenciesException $e) {
-        drupal_set_message(
+        $messenger->addMessage(
           $e->getTranslatedMessage($this->getStringTranslation(), $modules_to_install[$e->getExtension()]),
           'error'
         );

--- a/modules/custom/openy_system/src/Form/OpenyModulesUninstallConfirmForm.php
+++ b/modules/custom/openy_system/src/Form/OpenyModulesUninstallConfirmForm.php
@@ -36,10 +36,11 @@ class OpenyModulesUninstallConfirmForm extends ModulesUninstallConfirmForm {
     $account = $this->currentUser()->id();
     $this->modules = $this->keyValueExpirable->get($account);
     $packages = $this->keyValueExpirable->get($account . '_packages');
+    $messenger = \Drupal::messenger();
 
     // Prevent this page from showing when the packages list is empty.
     if (empty($packages)) {
-      drupal_set_message($this->t('The selected packages could not be uninstalled, either due to a website problem or due to the uninstall confirmation form timing out. Please try again.'), 'error');
+      $messenger->addMessage($this->t('The selected packages could not be uninstalled, either due to a website problem or due to the uninstall confirmation form timing out. Please try again.'), 'error');
       return $this->redirect('openy_system.modules_uninstall');
     }
 
@@ -59,13 +60,14 @@ class OpenyModulesUninstallConfirmForm extends ModulesUninstallConfirmForm {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
+    $messenger = \Drupal::messenger();
     // Clear the key value store entry.
     $account = $this->currentUser()->id();
     $this->keyValueExpirable->delete($account);
     $this->keyValueExpirable->delete($account. '_packages');
     // Uninstall the modules.
     $this->moduleInstaller->uninstall($this->modules);
-    drupal_set_message($this->t('The selected packages have been uninstalled.'));
+    $messenger->addMessage($this->t('The selected packages have been uninstalled.'));
     // Set redirect to project uninstall page
     $form_state->setRedirect('openy_system.modules_uninstall');
   }

--- a/modules/custom/openy_upgrade_tool/src/Form/OpenyUpgradeLogDiff.php
+++ b/modules/custom/openy_upgrade_tool/src/Form/OpenyUpgradeLogDiff.php
@@ -331,8 +331,9 @@ class OpenyUpgradeLogDiff extends FormBase {
    * Set status TRUE to selected logger entity (conflict resolved).
    */
   public function applyCurrentActiveVersion(array &$form, FormStateInterface $form_state) {
+    $messenger = \Drupal::messenger();
     $this->entity->applyCurrentActiveVersion();
-    drupal_set_message($this->t('Conflict resolved for "@name" config, confirmed current config version from active storage and left unchanged.', [
+    $messenger->addMessage($this->t('Conflict resolved for "@name" config, confirmed current config version from active storage and left unchanged.', [
       '@name' => $this->entity->getName(),
     ]));
   }

--- a/modules/custom/openy_upgrade_tool/src/Form/OpenyUpgradeLogForm.php
+++ b/modules/custom/openy_upgrade_tool/src/Form/OpenyUpgradeLogForm.php
@@ -74,6 +74,7 @@ class OpenyUpgradeLogForm extends ContentEntityForm {
    * {@inheritdoc}
    */
   public function save(array $form, FormStateInterface $form_state) {
+    $messenger = \Drupal::messenger();
     $entity = $this->entity;
 
     // Save as a new revision if requested to do so.
@@ -92,13 +93,13 @@ class OpenyUpgradeLogForm extends ContentEntityForm {
 
     switch ($status) {
       case SAVED_NEW:
-        drupal_set_message($this->t('Created the %label Openy upgrade log.', [
+        $messenger->addMessage($this->t('Created the %label Openy upgrade log.', [
           '%label' => $entity->label(),
         ]));
         break;
 
       default:
-        drupal_set_message($this->t('Saved the %label Openy upgrade log.', [
+        $messenger->addMessage($this->t('Saved the %label Openy upgrade log.', [
           '%label' => $entity->label(),
         ]));
     }

--- a/modules/custom/openy_upgrade_tool/src/Form/OpenyUpgradeLogRevisionDeleteForm.php
+++ b/modules/custom/openy_upgrade_tool/src/Form/OpenyUpgradeLogRevisionDeleteForm.php
@@ -104,10 +104,11 @@ class OpenyUpgradeLogRevisionDeleteForm extends ConfirmFormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
+    $messenger = \Drupal::messenger();
     $this->OpenyUpgradeLogStorage->deleteRevision($this->revision->getRevisionId());
 
     $this->logger('content')->notice('Openy upgrade log: deleted %title revision %revision.', ['%title' => $this->revision->label(), '%revision' => $this->revision->getRevisionId()]);
-    drupal_set_message(t('Revision from %revision-date of Openy upgrade log %title has been deleted.', ['%revision-date' => format_date($this->revision->getRevisionCreationTime()), '%title' => $this->revision->label()]));
+    $messenger->addMessage(t('Revision from %revision-date of Openy upgrade log %title has been deleted.', ['%revision-date' => format_date($this->revision->getRevisionCreationTime()), '%title' => $this->revision->label()]));
     $form_state->setRedirect(
       'entity.openy_upgrade_log.canonical',
        ['openy_upgrade_log' => $this->revision->id()]

--- a/modules/custom/openy_upgrade_tool/src/Form/OpenyUpgradeLogRevisionRevertForm.php
+++ b/modules/custom/openy_upgrade_tool/src/Form/OpenyUpgradeLogRevisionRevertForm.php
@@ -111,6 +111,7 @@ class OpenyUpgradeLogRevisionRevertForm extends ConfirmFormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
+    $messenger = \Drupal::messenger();
     // The revision timestamp will be updated when the revision is saved. Keep
     // the original one for the confirmation message.
     $original_revision_timestamp = $this->revision->getRevisionCreationTime();
@@ -120,7 +121,7 @@ class OpenyUpgradeLogRevisionRevertForm extends ConfirmFormBase {
     $this->revision->save();
 
     $this->logger('content')->notice('Openy upgrade log: reverted %title revision %revision.', ['%title' => $this->revision->label(), '%revision' => $this->revision->getRevisionId()]);
-    drupal_set_message(t('Openy upgrade log %title has been reverted to the revision from %revision-date.', ['%title' => $this->revision->label(), '%revision-date' => $this->dateFormatter->format($original_revision_timestamp)]));
+    $messenger->addMessage(t('Openy upgrade log %title has been reverted to the revision from %revision-date.', ['%title' => $this->revision->label(), '%revision-date' => $this->dateFormatter->format($original_revision_timestamp)]));
     $form_state->setRedirect(
       'entity.openy_upgrade_log.version_history',
       ['openy_upgrade_log' => $this->revision->id()]

--- a/modules/openy_features/openy_demo_content/modules/openy_demo_ncampaign/src/Form/GenerateContentForm.php
+++ b/modules/openy_features/openy_demo_content/modules/openy_demo_ncampaign/src/Form/GenerateContentForm.php
@@ -39,10 +39,12 @@ class GenerateContentForm extends FormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
+    $messenger = \Drupal::messenger();
+
     module_load_include('inc', 'openy_demo_ncampaign', 'includes/openy_demo_ncampaign.members');
     _openy_demo_ncampaign_members_create($form_state->getValue('options'));
 
-    drupal_set_message($this->t('Members generated'));
+    $messenger->addMessage($this->t('Members generated'));
   }
 
 }

--- a/modules/openy_features/openy_node/src/BatchNodeUpdate.php
+++ b/modules/openy_features/openy_node/src/BatchNodeUpdate.php
@@ -65,6 +65,8 @@ class BatchNodeUpdate {
    *   If $success is FALSE, contains the operations that remained unprocessed.
    */
   public static function finished($success, $results, $operations) {
+    $messenger = \Drupal::messenger();
+
     if ($success) {
       if ($results['status']) {
         $status = 'published';
@@ -83,6 +85,6 @@ class BatchNodeUpdate {
     } else {
       $message = t('There was an error updating @type.', ['@type' => $results['type']]);
     }
-    drupal_set_message($message);
+    $messenger->addMessage($message);
   }
 }

--- a/openy.install
+++ b/openy.install
@@ -737,11 +737,12 @@ function openy_update_8049() {
  * Enable font-your-face module.
  */
 function openy_update_8050() {
+  $messenger = \Drupal::messenger();
   \Drupal::service('module_installer')->install(['fontyourface']);
   if (\Drupal::service('module_handler')->moduleExists('openy_font')) {
     $message = 'Open Y Font module was replaced in favor of <a href="https://www.drupal.org/project/fontyourface">FontYourFace</a> module.
         Please, <a href="/admin/appearance/font/local_font_config_entity">use it</a> to add purchased fonts to the site and uninstall Open Y Font module.';
-    drupal_set_message($message, 'warning');
+    $messenger->addMessage($message, 'warning');
   }
 }
 
@@ -869,11 +870,12 @@ function openy_update_8057() {
   $query->condition('par.type', 'lto');
   $query->addField('n', 'nid');
   $resultField = $query->execute()->fetchField();
+  $messenger = \Drupal::messenger();
   if ($resultField) {
     $message = t('Visit <a href="/node/' . $resultField . '/edit">Locations edit page</a> and
       delete "Search by Amenities" Limited Time Offer paragraph in Header area.
       With Sidebar "Amenities" filter it became redundant.');
-    drupal_set_message($message, 'warning');
+    $messenger->addMessage($message, 'warning');
   }
 }
 

--- a/src/Form/ThirdPartyServicesForm.php
+++ b/src/Form/ThirdPartyServicesForm.php
@@ -284,6 +284,7 @@ class ThirdPartyServicesForm extends FormBase {
    *   Whether the files were saved.
    */
   public function saveSnippets() {
+    $messenger = \Drupal::messenger();
     // Save the altered snippets after hook_google_tag_snippets_alter().
     module_load_include('inc', 'google_tag', 'includes/snippet');
     $result = TRUE;
@@ -293,10 +294,10 @@ class ThirdPartyServicesForm extends FormBase {
       $result = !$path ? FALSE : $result;
     }
     if (!$result) {
-      drupal_set_message(t('An error occurred saving one or more snippet files. Please try again or contact the site administrator if it persists.'));
+      $messenger->addMessage(t('An error occurred saving one or more snippet files. Please try again or contact the site administrator if it persists.'));
     }
     else {
-      drupal_set_message(t('Created three snippet files based on configuration.'));
+      $messenger->addMessage(t('Created three snippet files based on configuration.'));
       $this->collectionOptimizer->deleteAll();
       _drupal_flush_css_js();
     }


### PR DESCRIPTION
### How to review:
- [ ] Make sure that there are no errors about deprecated function `drupal_set_message()`

## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer. See [Code of Conduct](https://github.com/ymcatwincities/openy/wiki/Open-Y-Code-of-Conduct-and-Best-Practices).
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
