### PR TITLE
[CR-18] Remove dependencies to media_entity_video, switch to core video media

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -172,6 +172,10 @@
                 "2918172 - Media Entity upgrade -> add revision fields": "https://www.drupal.org/files/issues/2918172-5.patch",
                 "2918172 - Media Entity upgrade -> core fails on absent column revision_uid": "https://www.drupal.org/files/issues/2918172-6-8.4.4.patch"
             },
+            "drupal/media_entity_video": {
+                "3148060 - Drupal 9 compatibility fixes": "https://www.drupal.org/files/issues/2020-09-15/3148060-media_entity_video-d9_fixes-8_0.patch",
+                "3149789 - Add a 3.x branch with an update path to the video source in core.": "https://www.drupal.org/files/issues/2020-06-11/3149789-4.patch"
+            },
             "drupal/blazy": {
                 "Remove core media dependencies to unblock upgrade": "https://raw.githubusercontent.com/ymcatwincities/openy/8.x-2.x/patches/blazy/remove-core-media-dependencies.patch",
                 "Add option for native browser lazy load": "https://www.drupal.org/files/issues/2020-06-18/3142503-native-option-2.patch",

--- a/modules/openy_features/openy_media/modules/openy_media_local_video/config/install/media.type.video_local.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_local_video/config/install/media.type.video_local.yml
@@ -3,14 +3,13 @@ status: true
 dependencies:
   module:
     - crop
-    - media_entity_video
 third_party_settings:
   crop:
     image_field: null
 id: video_local
 label: 'Local Video'
 description: 'Use Local Video for uploading locally hosted videos.'
-source: video
+source: video_file
 queue_thumbnail_downloads: false
 new_revision: false
 source_configuration:

--- a/modules/openy_features/openy_media/modules/openy_media_local_video/openy_media_local_video.info.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_local_video/openy_media_local_video.info.yml
@@ -22,5 +22,4 @@ dependencies:
   - entity_embed:entity_embed
   - openy_media:openy_media
   - video:video
-  - media_entity_video:media_entity_video
 core_incompatible: false

--- a/modules/openy_features/openy_media/modules/openy_media_video/openy_media_video.info.yml
+++ b/modules/openy_features/openy_media/modules/openy_media_video/openy_media_video.info.yml
@@ -16,7 +16,6 @@ dependencies:
   - entity_browser:entity_browser
   - entity_browser_entity_form:entity_browser_entity_form
   - entity_embed:entity_embed
-  - media_entity_video:media_entity_video
   - openy_media:openy_media
   - video_embed_field:video_embed_field
   - video_embed_media:video_embed_media

--- a/openy.install
+++ b/openy.install
@@ -586,7 +586,6 @@ function openy_update_8044() {
 function openy_update_8045() {
   // Enable modules.
   $modules = [
-    'media_entity_video',
     'video',
   ];
   foreach ($modules as $module) {


### PR DESCRIPTION
Original Issue, this PR is going to fix: https://github.com/ymcatwincities/openy/issues/2183

## Steps for review

- [x] verify the builds are successfully built
- [x] verify there are no dependencies to media_entity_video in Open Y anymore
- [x] verify the module is not turning on on fresh installs
- [x] verify the module is not turned off on upgrade builds 
- [x] verify the Local Video media type uses the Video file core media source:
  - [x] login as admin
  - [x] edit the Video Local media type (go to `/admin/structure/media/manage/video_local`)
  - [x] verify the `Media source` field indicates `Video file`
  ![image](https://user-images.githubusercontent.com/5453109/93317666-6d9a0200-f816-11ea-812d-1da51b976cae.png)
  If the `Media source` field is showing `Video` instead of `Video file`, the upgrade didn't go well.  `Media source` **prior to this PR**:
  ![image](https://user-images.githubusercontent.com/5453109/93318002-d2edf300-f816-11ea-884d-fb29aa750c9d.png)

## media_ modules overview
There are following `media_` modules in Open Y:
- **media_directories** - this is a module that provides Media Library browser thing, should be kept untouched;
- **media_entity** - legacy media_entity module, moved to Drupal Core, left in composer.json as a dependency for the Upgrade path from Open Y 1.x;
- **media_entity_document** - is not used by Open Y anymore, left in composer.json as a dependency for the Upgrade path from Open Y 1.x.
- **media_entity_image** - is not used by Open Y anymore, left here for the Upgrade path from Open Y 1.x;
- **media_entity_video** - this is a module in use. There are a couple of issues to resolve to get rid of the module: [fix d9 compatibility](https://www.drupal.org/project/media_entity_video/issues/3148060), [migrate to Drupal Core media](https://www.drupal.org/project/media_entity_video/issues/3149789) - both addressed in this PR. The module can be marked as deprecated in the release note. Should be kept in composer.json for the Upgrade path from Open Y 1.x.

## The way to deprecate modules:
  - add a note into the release notes that this is the last release with the ability to upgrade from Open Y 1.x;
  - remove the modules from composer.json in the release following the one with the deprecation note.