### PR TITLE
Fix location teasers view modes update.

### DIFF
--- a/modules/openy_features/openy_location/modules/openy_loc_branch/openy_loc_branch.install
+++ b/modules/openy_features/openy_location/modules/openy_loc_branch/openy_loc_branch.install
@@ -450,7 +450,5 @@ function openy_loc_branch_update_8021() {
   $config_importer->setDirectory($config_dir);
   $config_importer->importConfigs([
     'core.entity_view_display.node.branch.teaser',
-    'core.entity_view_display.node.facility.teaser',
-    'core.entity_view_display.node.camp.teaser',
   ]);
 }

--- a/modules/openy_features/openy_location/modules/openy_loc_camp/openy_loc_camp.install
+++ b/modules/openy_features/openy_location/modules/openy_loc_camp/openy_loc_camp.install
@@ -297,3 +297,15 @@ function openy_loc_camp_update_8011() {
     }
   }
 }
+
+/**
+ * Update teaser view mode configs.
+ */
+function openy_loc_camp_update_8012() {
+  $config_dir = drupal_get_path('module', 'openy_loc_camp') . '/config/install/';
+  $config_importer = \Drupal::service('openy_upgrade_tool.importer');
+  $config_importer->setDirectory($config_dir);
+  $config_importer->importConfigs([
+    'core.entity_view_display.node.camp.teaser',
+  ]);
+}

--- a/modules/openy_features/openy_location/modules/openy_loc_facility/openy_loc_facility.install
+++ b/modules/openy_features/openy_location/modules/openy_loc_facility/openy_loc_facility.install
@@ -276,3 +276,15 @@ function openy_loc_facility_update_8012() {
     }
   }
 }
+
+/**
+ * Update teaser view mode configs.
+ */
+function openy_loc_facility_update_8013() {
+  $config_dir = drupal_get_path('module', 'openy_loc_facility') . '/config/install/';
+  $config_importer = \Drupal::service('openy_upgrade_tool.importer');
+  $config_importer->setDirectory($config_dir);
+  $config_importer->importConfigs([
+    'core.entity_view_display.node.facility.teaser',
+  ]);
+}


### PR DESCRIPTION
Apparently there is an issue in openy_loc_branch_update_8021() function as the 3 updated configs are in different modules/directories.
So the fix is to move erroneous config updates into corresponding modules.
