### PR TITLE
[RGTC-1109] Fix call to deprecated constant REQUEST_TIME

### DIFF
--- a/modules/custom/openy_field_hours/modules/openy_field_holiday_hours/src/Plugin/Field/FieldFormatter/HolidayHoursFormatter.php
+++ b/modules/custom/openy_field_hours/modules/openy_field_holiday_hours/src/Plugin/Field/FieldFormatter/HolidayHoursFormatter.php
@@ -112,8 +112,8 @@ class HolidayHoursFormatter extends FormatterBase implements ContainerFactoryPlu
       }
 
       $holiday_timestamp = $values['date'];
-
-      if (REQUEST_TIME < ($holiday_timestamp + $show_after_offset) && ($holiday_timestamp - REQUEST_TIME) <= $show_before_offset) {
+      $request_time = \Drupal::time()->getRequestTime();
+      if ($request_time < ($holiday_timestamp + $show_after_offset) && ($holiday_timestamp - $request_time) <= $show_before_offset) {
         $title = Html::escape($values['holiday']);
         $rows[] = [
           'data' => [

--- a/modules/custom/openy_group_schedules/modules/groupex_form_cache/src/GroupexFormCacheWarmer.php
+++ b/modules/custom/openy_group_schedules/modules/groupex_form_cache/src/GroupexFormCacheWarmer.php
@@ -165,9 +165,10 @@ class GroupexFormCacheWarmer implements OpenyCronServiceInterface {
    *   TRUE if cache entity is valid.
    */
   private function isValid(GroupexFormCacheInterface $entity) {
+    $request_time = \Drupal::time()->getRequestTime();
     $options = unserialize($entity->field_gfc_options->value);
     if (array_key_exists('start', $options['query']) && array_key_exists('end', $options['query'])) {
-      if (REQUEST_TIME >= $options['end']) {
+      if ($request_time >= $options['end']) {
         return FALSE;
       }
     }
@@ -188,9 +189,10 @@ class GroupexFormCacheWarmer implements OpenyCronServiceInterface {
     if (!$created = $entity->field_gfc_created->value) {
       return TRUE;
     }
+    $request_time = \Drupal::time()->getRequestTime();
 
     $config = $this->configFactory->get('groupex_form_cache.settings');
-    if ((REQUEST_TIME - $created) > $config->get('cache_warmup_interval')) {
+    if (($request_time - $created) > $config->get('cache_warmup_interval')) {
       return TRUE;
     }
 

--- a/modules/custom/openy_group_schedules/src/Form/GroupexFormBase.php
+++ b/modules/custom/openy_group_schedules/src/Form/GroupexFormBase.php
@@ -50,6 +50,7 @@ abstract class GroupexFormBase extends FormBase {
     $timezone = new \DateTimeZone($this->config('system.date')->get('timezone')['default']);
     $conf = $this->configFactory->get('openy_group_schedules.settings');
     $max_age = is_numeric($conf->get('cache_max_age')) ? $conf->get('cache_max_age') : 3600;
+    $request_time = \Drupal::time()->getRequestTime();
 
     // Check if we have additional argument to prepopulate the form.
     $refine = FALSE;
@@ -107,7 +108,7 @@ abstract class GroupexFormBase extends FormBase {
       '#title' => $this->t('View Day or Week'),
     ];
 
-    $filter_date_default = DrupalDateTime::createFromTimestamp(REQUEST_TIME, $timezone);
+    $filter_date_default = DrupalDateTime::createFromTimestamp($request_time, $timezone);
     if ($refine && !empty($params['filter_date'])) {
       $date = DrupalDateTime::createFromFormat(
         self::$dateFilterFormat,

--- a/modules/custom/openy_group_schedules/src/Form/GroupexFormFull.php
+++ b/modules/custom/openy_group_schedules/src/Form/GroupexFormFull.php
@@ -158,6 +158,7 @@ class GroupexFormFull extends GroupexFormBase {
     $conf = $this->configFactory->get('openy_group_schedules.settings');
     $max_age = is_numeric($conf->get('cache_max_age')) ? $conf->get('cache_max_age') : 3600;
     $instructors_options = [];
+    $request_time = \Drupal::time()->getRequestTime();
 
     // Get location options.
     $this->locationOptions = $this->getOptions($this->request(['query' => ['locations' => TRUE]]), 'id', 'name');
@@ -284,7 +285,7 @@ class GroupexFormFull extends GroupexFormBase {
     else {
       $dt = new \DateTime();
       $dt->setTimezone($tz);
-      $dt->setTimestamp(REQUEST_TIME);
+      $dt->setTimestamp($request_time);
       $default_date = $dt->format('Y-m-d');
     }
 
@@ -451,7 +452,7 @@ class GroupexFormFull extends GroupexFormBase {
       ];
     }
 
-    $filter_date_default = date('n/d/y', REQUEST_TIME);
+    $filter_date_default = date('n/d/y', $request_time);
     $form['date'] = [
       '#type' => 'hidden',
       '#default_value' => $filter_date_default,

--- a/modules/custom/openy_group_schedules/src/GroupexScheduleFetcher.php
+++ b/modules/custom/openy_group_schedules/src/GroupexScheduleFetcher.php
@@ -127,14 +127,14 @@ class GroupexScheduleFetcher {
     if ($this->schedule) {
       return $this->schedule;
     }
-
+    $request_time = \Drupal::time()->getRequestTime();
     $conf = $this->configFactory->get('openy_group_schedules.settings');
     $days_range = is_numeric($conf->get('days_range')) ? $conf->get('days_range') : 14;
 
     $filter_date = DrupalDateTime::createFromTimestamp($this->parameters['filter_timestamp'], $this->timezone);
-    $current_date = DrupalDateTime::createFromTimestamp(REQUEST_TIME, $this->timezone)->format(GroupexRequestTrait::$dateFilterFormat);
+    $current_date = DrupalDateTime::createFromTimestamp($request_time, $this->timezone)->format(GroupexRequestTrait::$dateFilterFormat);
     // Define end date of shown items as 2 weeks.
-    $end_date = DrupalDateTime::createFromTimestamp(REQUEST_TIME + 86400 * $days_range, $this->timezone);
+    $end_date = DrupalDateTime::createFromTimestamp($request_time + 86400 * $days_range, $this->timezone);
 
     // Prepare classes items.
     $items = [];
@@ -560,11 +560,12 @@ class GroupexScheduleFetcher {
   public static function normalizeParameters(array $parameters) {
     $normalized = $parameters;
 
+    $request_time = \Drupal::time()->getRequestTime();
     $timezone = new \DateTimeZone(\Drupal::config('system.date')->get('timezone')['default']);
 
     // The old site has a habit to provide empty filter_date. Fix it here.
     if (empty($normalized['filter_date'])) {
-      $date = DrupalDateTime::createFromTimestamp(REQUEST_TIME, $timezone);
+      $date = DrupalDateTime::createFromTimestamp($request_time, $timezone);
       $normalized['filter_date'] = $date->format(self::$dateFilterFormat);
     }
 
@@ -581,7 +582,7 @@ class GroupexScheduleFetcher {
       $timestamp += $offset;
     }
     else {
-      $date = DrupalDateTime::createFromTimestamp(REQUEST_TIME, $timezone);
+      $date = DrupalDateTime::createFromTimestamp($request_time, $timezone);
       $timestamp = $date->format('U');
     }
 

--- a/modules/custom/openy_hours_formatter/src/HoursToday.php
+++ b/modules/custom/openy_hours_formatter/src/HoursToday.php
@@ -16,6 +16,7 @@ class HoursToday {
    *   Renderable array of today hours.
    */
   public function generateHoursToday() {
+    $request_time = \Drupal::time()->getRequestTime();
     $hours = func_get_args();
     $days = [
       'Monday',
@@ -27,7 +28,7 @@ class HoursToday {
       'Sunday',
     ];
     $timezone = new \DateTimeZone(\Drupal::config('system.date')->get('timezone')['default']);
-    $date = DrupalDateTime::createFromTimestamp(REQUEST_TIME, $timezone);
+    $date = DrupalDateTime::createFromTimestamp($request_time, $timezone);
     $today = $date->format('l');
 
     return [

--- a/modules/custom/openy_myy/modules/myy_personify/src/Plugin/MyYAuthenticator/PersonifyAuthenticator.php
+++ b/modules/custom/openy_myy/modules/myy_personify/src/Plugin/MyYAuthenticator/PersonifyAuthenticator.php
@@ -142,6 +142,7 @@ class PersonifyAuthenticator extends PluginBase implements MyYAuthenticatorInter
    */
   public function authPage() {
 
+    $request_time = \Drupal::time()->getRequestTime();
     $query = $this->request->query->all();
     if (isset($query['ct']) && !empty($query['ct'])) {
       $decrypted_token = $this->personifySSO->decryptCustomerToken($query['ct']);
@@ -149,7 +150,7 @@ class PersonifyAuthenticator extends PluginBase implements MyYAuthenticatorInter
       if ($token = $this->personifySSO->validateCustomerToken($decrypted_token)) {
         user_cookie_save([
           'personify_authorized' => $token,
-          'personify_time' => REQUEST_TIME,
+          'personify_time' => $request_time,
         ]);
 
         $this->logger->info('A user logged in via Personify.');

--- a/modules/custom/openy_myy/modules/ymca_personify/src/Controller/PersonifyController.php
+++ b/modules/custom/openy_myy/modules/ymca_personify/src/Controller/PersonifyController.php
@@ -116,6 +116,7 @@ class PersonifyController extends ControllerBase {
    * Auth page.
    */
   public function authPage() {
+    $request_time = \Drupal::time()->getRequestTime();
     $query = \Drupal::request()->query->all();
     if (isset($query['ct']) && !empty($query['ct'])) {
       $this->config = \Drupal::config('ymca_personify.settings')->getRawData();
@@ -126,7 +127,7 @@ class PersonifyController extends ControllerBase {
       if ($token = $this->sso->validateCustomerToken($decrypted_token)) {
         user_cookie_save([
           'personify_authorized' => $token,
-          'personify_time' => REQUEST_TIME,
+          'personify_time' => $request_time,
           'personify_id' => $id
         ]);
         \Drupal::logger('ymca_personify')->info('A user logged in via Personify.');

--- a/modules/custom/openy_myy/modules/ymca_personify/src/EventSubscriber/TokenChecker.php
+++ b/modules/custom/openy_myy/modules/ymca_personify/src/EventSubscriber/TokenChecker.php
@@ -29,6 +29,7 @@ class TokenChecker implements EventSubscriberInterface {
    *   Event.
    */
   public function checkToken(GetResponseEvent $event) {
+    $request_time = \Drupal::time()->getRequestTime();
     $container = \Drupal::getContainer();
 
     /** @var Request $request */
@@ -43,7 +44,7 @@ class TokenChecker implements EventSubscriberInterface {
     }
 
     // Do not check on every request.
-    if (!empty($time) && (REQUEST_TIME - $time) < self::CHECK_TIME) {
+    if (!empty($time) && ($request_time - $time) < self::CHECK_TIME) {
       return;
     }
 
@@ -71,7 +72,7 @@ class TokenChecker implements EventSubscriberInterface {
     if ($token = $sso->validateCustomerToken($token)) {
       user_cookie_save([
         'personify_authorized' => $token,
-        'personify_time' => REQUEST_TIME,
+        'personify_time' => $request_time,
       ]);
     }
     else {

--- a/modules/custom/openy_myy/src/Plugin/rest/resource/MyYProfileFamilyList.php
+++ b/modules/custom/openy_myy/src/Plugin/rest/resource/MyYProfileFamilyList.php
@@ -90,6 +90,7 @@ class MyYProfileFamilyList extends ResourceBase {
    */
   public function get() {
 
+    $request_time = \Drupal::time()->getRequestTime();
     $myy_config = $this->config->getRawData();
     $myy_authenticator_instances = $this->myYDataProfile->getDefinitions();
     if (array_key_exists($myy_config['myy_data_profile'], $myy_authenticator_instances)) {
@@ -104,7 +105,7 @@ class MyYProfileFamilyList extends ResourceBase {
           ->myYDataProfile
           ->createInstance($myy_config['myy_data_profile'])
           ->getFamilyInfo();
-        \Drupal::cache()->set($cid, $response, REQUEST_TIME + 3600);
+        \Drupal::cache()->set($cid, $response, $request_time + 3600);
       }
 
     } else {

--- a/modules/custom/openy_myy/src/Plugin/rest/resource/MyYProfileGuestPasses.php
+++ b/modules/custom/openy_myy/src/Plugin/rest/resource/MyYProfileGuestPasses.php
@@ -90,7 +90,7 @@ class MyYProfileGuestPasses extends ResourceBase {
    */
   public function get() {
 
-
+    $request_time = \Drupal::time()->getRequestTime();
     $myy_config = $this->config->getRawData();
     $myy_authenticator_instances = $this->myYDataProfile->getDefinitions();
     if (array_key_exists($myy_config['myy_data_profile'], $myy_authenticator_instances)) {
@@ -105,7 +105,7 @@ class MyYProfileGuestPasses extends ResourceBase {
           ->myYDataProfile
           ->createInstance($myy_config['myy_data_profile'])
           ->getGuestPasses();
-        \Drupal::cache()->set($cid, $response, REQUEST_TIME + 3600);
+        \Drupal::cache()->set($cid, $response, $request_time + 3600);
       }
 
     } else {

--- a/modules/custom/openy_myy/src/Plugin/rest/resource/MyYProfileMembershipInfo.php
+++ b/modules/custom/openy_myy/src/Plugin/rest/resource/MyYProfileMembershipInfo.php
@@ -90,6 +90,7 @@ class MyYProfileMembershipInfo extends ResourceBase {
    */
   public function get() {
 
+    $request_time = \Drupal::time()->getRequestTime();
     $myy_config = $this->config->getRawData();
     $myy_authenticator_instances = $this->myYDataProfile->getDefinitions();
     if (array_key_exists($myy_config['myy_data_profile'], $myy_authenticator_instances)) {
@@ -104,7 +105,7 @@ class MyYProfileMembershipInfo extends ResourceBase {
           ->myYDataProfile
           ->createInstance($myy_config['myy_data_profile'])
           ->getMembershipInfo();
-        \Drupal::cache()->set($cid, $response, REQUEST_TIME + 3600);
+        \Drupal::cache()->set($cid, $response, $request_time + 3600);
       }
 
     } else {

--- a/modules/custom/openy_socrates/src/OpenySocratesFacade.php
+++ b/modules/custom/openy_socrates/src/OpenySocratesFacade.php
@@ -115,6 +115,8 @@ class OpenySocratesFacade {
    * Runner for all openy cron services.
    */
   public function cron() {
+    $request_time = \Drupal::time()->getRequestTime();
+
     // @todo Use config to stop/resume the runner.
     $prefix = 'openy_cron_';
     /** @var OpenyCronServiceInterface $service */
@@ -122,13 +124,13 @@ class OpenySocratesFacade {
       foreach ($services as $service) {
         $name = $prefix . $service->_serviceId;
         $last_run = $this->state->get($name);
-        if ((REQUEST_TIME - $last_run) > $periodicity) {
+        if (($request_time - $last_run) > $periodicity) {
           // @todo Fix DI on OpenY sprint.
           \Drupal::logger("openy_cron")->info('Service %service has been started.', ['%service' => $service->_serviceId]);
           Timer::start($name);
           $service->runCronServices();
           $execution_time = Timer::read($name) / 1000;
-          $this->state->set($name, REQUEST_TIME);
+          $this->state->set($name, $request_time);
           \Drupal::logger("openy_cron")->info('Service %service has been finished. Execution time: %time sec.', ['%service' => $service->_serviceId, '%time' => $execution_time]);
           Timer::stop($name);
         }

--- a/modules/custom/openy_upgrade_tool/src/Form/OpenyUpgradeLogForm.php
+++ b/modules/custom/openy_upgrade_tool/src/Form/OpenyUpgradeLogForm.php
@@ -75,6 +75,7 @@ class OpenyUpgradeLogForm extends ContentEntityForm {
    */
   public function save(array $form, FormStateInterface $form_state) {
     $messenger = \Drupal::messenger();
+    $request_time = \Drupal::time()->getRequestTime();
     $entity = $this->entity;
 
     // Save as a new revision if requested to do so.
@@ -82,7 +83,7 @@ class OpenyUpgradeLogForm extends ContentEntityForm {
       $entity->setNewRevision();
 
       // If a new revision is created, save the current user as revision author.
-      $entity->setRevisionCreationTime(REQUEST_TIME);
+      $entity->setRevisionCreationTime($request_time);
       $entity->setRevisionUserId($this->accountProxy->id());
     }
     else {

--- a/modules/custom/openy_upgrade_tool/src/Form/OpenyUpgradeLogRevisionRevertForm.php
+++ b/modules/custom/openy_upgrade_tool/src/Form/OpenyUpgradeLogRevisionRevertForm.php
@@ -140,9 +140,10 @@ class OpenyUpgradeLogRevisionRevertForm extends ConfirmFormBase {
    *   The prepared revision ready to be stored.
    */
   protected function prepareRevertedRevision(OpenyUpgradeLogInterface $revision, FormStateInterface $form_state) {
+    $request_time = \Drupal::time()->getRequestTime();
     $revision->setNewRevision();
     $revision->isDefaultRevision();
-    $revision->setRevisionCreationTime(REQUEST_TIME);
+    $revision->setRevisionCreationTime($request_time);
 
     return $revision;
   }

--- a/modules/openy_features/openy_demo_content/modules/openy_demo_ncampaign/includes/openy_demo_ncampaign.members.inc
+++ b/modules/openy_features/openy_demo_content/modules/openy_demo_ncampaign/includes/openy_demo_ncampaign.members.inc
@@ -54,6 +54,7 @@ function _openy_demo_ncampaign_members_create($options) {
  * Helper function to create fake checkins.
  */
 function _openy_demo_ncampaign_checkins_create($member, $everyday = FALSE) {
+  $request_time = \Drupal::time()->getRequestTime();
   $count = rand(3, 8);
   $dates = _openy_demo_ncampaign_generate_random_dates($count, $everyday);
   if ($everyday) {
@@ -63,7 +64,7 @@ function _openy_demo_ncampaign_checkins_create($member, $everyday = FALSE) {
     $checkin = \Drupal::entityTypeManager()
       ->getStorage('openy_campaign_member_checkin')
       ->create([
-        'created' => REQUEST_TIME,
+        'created' => $request_time,
         'date' => $dates[$i]->getTimestamp(),
         'member' => $member->id(),
         'checkin' => TRUE,
@@ -76,13 +77,14 @@ function _openy_demo_ncampaign_checkins_create($member, $everyday = FALSE) {
  * Helper function to create fake bonuses.
  */
 function _openy_demo_ncampaign_bonuses_create($member) {
+  $request_time = \Drupal::time()->getRequestTime();
   $count = rand(3, 8);
   $dates = _openy_demo_ncampaign_generate_random_dates($count);
   for ($i = 0; $i < $count; $i++) {
     $bonus = \Drupal::entityTypeManager()
       ->getStorage('openy_campaign_member_bonus')
       ->create([
-        'created' => REQUEST_TIME,
+        'created' => $request_time,
         'date' => $dates[$i]->getTimestamp(),
         'member' => $member->id(),
         'bonus_code' => _openy_demo_ncampaign_generate_random_string(3),
@@ -95,6 +97,7 @@ function _openy_demo_ncampaign_bonuses_create($member) {
  * Helper function to create fake activities.
  */
 function _openy_demo_ncampaign_activities_create($member) {
+  $request_time = \Drupal::time()->getRequestTime();
   $activities_number = rand(20, 50);
 
   // Load activity terms.
@@ -113,7 +116,7 @@ function _openy_demo_ncampaign_activities_create($member) {
     }
 
     $activity = MemberActivity::create([
-      'timestamp' => REQUEST_TIME,
+      'timestamp' => $request_time,
       'member' => $member->id(),
       'activity_type' => $term->tid,
     ]);


### PR DESCRIPTION
### How to review:
- [ ] Make sure that there are no errors about deprecated constant `REQUEST_TIME`

## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer. See [Code of Conduct](https://github.com/ymcatwincities/openy/wiki/Open-Y-Code-of-Conduct-and-Best-Practices).
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
