### PR TITLE
Fix the fatal error on Locations page

### DIFF
--- a/modules/custom/openy_data_wrapper/src/DataWrapper.php
+++ b/modules/custom/openy_data_wrapper/src/DataWrapper.php
@@ -118,6 +118,7 @@ class DataWrapper implements OpenyDataServiceInterface {
     }
     else {
       $location_ids = $this->entityTypeManager->getStorage('node')
+        ->getQuery()
         ->condition('type', $type)
         ->condition('status', 1)
         ->execute();


### PR DESCRIPTION
Original Issue, this PR is going to fix: broken Locations page https://sandbox-rose-cus.openy.org/locations
![Screenshot from 2020-08-11 12-18-56](https://user-images.githubusercontent.com/58946680/89880419-e4ffc480-dbcc-11ea-87c0-6c08c7d93ffc.png)
The issue is related to https://github.com/ymcatwincities/openy/commit/87b55b51d67d0183e031281ca824f1bb67318366#diff-5cfaa65c0c2321dfe515f221eb69d52fL131


## Steps for review

- [ ] Go to the Locations page `/locations`
- [ ] Verify the error is fixed
