### PR TITLE
[YPKCOY-82] Fix sticky sidebar when alert height is undefined (Carnation)

### DIFF
--- a/themes/openy_themes/openy_carnation/dist/js/openy_carnation_landing.js
+++ b/themes/openy_themes/openy_carnation/dist/js/openy_carnation_landing.js
@@ -6,8 +6,6 @@
         var contentHeight = $('.main-region').outerHeight();
         var sidebarHeight = $('.sidebar-region').outerHeight();
 
-        var headerWrapperHeight = $('.wrapper-field-header-content').outerHeight();
-
         if (contentHeight >= sidebarHeight) {
           var $sidebar = $('.landing-content.two-column-fixed .wrapper-field-sidebar-content');
           $sidebar.unbind();
@@ -19,8 +17,8 @@
           else {
             top = 120;
           }
-          var top_offset = $('.header-alerts-list').outerHeight(true) + $('.wrapper-field-header-content').outerHeight(true) + top;
-          var bottom_offset = $('.footer').outerHeight(true) + $('.wrapper-field-bottom-content').outerHeight(true) + $('.site-alert--footer').outerHeight(true);
+          var top_offset = ($('.header-alerts-list').outerHeight(true) || 0) + ($('.wrapper-field-header-content').outerHeight(true) || 0) + top;
+          var bottom_offset = ($('.footer').outerHeight(true) || 0) + ($('.wrapper-field-bottom-content').outerHeight(true) || 0) + ($('.site-alert--footer').outerHeight(true) || 0);
           $sidebar.affix({
             offset: {
               top: top_offset,

--- a/themes/openy_themes/openy_carnation/dist/js/openy_carnation_sticky_sidebar.js
+++ b/themes/openy_themes/openy_carnation/dist/js/openy_carnation_sticky_sidebar.js
@@ -7,8 +7,6 @@
         var contentHeight = $('.main-region').outerHeight();
         var sidebarHeight = $('.sidebar-region').outerHeight();
 
-        var headerWrapperHeight = $('.wrapper-field-header-content').outerHeight();
-
         if (contentHeight >= sidebarHeight) {
           var $sidebar = $('.landing-content.two-column-fixed .wrapper-field-sidebar-content');
           if($sidebar.length == 0) {
@@ -23,8 +21,8 @@
           else {
             top = 120;
           }
-          var top_offset = $('.header-alerts-list').outerHeight(true) + $('.wrapper-field-header-content').outerHeight(true) + top;
-          var bottom_offset = $('.footer').outerHeight(true) + $('.wrapper-field-bottom-content').outerHeight(true) + $('.site-alert--footer').outerHeight(true);
+          var top_offset = ($('.header-alerts-list').outerHeight(true) || 0) + ($('.wrapper-field-header-content').outerHeight(true) || 0) + top;
+          var bottom_offset = ($('.footer').outerHeight(true) || 0) + ($('.wrapper-field-bottom-content').outerHeight(true) || 0) + ($('.site-alert--footer').outerHeight(true) || 0);
           $sidebar.affix({
             offset: {
               top: top_offset,


### PR DESCRIPTION
### Original Issue, this PR is going to fix: 

> From the client: When using a fixed sidebar on the right, when you scroll down the sidebar content doesn’t stop at the end of the body container.

### Reason: 

```js
var top_offset = $('.header-alerts-list').outerHeight(true) + $('.wrapper-field-header-content').outerHeight(true) + top;
var bottom_offset = $('.footer').outerHeight(true) + $('.wrapper-field-bottom-content').outerHeight(true) + $('.site-alert--footer').outerHeight(true);
```

In my case there no footer alert on the page, so height for this block was **undefined** and **bottom_offset** s result also **undefined**. 

### Solution:  

set 0 if there no such block on the page (for each component).

### Steps for review

- [ ] Create page with layout = **Two Columns with fixed sidebar (sticky at the top)**
- [ ] Add some content for scroll testing (you can use https://loremipsum.io/)
- [ ] Add banner to bottom content
- [ ] Check that there no footer alert 
- [ ] Check that sidebar fixed and stops scrolling on the bottom content
