### PR TITLE
[RGTC-1110] Replace deprecated parameters  $entity_manager 

### DIFF
--- a/modules/custom/openy_migrate/src/Plugin/migrate/process/SkipIfBundleNotExist.php
+++ b/modules/custom/openy_migrate/src/Plugin/migrate/process/SkipIfBundleNotExist.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\openy_migrate\Plugin\migrate\process;
 
-use Drupal\Core\Entity\EntityManagerInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\migrate\MigrateSkipProcessException;
 use Drupal\migrate\ProcessPluginBase;
 use Drupal\migrate\MigrateExecutableInterface;
@@ -65,7 +65,7 @@ class SkipIfBundleNotExist extends ProcessPluginBase implements ContainerFactory
   /**
    * The entity manager.
    *
-   * @var \Drupal\Core\Entity\EntityManagerInterface
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
   protected $entityManager;
 
@@ -110,7 +110,7 @@ class SkipIfBundleNotExist extends ProcessPluginBase implements ContainerFactory
       $plugin_id,
       $plugin_definition,
       $migration,
-      $container->get('entity.manager')
+      $container->get('entity_type.manager')
     );
   }
 

--- a/modules/custom/openy_socrates/modules/openy_autocomplete_path/src/EntityAutocompleteMatcher.php
+++ b/modules/custom/openy_socrates/modules/openy_autocomplete_path/src/EntityAutocompleteMatcher.php
@@ -5,7 +5,6 @@ namespace Drupal\openy_autocomplete_path;
 use Drupal\Component\Utility\Html;
 use Drupal\Component\Utility\Tags;
 use Drupal\Core\Entity\EntityAutocompleteMatcher as SystemEntityAutocompleteMatcher;
-use Drupal\Core\Entity\EntityManagerInterface;
 use Drupal\Core\Entity\EntityReferenceSelection\SelectionPluginManagerInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\path_alias\AliasManagerInterface;
@@ -39,12 +38,6 @@ class EntityAutocompleteMatcher extends SystemEntityAutocompleteMatcher {
   protected $aliasManager;
 
   /**
-   * Entity Manager.
-   * @var \Drupal\Core\Entity\EntityManagerInterface
-   */
-  protected $entityManager;
-
-  /**
    * Constructs a EntityAutocompleteMatcher object.
    *
    * @param \Drupal\Core\Entity\EntityReferenceSelection\SelectionPluginManagerInterface $selection_manager
@@ -53,15 +46,12 @@ class EntityAutocompleteMatcher extends SystemEntityAutocompleteMatcher {
    *   Entity type manager.
    * @param \Drupal\path_alias\AliasManagerInterface $aliasManager
    *   Alias manager.
-   * @param \Drupal\Core\Entity\EntityManagerInterface $entityManager
-   *   Entity manager.
    */
-  public function __construct(SelectionPluginManagerInterface $selection_manager, EntityTypeManagerInterface $entityTypeManager, AliasManagerInterface $aliasManager, EntityManagerInterface $entityManager) {
+  public function __construct(SelectionPluginManagerInterface $selection_manager, EntityTypeManagerInterface $entityTypeManager, AliasManagerInterface $aliasManager) {
     parent::__construct($selection_manager);
     $this->selectionManager = $selection_manager;
     $this->entityTypeManager = $entityTypeManager;
     $this->aliasManager = $aliasManager;
-    $this->entityManager = $entityManager;
   }
 
   /**
@@ -84,7 +74,7 @@ class EntityAutocompleteMatcher extends SystemEntityAutocompleteMatcher {
       foreach ($entity_labels as $values) {
         foreach ($values as $entity_id => $label) {
           $entity = $this->entityTypeManager->getStorage($target_type)->load($entity_id);
-          $entity = $this->entityManager->getTranslationFromContext($entity);
+          $entity = \Drupal::service('entity.repository')->getTranslationFromContext($entity);
 
           $status = '';
           $alias = '';

--- a/modules/custom/openy_upgrade_tool/src/Form/OpenyUpgradeLogForm.php
+++ b/modules/custom/openy_upgrade_tool/src/Form/OpenyUpgradeLogForm.php
@@ -4,7 +4,7 @@ namespace Drupal\openy_upgrade_tool\Form;
 
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Entity\ContentEntityForm;
-use Drupal\Core\Entity\EntityManagerInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -28,7 +28,7 @@ class OpenyUpgradeLogForm extends ContentEntityForm {
    * {@inheritdoc}
    */
   public function __construct(
-    EntityManagerInterface $entity_manager,
+    EntityTypeManagerInterface $entity_manager,
     AccountProxyInterface $account_proxy,
     EntityTypeBundleInfoInterface $entity_type_bundle_info = NULL,
     TimeInterface $time = NULL
@@ -44,7 +44,7 @@ class OpenyUpgradeLogForm extends ContentEntityForm {
    */
   public static function create(ContainerInterface $container) {
     return new static(
-      $container->get('entity.manager'),
+      $container->get('entity_type.manager'),
       $container->get('current_user'),
       $container->get('entity_type.bundle.info'),
       $container->get('datetime.time')


### PR DESCRIPTION
### How to review: 

- [ ] Make sure that deprecated parameter `$entity_manager` is replased.

## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer. See [Code of Conduct](https://github.com/ymcatwincities/openy/wiki/Open-Y-Code-of-Conduct-and-Best-Practices).
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
