### PR TITLE
[YGO-194] Fix menu attributes issue.

### DIFF
--- a/themes/openy_themes/openy_carnation/templates/menu/menu--account--secondary-menu.html.twig
+++ b/themes/openy_themes/openy_carnation/templates/menu/menu--account--secondary-menu.html.twig
@@ -37,22 +37,11 @@
       {%
         set classes = [
         item.in_active_trail ? 'is-active',
-        item.below ? 'dropdown',
         'h-100 d-flex align-items-center'
         ]
       %}
       <li{{ item.attributes.addClass(classes) }}>
-        {% if item.below %}
-          <a data-toggle="dropdown" href="{{ item.url }}" class="nav-link px-4">
-            {{ item.title }}
-            <i class="fa fa-angle-up" aria-hidden="true"></i>
-            <i class="fa fa-angle-down" aria-hidden="true"></i>
-          </a>
-        {% else %}
-          <a href="{{ item.url }}" class="nav-link px-4">
-            {{ item.title }}
-          </a>
-        {% endif %}
+        {{ link(item.title, item.url, item.attributes.addClass(['nav-link', 'px-4'])) }}
       </li>
     {% endfor %}
     </ul>

--- a/themes/openy_themes/openy_carnation/templates/menu/menu--main--primary-menu.html.twig
+++ b/themes/openy_themes/openy_carnation/templates/menu/menu--main--primary-menu.html.twig
@@ -37,16 +37,15 @@
       {% set ia = ia.addClass('nav-item nav-level-2') %}
       <li{{ item.attributes.addClass('menu-item-' ~ item.title|clean_class) }}>
         {% if item.below %}
-          <a data-toggle="dropdown" href="{{ item.url }}" class="nav-link text-uppercase" aria-expanded="false">
+          {% set item_title %}
             {{ item.title }}
             <i class="fa fa-angle-up" aria-hidden="true"></i>
             <i class="fa fa-angle-down" aria-hidden="true"></i>
-          </a>
+          {% endset %}
+          {{ link(item_title, item.url, {'aria-expanded': 'false', 'data-toggle': 'dropdown', 'class' : ['nav-link', 'text-uppercase']}) }}
           {{ menus.menu_links_level_2(item.below, attributes, menu_level + 1) }}
         {% else %}
-          <a href="{{ item.url }}" class="nav-link text-uppercase">
-            {{ item.title }}
-          </a>
+          {{ link(item.title, item.url, {'class' : ['nav-link', 'text-uppercase']}) }}
         {% endif %}
       </li>
     {% endfor %}
@@ -70,10 +69,11 @@
       {% set ia = item.attributes.addClass(['nav-level-3 col-md-3 col-lg-2 menu-item-' ~ item.title|clean_class]) %}
       <li{{ ia }}>
         {% if item.below %}
-          <a href="{{ item.url }}" class="d-flex">
+          {% set item_title %}
             <i class="fa fa-angle-right pr-2" aria-hidden="true"></i>
             {{ item.title }}
-          </a>
+          {% endset %}
+          {{ link(item_title, item.url, {'class' : 'd-flex'}) }}
           {{ menus.menu_links_level_3(item.below, item, attributes, menu_level) }}
         {% else %}
           {{ link(item.title, item.url) }}

--- a/themes/openy_themes/openy_carnation/templates/menu/mobile/menu--main--mobile-menu.html.twig
+++ b/themes/openy_themes/openy_carnation/templates/menu/mobile/menu--main--mobile-menu.html.twig
@@ -37,16 +37,15 @@
       {% set ia = ia.addClass('nav-item nav-level-2') %}
       <li{{ item.attributes.addClass('menu-item-' ~ item.title|clean_class) }}>
         {% if item.below %}
-          <a data-toggle="dropdown" href="{{ item.url }}" class="nav-link dropdown-toggle text-uppercase">
+          {% set item_title %}
             {{ item.title }}
-            <i class="fa fa-caret-up" aria-hidden="true"></i>
-            <i class="fa fa-caret-down" aria-hidden="true"></i>
-          </a>
+            <i class="fa fa-angle-up" aria-hidden="true"></i>
+            <i class="fa fa-angle-down" aria-hidden="true"></i>
+          {% endset %}
+          {{ link(item_title, item.url, {'aria-expanded': 'false', 'data-toggle': 'dropdown', 'class' : ['nav-link', 'text-uppercase', 'dropdown-toggle']}) }}
           {{ menus.menu_links_level_2(item.below, attributes, menu_level + 1) }}
         {% else %}
-          <a href="{{ item.url }}" class="nav-link text-uppercase">
-            {{ item.title }}
-          </a>
+          {{ link(item.title, item.url, {'class' : ['nav-link', 'text-uppercase']}) }}
         {% endif %}
       </li>
     {% endfor %}
@@ -61,9 +60,7 @@
     {% for item in items %}
       {% set ia = item.attributes.addClass(['nav-item nav-level-3 menu-item-' ~ item.title|clean_class]) %}
       <li{{ ia }}>
-        <a href="{{ item.url }}" class="nav-link">
-          {{ item.title }}
-        </a>
+        {{ link(item.title, item.url, {'class' : 'nav-link'}) }}
       </li>
     {% endfor %}
     </ul>


### PR DESCRIPTION
This PR is going to fix issue with missed 'target', 'rel', 'class' attributes that are available in "Link (with attributes)" Link field widget.

## Steps for review
- [ ] visit **Main navigation** menu /admin/structure/menu/manage/main
- [ ] edit any menu item
- [ ] set 'target', 'rel', 'class' https://i.imgur.com/zSt2ci6.png
- [ ] open homepage
- [ ] make sure that attributes added to menu link https://i.imgur.com/vYlWjFx.png
- [ ] repeat the same for **User account menu**
P.S. As User account menu not configured (in current realization of configs and template) to display 2 level links, this condition was removed. 
