### PR TITLE
[CR-42] Fix dependency to gallery config (crop.type.crop_1920_700)

### DIFF
--- a/modules/openy_features/openy_prgf/modules/openy_prgf_banner/openy_prgf_banner.info.yml
+++ b/modules/openy_features/openy_prgf/modules/openy_prgf_banner/openy_prgf_banner.info.yml
@@ -22,5 +22,6 @@ dependencies:
   - openy_media_image:openy_media_image
   - openy_prgf:openy_prgf
   - openy_txnm_color:openy_txnm_color
+  - openy_prgf_gallery:openy_prgf_gallery
   - paragraphs:paragraphs
 core_incompatible: false


### PR DESCRIPTION
Original Issue, this PR is going to fix: 

[This PR](https://github.com/ymcatwincities/openy/pull/2134) brokes OpenY fresh install, because there exist dependency to `crop.type.crop_1920_700` config from openy_prgf_gallery

## Steps for review

- [ ] Check that OpenY fresh install works fine (test on **Open Y Installation Wizard build**)

