### PR TITLE
Carnation: fix Duplicate attribute `type`

### DIFF
--- a/themes/openy_themes/openy_carnation/templates/page/page.html.twig
+++ b/themes/openy_themes/openy_carnation/templates/page/page.html.twig
@@ -83,7 +83,7 @@
             <form method="get" action="{{ search_results_path }}">
               <i class="fa fa-search search-input-decoration" aria-hidden="true"></i>
               <input type="search" name="{{ search_key }}" class="search-input" placeholder="{{ 'Search'|t }}">
-              <input type="submit" type="submit" value="Search">
+              <input type="submit" value="Search">
             </form>
           </div>
         {% endif %}


### PR DESCRIPTION
Original Issue, this PR is going to fix: Doubled `type` attribute for the search submit button in Carnation

## Steps for review

- [ ] Use Carnation theme
- [ ] Check the search form with developer tools
- [ ] Verify the button has only one `type` attribute
