### PR TITLE
[RGTC-1112] Fix call to deprecated method l()

### DIFF
--- a/modules/custom/logger_entity/src/LoggerEntityListBuilder.php
+++ b/modules/custom/logger_entity/src/LoggerEntityListBuilder.php
@@ -4,8 +4,8 @@ namespace Drupal\logger_entity;
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityListBuilder;
-use Drupal\Core\Routing\LinkGeneratorTrait;
 use Drupal\Core\Url;
+use Drupal\Core\Link;
 
 /**
  * Defines a class to build a listing of Logger Entity entities.
@@ -13,8 +13,6 @@ use Drupal\Core\Url;
  * @ingroup logger_entity
  */
 class LoggerEntityListBuilder extends EntityListBuilder {
-
-  use LinkGeneratorTrait;
 
   /**
    * {@inheritdoc}
@@ -31,7 +29,7 @@ class LoggerEntityListBuilder extends EntityListBuilder {
   public function buildRow(EntityInterface $entity) {
     /* @var $entity \Drupal\logger_entity\Entity\LoggerEntity */
     $row['id'] = $entity->id();
-    $row['name'] = $this->l(
+    $row['name'] = Link::fromTextAndUrl(
       $entity->label(),
       new Url(
         'entity.logger_entity.edit_form', array(

--- a/modules/custom/openy_group_schedules/modules/groupex_form_cache/src/GroupexFormCacheListBuilder.php
+++ b/modules/custom/openy_group_schedules/modules/groupex_form_cache/src/GroupexFormCacheListBuilder.php
@@ -4,8 +4,8 @@ namespace Drupal\groupex_form_cache;
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityListBuilder;
-use Drupal\Core\Routing\LinkGeneratorTrait;
 use Drupal\Core\Url;
+use Drupal\Core\Link;
 
 /**
  * Defines a class to build a listing of GroupEx Pro Form Cache entities.
@@ -13,8 +13,6 @@ use Drupal\Core\Url;
  * @ingroup groupex_form_cache
  */
 class GroupexFormCacheListBuilder extends EntityListBuilder {
-
-  use LinkGeneratorTrait;
 
   /**
    * {@inheritdoc}
@@ -31,7 +29,7 @@ class GroupexFormCacheListBuilder extends EntityListBuilder {
   public function buildRow(EntityInterface $entity) {
     /* @var $entity \Drupal\groupex_form_cache\Entity\GroupexFormCache */
     $row['id'] = $entity->id();
-    $row['name'] = $this->l(
+    $row['name'] = Link::fromTextAndUrl(
       $entity->label(),
       new Url(
         'entity.groupex_form_cache.edit_form', [

--- a/modules/custom/openy_mappings/src/Controller/MappingAddController.php
+++ b/modules/custom/openy_mappings/src/Controller/MappingAddController.php
@@ -5,7 +5,8 @@ namespace Drupal\openy_mappings\Controller;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Entity\EntityStorageInterface
+use Drupal\Core\Link;
 use Drupal\Core\Url;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -62,7 +63,7 @@ class MappingAddController extends ControllerBase {
       return array(
         '#markup' => $this->t('You have not created any %bundle types yet. @link to add a new type.', [
           '%bundle' => 'Mapping',
-          '@link' => $this->l($this->t('Go to the type creation page'), Url::fromRoute('entity.mapping_type.add_form')),
+          '@link' => Link::fromTextAndUrl($this->t('Go to the type creation page'), Url::fromRoute('entity.mapping_type.add_form')),
         ]),
       );
     }

--- a/modules/custom/openy_mappings/src/MappingListBuilder.php
+++ b/modules/custom/openy_mappings/src/MappingListBuilder.php
@@ -4,8 +4,8 @@ namespace Drupal\openy_mappings;
 
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityListBuilder;
-use Drupal\Core\Routing\LinkGeneratorTrait;
 use Drupal\Core\Url;
+use Drupal\Core\Link;
 
 /**
  * Defines a class to build a listing of Mapping entities.
@@ -13,8 +13,6 @@ use Drupal\Core\Url;
  * @ingroup openy_mappings
  */
 class MappingListBuilder extends EntityListBuilder {
-
-  use LinkGeneratorTrait;
 
   /**
    * {@inheritdoc}
@@ -31,7 +29,7 @@ class MappingListBuilder extends EntityListBuilder {
   public function buildRow(EntityInterface $entity) {
     /* @var $entity \Drupal\openy_mappings\Entity\Mapping */
     $row['id'] = $entity->id();
-    $row['name'] = $this->l(
+    $row['name'] = Link::fromTextAndUrl(
       $entity->label(),
       new Url(
         'entity.mapping.edit_form', array(

--- a/modules/custom/openy_upgrade_tool/src/Controller/OpenyUpgradeLogController.php
+++ b/modules/custom/openy_upgrade_tool/src/Controller/OpenyUpgradeLogController.php
@@ -7,6 +7,7 @@ use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
 use Drupal\Core\Render\RendererInterface;
+use Drupal\Core\Link;
 use Drupal\Core\Url;
 use Drupal\openy_upgrade_tool\Entity\OpenyUpgradeLogInterface;
 use Drupal\openy_upgrade_tool\OpenyUpgradeLogManagerInterface;
@@ -212,7 +213,7 @@ class OpenyUpgradeLogController extends ControllerBase implements ContainerInjec
         // Use revision link to link to revisions that are not active.
         $date = $this->dateFormatter->format($revision->getRevisionCreationTime(), 'short');
         if ($vid != $openy_upgrade_log->getRevisionId()) {
-          $link = $this->l($date, new Url('entity.openy_upgrade_log.revision', ['openy_upgrade_log' => $openy_upgrade_log->id(), 'openy_upgrade_log_revision' => $vid]));
+          $link = Link::fromTextAndUrl($date, new Url('entity.openy_upgrade_log.revision', ['openy_upgrade_log' => $openy_upgrade_log->id(), 'openy_upgrade_log_revision' => $vid]));
         }
         else {
           $link = $openy_upgrade_log->link($date);


### PR DESCRIPTION
### How to review:
- [ ] Make sure that there are no errors about deprecated method `l()`.

## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer. See [Code of Conduct](https://github.com/ymcatwincities/openy/wiki/Open-Y-Code-of-Conduct-and-Best-Practices).
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
