### PR TITLE
Get stable version of custom formatters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "drupal/crop": "^2.0",
         "drupal/css_editor": "^1.2",
         "drupal/ctools": "3.0",
-        "drupal/custom_formatters": "3.0-alpha1",
+        "drupal/custom_formatters": "^3.0 || ^3.0@beta",
         "drupal/datalayer": "1.x-dev",
         "drupal/domain": "1.0-alpha14",
         "drupal/domain_theme_switch": "^1.4",


### PR DESCRIPTION
https://www.drupal.org/project/custom_formatters/releases/8.x-3.0-beta1

Original Issue, this PR is going to fix: get rid of dev/alpha version constraints


## Steps for review

- [ ] Tested on Drupal 9 https://github.com/ymcatwincities/openy/pull/2255.
- [ ] CHeck Branch Amenities Block is working.


Thank you for your contribution!
