### PR TITLE
Fix squashed Open Y Rose embedded images

### DIFF
--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -6324,7 +6324,6 @@ body .branch-popup + .ui-widget-overlay {
 }
 .embedded-entity img {
   display: inline-block;
-  padding: 10px 0;
 }
 
 a[href="#step2"] {

--- a/themes/openy_themes/openy_rose/scss/modules/_landing.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_landing.scss
@@ -34,6 +34,5 @@
 
   img {
     display: inline-block;
-    padding: 10px 0;
   }
 }


### PR DESCRIPTION
Original Issue, this PR is going to fix: 
In Open Y Rose, the images embedded via WYSIWYG are getting squashed vertically.

The root cause is that the vertical spacing is added using the `padding` CSS property on the `img` tag. That produces the unwanted result when the `height` CSS property is set to `auto`. Vertical spacing must be controlled (and is already controlled) on the image wrapper level.

Steps for review:
- [ ] create a new landing page or edit existing
- [ ] add a simple content paragraph, embed an image
- [ ] verify the embedded image is not distorted and maintains its aspect ratio