### PR TITLE
[CR-43] Fix blazy aspect ratio styles

### DIFF
--- a/modules/openy_features/openy_media/css/blazy.ratio.css
+++ b/modules/openy_features/openy_media/css/blazy.ratio.css
@@ -1,0 +1,10 @@
+/**
+ * @file
+ * Fix for blazy aspect ratio.
+ */
+.media.media--ratio {
+  height: auto;
+}
+.media.media--ratio .media__element {
+  position: relative;
+}

--- a/modules/openy_features/openy_media/openy_media.libraries.yml
+++ b/modules/openy_features/openy_media/openy_media.libraries.yml
@@ -11,6 +11,7 @@ browser:
     - core/underscore
 
 blazy_ratio:
+  version: 0.1
   css:
     component:
       css/blazy.ratio.css: {}

--- a/modules/openy_features/openy_media/openy_media.libraries.yml
+++ b/modules/openy_features/openy_media/openy_media.libraries.yml
@@ -9,3 +9,8 @@ browser:
     - core/jquery
     - core/drupal
     - core/underscore
+
+blazy_ratio:
+  css:
+    component:
+      css/blazy.ratio.css: {}

--- a/modules/openy_features/openy_media/openy_media.module
+++ b/modules/openy_features/openy_media/openy_media.module
@@ -77,3 +77,10 @@ function openy_media_library_info_alter(&$libraries, $extension) {
     ];
   }
 }
+
+/**
+ * Implements hook_blazy_attach_alter().
+ */
+function openy_media_blazy_attach_alter(array &$load, array $settings = []) {
+  $load['library'][] = 'openy_media/blazy_ratio';
+}


### PR DESCRIPTION
Original Issue, this PR is going to fix: https://github.com/ymcatwincities/openy/issues/2135

## Steps for review

- [ ] Login as admin.
- [ ] Go to /admin/modules
- [ ] Check that blazy version is 2.1
- [ ] Go to join page (or any page with images that loaded by blazy)
- [ ] Check that all works fine

**Before fix:**

![Screenshot from 2020-09-04 17-02-24](https://user-images.githubusercontent.com/13733670/92248358-3865e980-eed1-11ea-9a05-18c87069211d.png)

**After fix:**

![Screenshot from 2020-09-04 17-02-40](https://user-images.githubusercontent.com/13733670/92248366-3ac84380-eed1-11ea-92e2-3f6e9f222259.png)
