### PR TITLE
Tokenize year in footer block migration

### DIFF
--- a/modules/openy_features/openy_demo_content/modules/openy_demo_bfooter/config/install/migrate_plus.migration.openy_demo_block_content_footer.yml
+++ b/modules/openy_features/openy_demo_content/modules/openy_demo_bfooter/config/install/migrate_plus.migration.openy_demo_block_content_footer.yml
@@ -32,7 +32,7 @@ source:
       description: 'Footer Copyright Block'
       title: ''
       body: |
-        <p>© 2020 YMCA</p>
+        <p>© [current-date:custom:Y] YMCA</p>
         <p>The YMCA is a 501(c)(3) not-for-profit social services organization dedicated to Youth Development, Healthy Living, and Social Responsibility.</p>
   ids:
     id:


### PR DESCRIPTION
Original Issue, this PR is going to fix: new issue

Since the footer copyright block is using the "Full HTML" text format and tokens are enabled (and I'm assuming will probably always be required) let's save ourselves and the movement a little work by keeping the copyright date current forever.

## Steps for review

- [ ] Build a new site
- [ ] Observe the footer copyright block says `2020`.
- [ ] BONUS: Change the date on your server and observe that the footer block changes.

## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer. See [Code of Conduct](https://github.com/ymcatwincities/openy/wiki/Open-Y-Code-of-Conduct-and-Best-Practices).
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
