### PR TITLE
[VYMCA-63] Virtual Y: Close mobile menu on the menu link click

### DIFF
--- a/themes/openy_themes/openy_carnation/openy_carnation.theme
+++ b/themes/openy_themes/openy_carnation/openy_carnation.theme
@@ -200,6 +200,12 @@ function openy_carnation_preprocess_menu(&$variables) {
   $variables['menu_name'] = isset($variables['menu_name']) ? $variables['menu_name'] : "";
   if ($variables['menu_name'] === 'main') {
     $variables['display_search'] = theme_get_setting('display_search_form');
+
+    foreach ($variables['items'] as &$item) {
+      // Add data-toggle for closing mobile menu on menu item click.
+      $item['attributes']->setAttribute('data-toggle', 'collapse');
+      $item['attributes']->setAttribute('data-target', '.mobile-sidebar.collapse.show');
+    }
   }
 }
 

--- a/themes/openy_themes/openy_lily/scripts/openy_lily.js
+++ b/themes/openy_themes/openy_lily/scripts/openy_lily.js
@@ -132,6 +132,14 @@
           }
         });
       });
+
+      // Close mobile menu on link click.
+      $("#side-area nav a:not(.dropdown-toggle)", context).click(function() {
+        $(".navbar-toggler", context).toggleClass('expanded-mobile');
+        $('#side-area, .viewport').toggleClass('expanded-mobile');
+        $('#side-area').attr('aria-hidden', 'true');
+        $('.viewport').removeAttr('aria-hidden');
+      });
     }
   };
 

--- a/themes/openy_themes/openy_rose/scripts/openy_rose.js
+++ b/themes/openy_themes/openy_rose/scripts/openy_rose.js
@@ -112,6 +112,19 @@
           return false;
         }
       });
+
+      // Close mobile menu on link click.
+      $('#sidebar nav a:not(.dropdown-toggle)', context).click(function() {
+        var sidebar = $('#sidebar');
+        var toggle = $('.navbar-toggle[data-target="#sidebar"]');
+        if (sidebar.attr('aria-expanded') == 'true') {
+          sidebar.trigger('hide.bs.collapse');
+          toggle.removeAttr('aria-expanded');
+          toggle.addClass('collapsed');
+          $('body').removeClass('sidebar-in');
+          $('html').removeClass('sidebar-in');
+        }
+      });
     }
   };
 


### PR DESCRIPTION
## Original Issue:

**Problem:** Mobile device user has no way to realize they have successfully navigated to a new page on Virtual YMCA.
**Steps to reproduce:**
1. Tap Virtual YMCA menu icon, the menu takes up the entire screen
2. Tap a link option
3. A new page loads underneath but menu display remains, covering the new page

## Steps for review

- [ ] Test header menu on rose, lily, and carnation
- [ ] Check that on the desktop it works like before fix 
- [ ] Check the mobile menu on rose, lily, and carnation
- [ ] It should collapse after a menu link click
- [ ] Check that expanded menu items works fine on mobile