### PR TITLE
Remove style duplicates in the carnation header

### DIFF
--- a/themes/openy_themes/openy_carnation/src/scss/modules/_header.scss
+++ b/themes/openy_themes/openy_carnation/src/scss/modules/_header.scss
@@ -71,14 +71,6 @@
   }
 }
 
-.viewport {
-  background-color: white;
-}
-
-.viewport {
-  background-color: white;
-}
-
 .site-name {
   @include cachet();
   font-size: 20px;


### PR DESCRIPTION
Original Issue, this PR is going to fix: REPLACE WITH A LINK TO ISSUE ( publicly available )

Remove viewport style duplicates in the carnation header.

## Steps for review

- [ ] Please provide steps for review here.
- [ ] Please provide steps for review here.
- [ ] Please provide steps for review here.
- [ ] Please provide steps for review here.

## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer. See [Code of Conduct](https://github.com/ymcatwincities/openy/wiki/Open-Y-Code-of-Conduct-and-Best-Practices).
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
