### PR TITLE
[2191] Display the field_content with any page layout value

### DIFF
--- a/themes/openy_themes/openy_rose/templates/node/node--landing-page--full.html.twig
+++ b/themes/openy_themes/openy_rose/templates/node/node--landing-page--full.html.twig
@@ -119,19 +119,7 @@
 
     {% if content.field_content|render|trim is not empty %}
       <div{{ content_attributes.addClass(content_classes) }}>
-        {% if node.field_lp_layout.value == "one_column" %}
-          <div class="main-region col-sm-12">
-            {{ content.field_content }}
-            {% if content.addthis is not empty %}
-              {{ content.addthis }}
-            {% endif %}
-            {% if content.field_sidebar_content.0 %}
-              <aside{{ sidebar_attributes.addClass(sidebar_classes) }}>
-                {{ content.field_sidebar_content }}
-              </aside>
-            {% endif %}
-          </div>
-        {% elseif ( node.field_lp_layout.value == "two_column" ) or ( node.field_lp_layout.value == "two_column_fixed" ) %}
+        {% if ( node.field_lp_layout.value == "two_column" ) or ( node.field_lp_layout.value == "two_column_fixed" ) %}
           <div class="two-column">
             <div class="main-region col-sm-8">
               {{ content.field_content }}
@@ -162,6 +150,18 @@
                 {{ content.addthis }}
               {% endif %}
             </div>
+          </div>
+        {% else %}
+          <div class="main-region{{ node.field_lp_layout.value == "one_column" ? ' col-sm-12' : '' }}">
+            {{ content.field_content }}
+            {% if content.addthis is not empty %}
+              {{ content.addthis }}
+            {% endif %}
+            {% if content.field_sidebar_content.0 %}
+              <aside{{ sidebar_attributes.addClass(sidebar_classes) }}>
+                {{ content.field_sidebar_content }}
+              </aside>
+            {% endif %}
           </div>
         {% endif %}
       </div>


### PR DESCRIPTION
Original Issue, this PR is going to fix: https://github.com/ymcatwincities/openy/issues/2191

## Steps for review

- [ ] Log in to a site.
- [ ] Ensure that the openy_rose theme is set as a default one.
- [ ] Visit `/activity-finder` page or create a new `Landing page` with some paragraph(s) in the `Content` region and the `"One Column - Full width"` layout.
- [ ] Ensure the paragraphs are displayed on the page view.
- [ ] Change the layout of the page to `"One Column"` and ensure the paragraphs are rendered.
- [ ] Change the layout of the page to other -- `"Two Columns"`, etc., add some paragraphs to the `Sidebar Area` region, and ensure both columns are shown, with paragraphs rendered respectively.