### PR TITLE
[INOYI-31] - added processing the '<front>' token for the 'alert_visibility_pages' field

### DIFF
--- a/modules/openy_features/openy_node/modules/openy_node_alert/config/install/field.field.node.alert.field_alert_visibility_state.yml
+++ b/modules/openy_features/openy_node/modules/openy_node_alert/config/install/field.field.node.alert.field_alert_visibility_state.yml
@@ -16,7 +16,7 @@ field_name: field_alert_visibility_state
 entity_type: node
 bundle: alert
 label: 'Alert visibility state'
-description: 'Specify pages by using their paths. Enter one path per line. The ''*'' character is a wildcard. An example path is /user/* for every user page. is the front page.'
+description: 'Specify pages by using their paths. Enter one path per line. The ''*'' character is a wildcard. An example path is /user/* for every user page. <front> is the front page.'
 required: true
 translatable: false
 default_value:


### PR DESCRIPTION
Original Issue, this PR is going to fix: [#2129](https://github.com/ymcatwincities/openy/issues/2129) ( publicly available )

Now we should have an ability to put the "**\<front\>**" token to the 'alert_visibility_pages' field.
![INOYI-31visibilityPages](https://user-images.githubusercontent.com/744406/98127762-bccbed00-1ebf-11eb-9a3c-fab3fd7814d3.png)


Make sure these boxes are checked before asking for review of your pull request - thank you!

If there is a new feature or this is a bug fix - use 8.x-2.x branch. We'll tag for release if the bug is critical asap or tag for release next bug fix release until critical issue arrived.

## Steps for review

- [ ] Log as admin.
- [ ] Go to the edit node CT Alert or to create a new one.
- [ ] Specify pages by using their paths. Enter one path per line in the  **Visibility pages->Pages** field. Please use the "**\<front\>**" as one of varinats.
- [ ] Save node.
- [ ] Go to the home page, you should see this alert banner. If you remove the "**\<front\>**"  from the **Visibility pages->Pages** field, you shouldn't see this banner on home page.


## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer. See [Code of Conduct](https://github.com/ymcatwincities/openy/wiki/Open-Y-Code-of-Conduct-and-Best-Practices).
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
