### PR TITLE
[RGTC-1114] Replace deprecated method in openy_upgrade_tool

### DIFF
--- a/modules/custom/openy_upgrade_tool/src/Controller/OpenyUpgradeLogController.php
+++ b/modules/custom/openy_upgrade_tool/src/Controller/OpenyUpgradeLogController.php
@@ -164,7 +164,7 @@ class OpenyUpgradeLogController extends ControllerBase implements ContainerInjec
    */
   public function revisionPageTitle($openy_upgrade_log_revision) {
     $openy_upgrade_log = $this->entityManager()->getStorage('openy_upgrade_log')->loadRevision($openy_upgrade_log_revision);
-    return $this->t('Revision of %title from %date', ['%title' => $openy_upgrade_log->label(), '%date' => format_date($openy_upgrade_log->getRevisionCreationTime())]);
+    return $this->t('Revision of %title from %date', ['%title' => $openy_upgrade_log->label(), '%date' => \Drupal::service('date.formatter')->format($openy_upgrade_log->getRevisionCreationTime())]);
   }
 
   /**
@@ -215,7 +215,7 @@ class OpenyUpgradeLogController extends ControllerBase implements ContainerInjec
           $link = $this->l($date, new Url('entity.openy_upgrade_log.revision', ['openy_upgrade_log' => $openy_upgrade_log->id(), 'openy_upgrade_log_revision' => $vid]));
         }
         else {
-          $link = $openy_upgrade_log->link($date);
+          $link = $openy_upgrade_log->toLink($date)->toString();;
         }
 
         $row = [];

--- a/modules/custom/openy_upgrade_tool/src/Form/OpenyUpgradeLogDiff.php
+++ b/modules/custom/openy_upgrade_tool/src/Form/OpenyUpgradeLogDiff.php
@@ -320,7 +320,7 @@ class OpenyUpgradeLogDiff extends FormBase {
    */
   public function closeModal(array $form, FormStateInterface $form_state) {
     $response = new AjaxResponse();
-    $dashboard_url = $this->getUrlGenerator()
+    $dashboard_url = \Drupal::service('url_generator')
       ->generateFromRoute(OpenyUpgradeLogManager::DASHBOARD);
     $response->addCommand(new RedirectCommand($dashboard_url));
     $response->addCommand(new CloseModalDialogCommand());

--- a/modules/custom/openy_upgrade_tool/src/Form/OpenyUpgradeLogRevisionDeleteForm.php
+++ b/modules/custom/openy_upgrade_tool/src/Form/OpenyUpgradeLogRevisionDeleteForm.php
@@ -73,7 +73,7 @@ class OpenyUpgradeLogRevisionDeleteForm extends ConfirmFormBase {
    * {@inheritdoc}
    */
   public function getQuestion() {
-    return t('Are you sure you want to delete the revision from %revision-date?', ['%revision-date' => format_date($this->revision->getRevisionCreationTime())]);
+    return t('Are you sure you want to delete the revision from %revision-date?', ['%revision-date' => \Drupal::service('date.formatter')->format($this->revision->getRevisionCreationTime())]);
   }
 
   /**
@@ -108,7 +108,7 @@ class OpenyUpgradeLogRevisionDeleteForm extends ConfirmFormBase {
     $this->OpenyUpgradeLogStorage->deleteRevision($this->revision->getRevisionId());
 
     $this->logger('content')->notice('Openy upgrade log: deleted %title revision %revision.', ['%title' => $this->revision->label(), '%revision' => $this->revision->getRevisionId()]);
-    $messenger->addMessage(t('Revision from %revision-date of Openy upgrade log %title has been deleted.', ['%revision-date' => format_date($this->revision->getRevisionCreationTime()), '%title' => $this->revision->label()]));
+    $messenger->addMessage(t('Revision from %revision-date of Openy upgrade log %title has been deleted.', ['%revision-date' => \Drupal::service('date.formatter')->format($this->revision->getRevisionCreationTime()), '%title' => $this->revision->label()]));
     $form_state->setRedirect(
       'entity.openy_upgrade_log.canonical',
        ['openy_upgrade_log' => $this->revision->id()]


### PR DESCRIPTION
### How to review: 

- [ ] Make sure that deprecated function `format_date()` is replace on  `\Drupal::service('date.formatter')->format()`
- [ ] Make sure that deprecated method `link()` is replace on `\Drupal\Core\EntityInterface::toLink()->toString()`
- [ ] Make sure that  deprecated method `getUrlGenerator()` is replace on ` url_generator`


## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer. See [Code of Conduct](https://github.com/ymcatwincities/openy/wiki/Open-Y-Code-of-Conduct-and-Best-Practices).
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
