### PR TITLE
Restore non patched version of entity_embed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "drupal/entity": "^1",
         "drupal/entity_browser": "^2",
         "drupal/entity_clone": "^1.0",
-        "drupal/entity_embed": "^1",
+        "drupal/entity_embed": "1.1",
         "drupal/entity_reference_revisions": "~1.6",
         "drupal/features": "^3",
         "drupal/field_group": "~3.0",

--- a/composer.json
+++ b/composer.json
@@ -176,6 +176,9 @@
                 "2862702 - PrepareModulesEntityUninstallForm::formTitle does not exist": "https://www.drupal.org/files/issues/2862702-3.patch",
                 "2996114 - JSON:API Argument error": "https://www.drupal.org/files/issues/2020-02-11/2996114-124.patch"
             },
+            "drupal/entity_embed": {
+                "Add BC layer for entity_embed 1.1 for https://www.drupal.org/project/entity_embed/issues/2511404#comment-12129724": "https://gist.githubusercontent.com/podarok/47b9e38df6570a31d1ea87fea250d6c2/raw/d1435211dffe31cb6206d360e1d99f44c0deddee/entity_embed_1_1_bc_link_to.patch"
+            },
             "drupal/media_entity": {
                 "2918172 - Media Entity upgrade -> add revision fields": "https://www.drupal.org/files/issues/2918172-5.patch",
                 "2918172 - Media Entity upgrade -> core fails on absent column revision_uid": "https://www.drupal.org/files/issues/2918172-6-8.4.4.patch"

--- a/composer.json
+++ b/composer.json
@@ -167,9 +167,6 @@
                 "2845037 - Fixed the issue of Call to a member function getConfigDependencyKey() on null on [Widget view], and [SelectionDisplay view]": "https://www.drupal.org/files/issues/2845037_15.patch",
                 "2927347 - Having Entity Browser 2.x on the codebase breaks upgrade path": "https://www.drupal.org/files/issues/2019-01-10/Having-Entity-Browser-breaks-upgrade-path-2927347-14.patch"
             },
-            "drupal/entity_embed": {
-                "2511404 - Image entities/fields embedded using Entity Embed cannot be linked in CKEditor": "https://www.drupal.org/files/issues/entity_embed_links-2511404-31.patch"
-            },
             "drupal/plugin": {
                 "2647312 - Use SubFormState in plugin selectors": "https://www.drupal.org/files/issues/plugin_2647312_20.patch"
             },


### PR DESCRIPTION
Original Issue, this PR is going to fix: #2184

Check https://www.drupal.org/project/entity_embed/issues/2511404
This patch came from https://github.com/ymcatwincities/openy/pull/614 back in 2017
Long story short - we were using Patch from Comment 31 but the community decided no go with 31 but allow Link to work now.

OpenY patched entity_embed
```
<drupal-entity data-embed-button="embed_image" data-entity-embed-display="view_mode:media.full_without_blazy" data-entity-embed-display-settings="{&quot;link_url&quot;:&quot;https:\/\/openy.org&quot;}" data-entity-type="media" data-entity-uuid="868962c4-6e3a-4fb6-81e5-811471ee2cf4"></drupal-entity>
```

Latest entity_embed
```
<a href="https://openy.org" title="And a link">
<drupal-entity data-caption="Test caption" data-embed-button="embed_image" data-entity-embed-display="view_mode:media.full_without_blazy" data-entity-embed-display-settings="{&quot;link_url&quot;:&quot;&quot;}" data-entity-type="media" data-entity-uuid="7b4b31fb-c872-4be3-8f25-e33986a0524e" data-langcode="en"></drupal-entity>
</a>
```

Entity_embed now has the ability to use a link option from WYSIWYG instead of patched "Link to" which is not applicable to the newer version anymore.

## Steps for review

- [ ] Add Image via WYSIWYG Image Embed.
- [ ] Chose an embedded entity and click Link in WYSIWYG to add a link.
- [ ] Save a page and verify it is working now.

Regression - there is no upgrade path (
Possible suggestion to overcome upgrade path
- maintain our own patch/fork of entity_embed with patch to keep the "Link To" option. Make it as deprecated in order to let Content Managers know this shouldn't be used anymore ( ETA 1h )
- write upgrade path script ( ETA 20-100h given the almost infinite number of possible content usage where entity could be embedded via WYSIWYG. QA is about impossible to achieve )

Thank you for your contribution!
