### PR TITLE
Resolve errors from logs when the `weeks` not set in the AF configuration

### DIFF
--- a/modules/custom/openy_activity_finder/config/install/openy_activity_finder.settings.yml
+++ b/modules/custom/openy_activity_finder/config/install/openy_activity_finder.settings.yml
@@ -1,6 +1,7 @@
 backend: openy_activity_finder.solr_backend
 index: default
 ages: "6,6mos\r\n12,12mos\r\n18,18mos\r\n24,2yrs\r\n36,3yrs\r\n48,4yrs\r\n60,5yrs\r\n72,6yrs\r\n84,7yrs\r\n96,8yrs\r\n108,9yrs\r\n120,10yrs\r\n132,11yrs\r\n144,12yrs\r\n156,13yrs\r\n168,14yrs\r\n180,15yrs\r\n192,16+yrs\r\n660,55+yrs"
+weeks: ""
 exclude: "61"
 disable_search_box: 0
 disable_spots_available: 0

--- a/modules/custom/openy_activity_finder/openy_activity_finder.install
+++ b/modules/custom/openy_activity_finder/openy_activity_finder.install
@@ -99,3 +99,14 @@ function openy_activity_finder_update_8006() {
     }
   }
 }
+
+/**
+ * Update Activity Finder configs.
+ */
+function openy_activity_finder_update_8007(&$sandbox) {
+  $config = \Drupal::configFactory()->getEditable('openy_activity_finder.settings');
+  if ($config && empty($config->get('weeks'))) {
+    $config->set('weeks', '');
+    $config->save();
+  }
+}

--- a/modules/custom/openy_activity_finder/src/OpenyActivityFinderBackend.php
+++ b/modules/custom/openy_activity_finder/src/OpenyActivityFinderBackend.php
@@ -44,6 +44,11 @@ abstract class OpenyActivityFinderBackend implements OpenyActivityFinderBackendI
     $ages = [];
 
     $ages_config = $this->config->get('ages');
+
+    if (!$ages_config) {
+      return [];
+    }
+
     foreach (explode("\n", $ages_config) as $row) {
       $row = trim($row);
       list($months, $label) = explode(',', $row);
@@ -63,6 +68,11 @@ abstract class OpenyActivityFinderBackend implements OpenyActivityFinderBackendI
     $weeks = [];
 
     $weeks_config = $this->config->get('weeks');
+
+    if (!$weeks_config) {
+      return [];
+    }
+
     foreach (explode("\n", $weeks_config) as $row) {
       $row = trim($row);
       list($months, $label) = explode(',', $row);

--- a/modules/custom/openy_activity_finder/src/OpenyActivityFinderSolrBackend.php
+++ b/modules/custom/openy_activity_finder/src/OpenyActivityFinderSolrBackend.php
@@ -577,10 +577,10 @@ class OpenyActivityFinderSolrBackend extends OpenyActivityFinderBackend {
           foreach ($program_subcategories as $program_subcategory_node) {
             if ($program_node = $program_subcategory_node->field_category_program->entity) {
               $data[$program_subcategory_node->id()] = [
-                'title' => $program_subcategory_node->title->value,
+                'title' => $program_subcategory_node->label(),
                 'program' => [
                   'nid' => $program_node->id(),
-                  'title' => $program_node->title->value,
+                  'title' => $program_node->label(),
                 ],
               ];
             }
@@ -647,14 +647,14 @@ class OpenyActivityFinderSolrBackend extends OpenyActivityFinderBackend {
                 ];
               }
             }
-            $data[$location->title->value] =[
+            $data[$location->label()] =[
               'type' => $location->bundle(),
               'address' => $address,
               'days' => $days,
               'email' => $location->field_location_email->value,
               'nid' => $location->id(),
               'phone' => $location->field_location_phone->value,
-              'title' => $location->title->value
+              'title' => $location->label()
             ];
           }
         }


### PR DESCRIPTION
Checking the possibility to use AF on the 9.x I've noticed some errors in the logs like:
![image](https://user-images.githubusercontent.com/5138333/96470259-c35b3300-1236-11eb-8ace-f27e8b141581.png)

The problem was that on the clean installation there are no `weeks` values in the module configuration.
From the other side, there are no checks if the value from the configs is present at all.
So I've added some checks, as well as some refactoring of the way the node titles values get.
