### PR TITLE
Patches cleanup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -191,7 +191,6 @@
                 "3099611 - Class 'Drush\\Commands\\DrushCommands' not found": "https://www.drupal.org/files/issues/2019-12-11/3099611-15.patch"
             },
             "drupal/geysir": {
-                "3021196 - Geysir tools are shown to users without the permission to use them": "https://www.drupal.org/files/issues/2018-12-18/check-permission.patch",
                 "Adds a feature for reload a page after success paragraph add or edit": "https://raw.githubusercontent.com/ymcatwincities/openy/8.x-2.x/patches/geysir/add-reload-page.patch"
             },
             "drupal/social_feed_fetcher": {
@@ -293,7 +292,7 @@
         "drupal/draggableviews": "^1.2",
         "drupal/twig_tweak": "^2.4",
         "drupal/image_widget_crop": "^2.2",
-        "drupal/geysir": "^1.1",
+        "drupal/geysir": "^1.2",
         "drupal/media_directories": "^1.0",
         "drupal/editor_advanced_link": "^1.6",
         "drupal/link_attributes": "^1.10"

--- a/composer.json
+++ b/composer.json
@@ -187,9 +187,6 @@
             "drupal/blazy": {
                 "Remove core media dependencies to unblock upgrade": "https://raw.githubusercontent.com/ymcatwincities/openy/8.x-2.x/patches/blazy/remove-core-media-dependencies.patch"
             },
-            "drupal/ckeditor_font": {
-                "Fixes CKEditor Font if a drupal website is installed in a subdirectory": "https://www.drupal.org/files/issues/ckeditor_font_8_1_0_libraries_integration_01.patch"
-            },
             "drupal/migrate_tools": {
                 "3099611 - Class 'Drush\\Commands\\DrushCommands' not found": "https://www.drupal.org/files/issues/2019-12-11/3099611-15.patch"
             },
@@ -292,7 +289,7 @@
         "npm-asset/slick-carousel": "^1.8",
         "npm-asset/dropzone": "^5.5",
         "npm-asset/jquery.easing": "^1.4",
-        "drupal/ckeditor_font": "^1.0",
+        "drupal/ckeditor_font": "^1.1",
         "drupal/draggableviews": "^1.2",
         "drupal/twig_tweak": "^2.4",
         "drupal/image_widget_crop": "^2.2",

--- a/patches/geysir/add-reload-page.patch
+++ b/patches/geysir/add-reload-page.patch
@@ -1,11 +1,11 @@
 diff --git a/js/geysir.js b/js/geysir.js
-index b671d6b..3c416f1 100644
+index f65c9ce..95c0bad 100644
 --- a/js/geysir.js
 +++ b/js/geysir.js
-@@ -53,4 +53,11 @@
-     }
+@@ -61,4 +61,11 @@
+     Drupal.attachBehaviors();
    };
- 
+
 +  /**
 +   * Triggered by AJAX action for page reload.
 +   */
@@ -15,22 +15,15 @@ index b671d6b..3c416f1 100644
 +
  })(jQuery, Drupal, drupalSettings);
 diff --git a/src/Form/GeysirModalParagraphForm.php b/src/Form/GeysirModalParagraphForm.php
-index 7139904..b00678c 100644
+index 5ec29ce..4ee19c2 100644
 --- a/src/Form/GeysirModalParagraphForm.php
 +++ b/src/Form/GeysirModalParagraphForm.php
-@@ -4,6 +4,7 @@ namespace Drupal\geysir\Form;
- 
- use Drupal\Core\Ajax\AjaxResponse;
- use Drupal\Core\Ajax\HtmlCommand;
-+use Drupal\Core\Ajax\InvokeCommand;
- use Drupal\Core\Form\FormStateInterface;
- use Drupal\geysir\Ajax\GeysirCloseModalDialogCommand;
- 
-@@ -92,6 +93,7 @@ class GeysirModalParagraphForm extends GeysirParagraphForm {
-       );
- 
+@@ -104,6 +104,8 @@ class GeysirModalParagraphForm extends GeysirParagraphForm {
        $response->addCommand(new GeysirCloseModalDialogCommand());
+
+       $response->addCommand(new GeysirReattachBehaviors());
++
 +      $response->addCommand(new InvokeCommand(NULL, 'reloadPageAjaxAction'));
      }
- 
+
      return $response;


### PR DESCRIPTION
Currently while installation of openy three patches are failed to apply. Some of them are already integrated into the latest versions of packages and not needed anymore if we rise package versions required.

1. https://www.drupal.org/files/issues/ckeditor_font_8_1_0_libraries_integration_01.patch
for drupal/ckeditor_font 1.0, the current version of this package is 1.1, and patch contents are already integrated into the package itself, so no need to apply this patch any more.

2. https://www.drupal.org/files/issues/2018-12-18/check-permission.patch
patch for drupal/geysir 1.1, the current version of this package is 1.2, and patch contents are already integrated into the package itself, so no need to apply this patch any more.

3. https://raw.githubusercontent.com/ymcatwincities/openy/8.x-2.x/patches/geysir/add-reload-page.patch
this patch is failed to apply to drupal/geysir 1.2 because it is rejected due to conflict with latest changes from this package https://git.drupalcode.org/project/geysir/-/blob/8.x-1.x/src/Form/GeysirModalParagraphForm.php#L106
I suggest a fix for add-reload-page.patch to make it apply on top of geysir 1.2
Also, due to the latest new code:
`$response->addCommand(new GeysirReattachBehaviors());`
in patched function "ajaxSave" I suggest deciding the necessity of applying the custom patch on top of that.