### PR TITLE
[CR-21] Update simple_menu_icons to 8.x-2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,7 +70,7 @@
         "drupal/scheduler": "1.3",
         "drupal/search_api": "1.17",
         "drupal/search_api_solr": "1.3",
-        "drupal/simple_menu_icons": "1.x-dev",
+        "drupal/simple_menu_icons": "2.x-dev",
         "drupal/simple_sitemap": "3.0.0",
         "drupal/slick": "~2.2",
         "drupal/slick_views": "~2.3",
@@ -150,9 +150,7 @@
         },
         "patches": {
             "drupal/simple_menu_icons": {
-                "2847964 - Clear cache after simple_menu_icons_css_generate": "https://www.drupal.org/files/issues/clear-cache-after-simple_menu_icons_css_generate-2847964.patch",
-                "2880544 - The theme implementations may not be rendered until all modules are loaded": "https://www.drupal.org/files/issues/theme-implementations-exception-2880544.patch",
-                "2937058 - Clear cache performance improvement": "https://www.drupal.org/files/issues/clear-cache-after-simple_menu_icons_css_generate-2847964-2.patch"
+                "3170845 - simple_menu_icons_css_generate() throws error if public://css doesn't exist": "https://www.drupal.org/files/issues/2020-09-14/simple_menu_icons-fix_500-3170845.patch"
             },
             "drupal/entity_browser": {
                 "2845037 - Fixed the issue of Call to a member function getConfigDependencyKey() on null on [Widget view], and [SelectionDisplay view]": "https://www.drupal.org/files/issues/2845037_15.patch",


### PR DESCRIPTION
Original Issue, this PR is going to fix: https://github.com/ymcatwincities/openy/issues/2080 

## Steps for review

- [x] verify compose checkouts `simple_menu_icon:8.x-2.x` and the patch applies well
- [ ] login as admin
- [ ] edit any menu's top-level menu item (e.g. main menu's menu item)
- [ ] upload an image using the **Icon image** field provided by the simple_menu_icons module
- [ ] save the menu item
- [ ] verify the site is not crashing
- [ ] verify a file `menu_icons_###########.css` created at `public://css` (depends on your setup, but usually it's `sites/default/files/css`):
  - the file contents should be similar to following:
```
  .menu-icon-7 .section-icon {
    background-image: url(/sites/lily/files/menu_icons/image.png);
  }

```
- [ ] go to the home page
- [ ] find the edited menu item
- [ ] add the `<div class="section-icon"></div>` markup under the `.menu-icon-7` element and verify the CSS is included on the page