### PR TITLE
Jquery ui 8x - replace deprecated with contribs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -88,6 +88,8 @@
         "drupal/views_infinite_scroll": "1.7",
         "drupal/webform": "~6.0",
         "grt107/grt-youtube-popup": "^1.0",
+        "drupal/jquery_ui_tooltip": "^1.1",
+        "drupal/jquery_ui_tabs":" ^1.1",
         "library-ckeditor/colorbutton": "4.10.1",
         "library-ckeditor/font": "4.12.1",
         "library-ckeditor/panelbutton": "4.10.1",

--- a/openy.info.yml
+++ b/openy.info.yml
@@ -46,6 +46,9 @@ dependencies:
   - drupal:toolbar
   - drupal:views
   - drupal:tour
+  # Compatibility
+  - jquery_ui_tooltip:jquery_ui_tooltip
+  
   # Contrib modules.
   - admin_toolbar:admin_toolbar
   - captcha:captcha

--- a/openy.info.yml
+++ b/openy.info.yml
@@ -87,5 +87,5 @@ dependencies:
   - openy_update:openy_update
 themes:
   - openy_admin
-  - claro
+  - seven
   - bartik

--- a/openy.info.yml
+++ b/openy.info.yml
@@ -88,3 +88,4 @@ dependencies:
 themes:
   - openy_admin
   - claro
+  - bartik

--- a/openy.info.yml
+++ b/openy.info.yml
@@ -86,6 +86,5 @@ dependencies:
   - openy_tour:openy_tour
   - openy_update:openy_update
 themes:
-  - bartik
   - openy_admin
-  - seven
+  - claro

--- a/openy.install
+++ b/openy.install
@@ -1149,7 +1149,7 @@ function openy_update_8081() {
 }
 
 /**
- * Enable openy_block_branch_contacts_info module.
+ * Enable jquery_ui_tooltip module.
  */
 function openy_update_8083() {
   \Drupal::service('module_installer')->install(['jquery_ui_tooltip']);

--- a/openy.install
+++ b/openy.install
@@ -1144,3 +1144,10 @@ function openy_update_8081() {
     ]);
   }
 }
+
+/**
+ * Enable openy_block_branch_contacts_info module.
+ */
+function openy_update_8083() {
+  \Drupal::service('module_installer')->install(['jquery_ui_tooltip']);
+}

--- a/openy.install
+++ b/openy.install
@@ -18,7 +18,7 @@ function openy_install() {
   // Set the default and admin theme.
   $config_factory
     ->getEditable('system.theme')
-    ->set('admin', 'claro')
+    ->set('admin', 'seven')
     ->save(TRUE);
 
   // Enable the admin theme.

--- a/openy.install
+++ b/openy.install
@@ -18,7 +18,7 @@ function openy_install() {
   // Set the default and admin theme.
   $config_factory
     ->getEditable('system.theme')
-    ->set('admin', 'seven')
+    ->set('admin', 'claro')
     ->save(TRUE);
 
   // Enable the admin theme.
@@ -29,6 +29,9 @@ function openy_install() {
 
   // Enable openy_upgrade_tool.
   $module_installer->install(['openy_upgrade_tool'], TRUE);
+
+  // Enable jquery_ui_tooltip for Installation Wizard.
+  $module_installer->install(['jquery_ui_tooltip'], TRUE);
 
   // Enable openy_user after all modules are installed.
   $module_installer->install(['openy_user'], TRUE);

--- a/openy.libraries.yml
+++ b/openy.libraries.yml
@@ -6,5 +6,5 @@ installation_ui:
   js:
     assets/installation-profile-ui.js: {}
   dependencies:
-    - core/jquery.ui.tooltip
+    - jquery_ui_tooltip/tooltip
     - core/jquery.ui.dialog

--- a/themes/openy_themes/openy_campaign_theme/openy_campaign_theme.info.yml
+++ b/themes/openy_themes/openy_campaign_theme/openy_campaign_theme.info.yml
@@ -7,6 +7,8 @@ package: Open Y (Experimental)
 base theme: openy_rose
 libraries:
   - openy_campaign_theme/global-styling
+dependencies:
+  - jquery_ui_tabs:jquery_ui_tabs
 regions:
   header: Header
   logo: Logo

--- a/themes/openy_themes/openy_campaign_theme/openy_campaign_theme.install
+++ b/themes/openy_themes/openy_campaign_theme/openy_campaign_theme.install
@@ -6,9 +6,8 @@
  */
 
 /**
- * Enable openy_block_branch_contacts_info module.
+ * Enable jquery_ui_tooltip module.
  */
 function openy_campaign_theme_update_8001() {
     \Drupal::service('module_installer')->install(['jquery_ui_tooltip']);
-  }
-  
+}

--- a/themes/openy_themes/openy_campaign_theme/openy_campaign_theme.install
+++ b/themes/openy_themes/openy_campaign_theme/openy_campaign_theme.install
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @file
+ * Install and uninstall functions for the Open Y Campaign Theme.
+ */
+
+/**
+ * Enable openy_block_branch_contacts_info module.
+ */
+function openy_campaign_theme_update_8001() {
+    \Drupal::service('module_installer')->install(['jquery_ui_tooltip']);
+  }
+  

--- a/themes/openy_themes/openy_campaign_theme/openy_campaign_theme.libraries.yml
+++ b/themes/openy_themes/openy_campaign_theme/openy_campaign_theme.libraries.yml
@@ -10,7 +10,7 @@ global-styling:
   dependencies:
     - core/jquery
     - core/jquery.once
-    - core/jquery.ui.tabs
+    - jquery_ui_tabs/tabs
     - core/jquery.ui.core
     - core/jquery.ui.widget
     - core/drupal

--- a/themes/openy_themes/openy_lily/openy_lily.info.yml
+++ b/themes/openy_themes/openy_lily/openy_lily.info.yml
@@ -7,6 +7,8 @@ core: 8.x
 base theme: false
 libraries:
   - openy_lily/global-styling
+dependencies:
+  - jquery_ui_tabs:jquery_ui_tabs
 regions:
   logo: 'Logo'
   header: 'Header'

--- a/themes/openy_themes/openy_lily/openy_lily.install
+++ b/themes/openy_themes/openy_lily/openy_lily.install
@@ -6,9 +6,8 @@
  */
 
 /**
- * Enable openy_block_branch_contacts_info module.
+ * Enable jquery_ui_tabs module.
  */
 function openy_lily_update_8001() {
     \Drupal::service('module_installer')->install(['jquery_ui_tabs']);
-  }
-  
+}

--- a/themes/openy_themes/openy_lily/openy_lily.install
+++ b/themes/openy_themes/openy_lily/openy_lily.install
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @file
+ * Install and uninstall functions for the Open Y Lily Theme.
+ */
+
+/**
+ * Enable openy_block_branch_contacts_info module.
+ */
+function openy_lily_update_8001() {
+    \Drupal::service('module_installer')->install(['jquery_ui_tabs']);
+  }
+  

--- a/themes/openy_themes/openy_lily/openy_lily.libraries.yml
+++ b/themes/openy_themes/openy_lily/openy_lily.libraries.yml
@@ -16,7 +16,7 @@ global-styling:
   dependencies:
     - core/jquery
     - core/jquery.once
-    - core/jquery.ui.tabs
+    - jquery_ui_tabs/tabs
     - core/jquery.ui.core
     - core/jquery.ui.widget
     - core/drupal

--- a/themes/openy_themes/openy_rose/openy_rose.info.yml
+++ b/themes/openy_themes/openy_rose/openy_rose.info.yml
@@ -7,6 +7,8 @@ core: 8.x
 base theme: false
 libraries:
   - openy_rose/global-styling
+dependencies:
+  - jquery_ui_tabs:jquery_ui_tabs
 regions:
   header: Header
   logo: Logo

--- a/themes/openy_themes/openy_rose/openy_rose.install
+++ b/themes/openy_themes/openy_rose/openy_rose.install
@@ -6,9 +6,8 @@
  */
 
 /**
- * Enable openy_block_branch_contacts_info module.
+ * Enable jquery_ui_tabs module.
  */
 function openy_rose_update_8001() {
     \Drupal::service('module_installer')->install(['jquery_ui_tabs']);
-  }
-  
+}

--- a/themes/openy_themes/openy_rose/openy_rose.install
+++ b/themes/openy_themes/openy_rose/openy_rose.install
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @file
+ * Install and uninstall functions for the Open Y Rose Theme.
+ */
+
+/**
+ * Enable openy_block_branch_contacts_info module.
+ */
+function openy_rose_update_8001() {
+    \Drupal::service('module_installer')->install(['jquery_ui_tabs']);
+  }
+  

--- a/themes/openy_themes/openy_rose/openy_rose.libraries.yml
+++ b/themes/openy_themes/openy_rose/openy_rose.libraries.yml
@@ -16,7 +16,7 @@ global-styling:
   dependencies:
     - core/jquery
     - core/jquery.once
-    - core/jquery.ui.tabs
+    - jquery_ui_tabs/tabs
     - core/jquery.ui.core
     - core/jquery.ui.widget
     - core/drupal


### PR DESCRIPTION
Original Issue, this PR is going to fix: Backport of https://github.com/ymcatwincities/openy/pull/2142
See https://www.drupal.org/node/3067969



## Steps for review

- [x] Verify Schedules, Install Wizard, Tabs.


![image](https://user-images.githubusercontent.com/563412/92732948-c897a900-f37f-11ea-8f41-85631b852192.png)
![image](https://user-images.githubusercontent.com/563412/92733008-d8af8880-f37f-11ea-94ee-c143d88f78d2.png)

Thank you for your contribution!
