### PR TITLE
[CR-31] Fix event page full template and calendar

### DIFF
--- a/modules/openy_features/openy_node/modules/openy_node_event/js/openy_node_event.js
+++ b/modules/openy_features/openy_node/modules/openy_node_event/js/openy_node_event.js
@@ -22,4 +22,25 @@
     }
   };
 
+  Drupal.behaviors.atcFix = {
+    attach: function (context, settings) {
+      $('.addtocalendar').click(function() {
+        if ($(this).hasClass('activated')) {
+          $(this).removeClass('activated');
+          $(this).find('.atcb-list').css({
+            'display' : 'none',
+            'visibility' : 'hidden'
+          });
+        }
+        else {
+          $(this).addClass('activated');
+          $(this).find('.atcb-list').css({
+            'display' : 'block',
+            'visibility' : 'visible'
+          });
+        }
+      });
+    }
+  };
+
 })(jQuery);

--- a/themes/openy_themes/openy_carnation/templates/node/event/node--event--full.html.twig
+++ b/themes/openy_themes/openy_carnation/templates/node/event/node--event--full.html.twig
@@ -90,7 +90,7 @@
 {% set hide_sidebar = true %}
 {% if not node.field_sidebar_content.isEmpty() or not node.field_event_location.isEmpty() %}
   {% set hide_sidebar = false %}
-  {% set main_class = main_class|merge(['col-md-8', 'col-lg-9'])  %}
+  {% set main_class = main_class|merge(['col-md-8', 'col-lg-8'])  %}
 {% endif %}
 
 {# default header #}
@@ -98,7 +98,7 @@
 
 <div class="container mt-5">
   <div class="row">
-    <div {{ attributes.addClass(main_class) }}>
+    <div class="{{ main_class|join(' ') }}">
       <article{{ attributes.addClass(classes) }}>
         <div{{ content_attributes.addClass('node__content') }}>
 
@@ -119,7 +119,7 @@
     </div>
 
     {% if not hide_sidebar %}
-      <div class="col-12 col-md-4 col-lg-3 side-col">
+      <div class="col-12 col-md-4 col-lg-4 side-col">
         <div class="card mb-3">
           <div class="card-body">
 


### PR DESCRIPTION
Events page before fix:

![screenshot-openy-origin docksal-2020 08 26-17_34_25](https://user-images.githubusercontent.com/13733670/91321828-b76b6b80-e7c7-11ea-9ee3-29cbac3a5ef0.png)

Events page after fix:

![screenshot-openy-origin docksal-2020 08 26-18_06_08](https://user-images.githubusercontent.com/13733670/91322135-0913f600-e7c8-11ea-8773-90a98595d5e3.png)


## Steps for review

- [ ] Go to any event page (For example /events/citycon-event)
- [ ] Check that there no empty space from the left side of the sidebar
- [ ] Check that "Add to calendar" works fine (compare with the sandbox or another build without this fix)

![screenshot-openy-origin docksal-2020 08 26-18_06_34](https://user-images.githubusercontent.com/13733670/91322408-60b26180-e7c8-11ea-8a82-a2f3d6f09180.png)

