### PR TITLE
[YPKCOY-129] Let link attributes work

### DIFF
--- a/themes/openy_themes/openy_carnation/templates/field/field--paragraph--field-prgf-link--banner.html.twig
+++ b/themes/openy_themes/openy_carnation/templates/field/field--paragraph--field-prgf-link--banner.html.twig
@@ -42,16 +42,12 @@
   {% if multiple %}
     <div{{ attributes.addClass('wrapper-' ~ field_name|clean_class) }}>
       {% for item in items %}
-        <a href="{{ item.content['#url'] }}" class="btn btn-lg btn-outline-light">
-          {{ item.content['#title'] }}
-        </a>
+        {{ item.content|merge({ '#options': {'attributes': {'class': ['btn', 'btn-lg', 'btn-outline-light']}}}) }}
       {% endfor %}
     </div>
   {% else %}
     {% for item in items %}
-      <a href="{{ item.content['#url'] }}" class="btn btn-lg btn-outline-light">
-        {{ item.content['#title'] }}
-      </a>
+      {{ item.content|merge({ '#options': {'attributes': {'class': ['btn', 'btn-lg', 'btn-outline-light']}}}) }}
     {% endfor %}
   {% endif %}
 {% else %}
@@ -61,9 +57,7 @@
     <div>
       {% endif %}
       {% for item in items %}
-        <a href="{{ item.content['#url'] }}" class="btn btn-lg btn-outline-light">
-          {{ item.content['#title'] }}
-        </a>
+        {{ item.content|merge({ '#options': {'attributes': {'class': ['btn', 'btn-lg', 'btn-outline-light']}}}) }}
       {% endfor %}
       {% if multiple %}
     </div>


### PR DESCRIPTION
Original Issue, this PR is going to fix: 
Carnation Banner paragraph links don't respect 'target', 'rel', 'class' and other attributes that are available in "Link (with attributes)" Link field widget.


## Steps for review
- [ ] create a landing page
- [ ] add a Banner paragraph
- [ ] set the paragraph's link URL and link text
- [ ] set the link's attribute values
![image](https://user-images.githubusercontent.com/5453109/89177497-49e76900-d594-11ea-9ecb-89eef5e6e0fc.png)
- [ ] submit the form and go to the page
- [ ] verify the link in the banner has all the attributes set as well as 'btn btn-lg btn-outline-light' classes added by Carnation theme
![image](https://user-images.githubusercontent.com/5453109/89177641-95017c00-d594-11ea-9fc9-d23926ab9ab2.png)

