### PR TITLE
[CR-42] Limit banner images by image style (carnation)

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_banner/config/install/image.style.carnation_banner_1920_700.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_banner/config/install/image.style.carnation_banner_1920_700.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - crop.type.crop_1920_700
+  module:
+    - openy_focal_point
+name: carnation_banner_1920_700
+label: 'Carnation banner (1920x700)'
+effects:
+  11e1b4c9-ba1c-41ed-b6b9-82ce6491bb04:
+    uuid: 11e1b4c9-ba1c-41ed-b6b9-82ce6491bb04
+    id: openy_crop_crop
+    weight: 1
+    data:
+      crop_type: crop_1920_700
+  f6a0b67b-a33d-44bf-bf54-37805268e519:
+    uuid: f6a0b67b-a33d-44bf-bf54-37805268e519
+    id: openy_focal_point_scale_and_crop
+    weight: 2
+    data:
+      width: '1920'
+      height: '700'
+      crop_type: focal_point

--- a/modules/openy_features/openy_prgf/modules/openy_prgf_banner/openy_prgf_banner.install
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_banner/openy_prgf_banner.install
@@ -198,3 +198,16 @@ function openy_prgf_banner_update_8010() {
     }
   }
 }
+
+/**
+ * Add carnation_banner_1920_700 image style.
+ */
+function openy_prgf_banner_update_8011() {
+  $config_dir = drupal_get_path('module', 'openy_prgf_banner') . '/config/install/';
+  // Import configuration.
+  $config_importer = \Drupal::service('openy_upgrade_tool.importer');
+  $config_importer->setDirectory($config_dir);
+  $config_importer->importConfigs([
+    'image.style.carnation_banner_1920_700'
+  ]);
+}

--- a/themes/openy_themes/openy_carnation/templates/paragraph/paragraph--banner.html.twig
+++ b/themes/openy_themes/openy_carnation/templates/paragraph/paragraph--banner.html.twig
@@ -50,7 +50,7 @@
 <div{{ attributes.addClass(classes) }} {% if color is not empty %} style="background-color: {{ color }}" {% endif %}>
 
   {% if not paragraph.field_prgf_image.isEmpty() %}
-    <div class="banner-bg" style="background: url('{{ file_url(paragraph.field_prgf_image.entity.field_media_image.entity.uri.value) }}') center center; background-size: cover;">
+    <div class="banner-bg" style="background: url('{{ paragraph.field_prgf_image.entity.field_media_image.entity.uri.value|image_style('carnation_banner_1920_700') }}') center center; background-size: cover;">
       <span></span>
     </div>
   {% endif %}

--- a/themes/openy_themes/openy_carnation/templates/paragraph/paragraph--small-banner.html.twig
+++ b/themes/openy_themes/openy_carnation/templates/paragraph/paragraph--small-banner.html.twig
@@ -50,7 +50,7 @@
 <div{{ attributes.addClass(classes) }} {% if color is not empty %} style="background-color: {{ color }}" {% endif %}>
 
   {% if not paragraph.field_prgf_image.isEmpty() %}
-    <div class="banner-bg" style="background: url('{{ file_url(paragraph.field_prgf_image.entity.field_media_image.entity.uri.value) }}') center center; background-size: cover;">
+    <div class="banner-bg" style="background: url('{{ file_url(paragraph.field_prgf_image.entity.field_media_image.entity.uri.value|image_style('carnation_banner_1920_700')) }}') center center; background-size: cover;">
       <span></span>
     </div>
   {% endif %}


### PR DESCRIPTION
**Original Issue, this PR is going to fix:** 

Banner and small banner images not limited by image style and shows origin image.


## Steps for review

- [ ] Check that Banner and small banner paragraphs displayed background image with carnation_banner_1920_700 image style
- [ ] Check-in Rose and Lily that banner and small banner paragraphs work like before this fix
