### PR TITLE
Make gallery heading optional

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_gallery/config/install/field.field.paragraph.gallery.field_prgf_headline.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_gallery/config/install/field.field.paragraph.gallery.field_prgf_headline.yml
@@ -10,7 +10,7 @@ entity_type: paragraph
 bundle: gallery
 label: Headline
 description: 'Headline of the gallery.'
-required: true
+required: false
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_gallery/openy_prgf_gallery.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_gallery/openy_prgf_gallery.install
@@ -127,3 +127,23 @@ function openy_prgf_gallery_update_8006() {
     }
   }
 }
+
+/**
+ * Make Gallery heading optional.
+ */
+function openy_prgf_gallery_update_8007() {
+  $config_dir = drupal_get_path('module', 'openy_prgf_gallery') . '/config/install/';
+  $configs = [
+    'field.field.paragraph.gallery.field_prgf_headline' =>[
+      'required',
+    ],
+  ];
+
+  $config_updater = \Drupal::service('openy_upgrade_tool.param_updater');
+  foreach ($configs as $config_name => $params) {
+    $config = $config_dir . $config_name . '.yml';
+    foreach ($params as $param) {
+      $config_updater->update($config, $config_name, $param);
+    }
+  }
+}

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_gallery/openy_prgf_gallery.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_gallery/openy_prgf_gallery.install
@@ -134,7 +134,7 @@ function openy_prgf_gallery_update_8006() {
 function openy_prgf_gallery_update_8007() {
   $config_dir = drupal_get_path('module', 'openy_prgf_gallery') . '/config/install/';
   $configs = [
-    'field.field.paragraph.gallery.field_prgf_headline' =>[
+    'field.field.paragraph.gallery.field_prgf_headline' => [
       'required',
     ],
   ];

--- a/themes/openy_themes/openy_carnation/templates/paragraph/paragraph--gallery--default.html.twig
+++ b/themes/openy_themes/openy_carnation/templates/paragraph/paragraph--gallery--default.html.twig
@@ -81,12 +81,16 @@ set classes = [
     <div class="container align-items-stretch m-auto p-5 py-lg-3 text-center text-white">
       <div class="row">
         <div class="cta-group col-12">
-          <h1 class="display-4 text-uppercase">
-            {{ content.field_prgf_headline }}
-          </h1>
-          <div class="text">
-            {{ content.field_prgf_description }}
-          </div>
+          {% if not paragraph.field_prgf_headline.isEmpty() %}
+            <h1 class="display-4 text-uppercase">
+              {{ content.field_prgf_headline }}
+            </h1>
+          {% endif %}
+          {% if not paragraph.field_prgf_description.isEmpty() %}
+            <div class="text">
+              {{ content.field_prgf_description }}
+            </div>
+          {% endif %}
           {% if content.field_prgf_link|render|trim is not empty %}
           <div class="mt-3">
             {{ content.field_prgf_link }}

--- a/themes/openy_themes/openy_carnation/templates/paragraph/paragraph--gallery-cta-content.html.twig
+++ b/themes/openy_themes/openy_carnation/templates/paragraph/paragraph--gallery-cta-content.html.twig
@@ -49,9 +49,15 @@ set classes = [
     <div class="container">
       <div class="row">
         <div class="cta-group">
-          <h1>{{ content.field_prgf_headline }}</h1>
-          <div class="text">{{ content.field_prgf_description }}</div>
-          <div class="btn btn-default btn-link blue">{{ content.field_prgf_link }}</div>
+          {% if not paragraph.field_prgf_headline.isEmpty() %}
+            <h1>{{ content.field_prgf_headline }}</h1>
+          {% endif %}
+          {% if not paragraph.field_prgf_description.isEmpty() %}
+            <div class="text">{{ content.field_prgf_description }}</div>
+          {% endif %}
+          {% if not paragraph.field_prgf_link.isEmpty() %}
+            <div class="btn btn-default btn-link blue">{{ content.field_prgf_link }}</div>
+          {% endif %}
         </div>
       </div>
     </div>

--- a/themes/openy_themes/openy_lily/templates/paragraphs/paragraph--gallery--default.html.twig
+++ b/themes/openy_themes/openy_lily/templates/paragraphs/paragraph--gallery--default.html.twig
@@ -77,8 +77,12 @@ view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
         <div class="row">
           {% if content.field_prgf_description['#items'] is not empty %}
             <div class="cta-group">
-              <h1>{{ content.field_prgf_headline }}</h1>
-              <div class="text">{{ content.field_prgf_description }}</div>
+              {% if not paragraph.field_prgf_headline.isEmpty() %}
+                <h1>{{ content.field_prgf_headline }}</h1>
+              {% endif %}
+              {% if not paragraph.field_prgf_description.isEmpty() %}
+                <div class="text">{{ content.field_prgf_description }}</div>
+              {% endif %}
               {% if content.field_prgf_link|render|trim is not empty %}
                 <div class="btn btn-default btn-link blue">{{ content.field_prgf_link }}</div>
               {% endif %}

--- a/themes/openy_themes/openy_lily/templates/paragraphs/paragraph--gallery-cta-content.html.twig
+++ b/themes/openy_themes/openy_lily/templates/paragraphs/paragraph--gallery-cta-content.html.twig
@@ -47,9 +47,15 @@
     <div class="container">
       <div class="row">
         <div class="cta-group">
-          <h1>{{ content.field_prgf_headline }}</h1>
-          <div class="text">{{ content.field_prgf_description }}</div>
-          <div class="btn btn-default btn-link blue">{{ content.field_prgf_link }}</div>
+          {% if not paragraph.field_prgf_headline.isEmpty() %}
+            <h1>{{ content.field_prgf_headline }}</h1>
+          {% endif %}
+          {% if not paragraph.field_prgf_description.isEmpty() %}
+            <div class="text">{{ content.field_prgf_description }}</div>
+          {% endif %}
+          {% if not paragraph.field_prgf_link.isEmpty() %}
+            <div class="btn btn-default btn-link blue">{{ content.field_prgf_link }}</div>
+          {% endif %}
         </div>
       </div>
     </div>

--- a/themes/openy_themes/openy_rose/templates/paragraph/paragraph--gallery--default.html.twig
+++ b/themes/openy_themes/openy_rose/templates/paragraph/paragraph--gallery--default.html.twig
@@ -78,8 +78,12 @@ set classes = [
     <div class="container">
       <div class="row">
         <div class="cta-group">
-          <h1>{{ content.field_prgf_headline }}</h1>
-          <div class="text">{{ content.field_prgf_description }}</div>
+          {% if not paragraph.field_prgf_headline.isEmpty() %}
+            <h1>{{ content.field_prgf_headline }}</h1>
+          {% endif %}
+          {% if not paragraph.field_prgf_description.isEmpty() %}
+            <div class="text">{{ content.field_prgf_description }}</div>
+          {% endif %}
           {% if content.field_prgf_link|render|trim is not empty %}
             <div class="btn btn-default btn-link blue">{{ content.field_prgf_link }}</div>
           {% endif %}


### PR DESCRIPTION
## Steps for review

- [ ] Login as admin
- [ ] Edit any landing page
- [ ] Add gallery
- [ ] Verify the heading field is optional now
- [ ] Save the node without gallery heading
- [ ] Check the page with different Open Y themes

## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer. See [Code of Conduct](https://github.com/ymcatwincities/openy/wiki/Open-Y-Code-of-Conduct-and-Best-Practices).
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
