### PR TITLE
[RGTC-1105] Replace deprecated method url()

### DIFF
--- a/modules/custom/openy_campaign/openy_campaign.module
+++ b/modules/custom/openy_campaign/openy_campaign.module
@@ -789,7 +789,7 @@ function openy_campaign_field_widget_form_alter(&$element, FormStateInterface $f
     $message = t($templateString, [
       '@publish_on' => $publishOn,
       '@unpublish_on' => $unpublishOn,
-    ]) . ' <a href="' . $node->url('edit-form') . '">' . t('Edit page') . '</a>';
+    ]) . ' <a href="' . $node->toUrl('edit-form') . '">' . t('Edit page') . '</a>';
 
     $element['#suffix'] = '<div class="publishing-dates">' . $message . '</div>';
   }
@@ -1015,7 +1015,7 @@ function openy_campaign_campaign_menu_field_render(&$form, FormStateInterface $f
 
       $menuBlock['links'][$row]['actions'] = [
         '#markup' => !empty($page)
-          ? '<a href="' . $page->url('edit-form') . '">' . t('Edit') . '</a>'
+          ? '<a href="' . $page->toUrl('edit-form') . '">' . t('Edit') . '</a>'
           : '',
       ];
 

--- a/modules/custom/openy_font/openy_font.module
+++ b/modules/custom/openy_font/openy_font.module
@@ -76,7 +76,7 @@ function openy_font_page_attachments(&$page) {
   $bold_settings = $config->get('cachet_bold');
   if (!empty($bold_settings)) {
     $bold = \Drupal\file\Entity\File::load(reset($bold_settings))
-      ->url('canonical');
+      ->toUrl('canonical');
     $css .= "
         @font-face {
           font-family: Cachet Bold;
@@ -87,7 +87,7 @@ function openy_font_page_attachments(&$page) {
   $book_settings = $config->get('cachet_book');
   if (!empty($book_settings)) {
     $book = \Drupal\file\Entity\File::load(reset($book_settings))
-      ->url('canonical');
+      ->toUrl('canonical');
     $css .= "
         @font-face {
           font-family: Cachet W01 Book;
@@ -98,7 +98,7 @@ function openy_font_page_attachments(&$page) {
   $medium_settings = $config->get('cachet_medium');
   if (!empty($medium_settings)) {
     $medium = \Drupal\file\Entity\File::load(reset($medium_settings))
-      ->url('canonical');
+      ->toUrl('canonical');
     $css .= "
         @font-face {
           font-family: Cachet Medium;

--- a/themes/openy_themes/openy_lily/openy_lily.theme
+++ b/themes/openy_themes/openy_lily/openy_lily.theme
@@ -301,7 +301,7 @@ function openy_lily_page_attachments_alter(array &$page) {
   }
 
   // Get Camp section favicon & mime type.
-  $favicon = $file->url();
+  $favicon = $file->toUrl();
   $type = $file->getMimeType();
 
   // Attach favicon.

--- a/themes/openy_themes/openy_rose/openy_rose.theme
+++ b/themes/openy_themes/openy_rose/openy_rose.theme
@@ -310,7 +310,7 @@ function openy_rose_page_attachments_alter(array &$page) {
   }
 
   // Get Camp section favicon & mime type.
-  $favicon = $file->url();
+  $favicon = $file->toUrl();
   $type = $file->getMimeType();
 
   // Attach favicon.


### PR DESCRIPTION
### How to review:
- [ ] Make sure that deprecated method `url()` is replaced on `toUrl()`

## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer. See [Code of Conduct](https://github.com/ymcatwincities/openy/wiki/Open-Y-Code-of-Conduct-and-Best-Practices).
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
