### PR TITLE
[PROVED] Verify a bug dissapears - Taxonomy Autocomplete.

### DIFF
--- a/openy.info.yml
+++ b/openy.info.yml
@@ -69,7 +69,7 @@ dependencies:
   - twig_tweak:twig_tweak
   # Open Y
   - advanced_help_block:advanced_help_block
-  - openy_autocomplete_path:openy_autocomplete_path
+  # - openy_autocomplete_path:openy_autocomplete_path
   - openy_block_custom_simple:openy_block_custom_simple
   - openy_datalayer:openy_datalayer
   - openy_editor:openy_editor


### PR DESCRIPTION
See https://docs.google.com/spreadsheets/d/1FPfNz7Y7qgFVD4Ho4bkZG_KG_ml4jJf-nyCLKJesyr4/edit#gid=2062474544&range=A7

Bug:
in Drupal 9 when you use autocomplete and there is a limit by the bundle in field settings - this limit won't work and shows all instances from all bundles in autocomplete search.
This happens due to openy_autocomplete_path was created for Drupal 8 but in Drupal 9 this whole subsystem [changed significantly](https://www.drupal.org/list-changes/drupal/published?keywords_description=autocomplete&to_branch=&version=&created_op=%3E%3D&created%5Bvalue%5D=&created%5Bmin%5D=&created%5Bmax%5D=) and the module should be rewritten from scratch

Thank you for your contribution!
