### PR TITLE
Fix Embed Button by downgrading dropzonejs to 2.1 version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "drupal/domain": "^1.0@beta || ^1.0",
         "drupal/domain_theme_switch": "^1.4",
         "drupal/draggableviews": "^1.2",
-        "drupal/dropzonejs": "^2.0",
+        "drupal/dropzonejs": "2.1",
         "drupal/easy_breadcrumb": "^1.8",
         "drupal/editor_advanced_link": "^1.6",
         "drupal/embed": "1.0",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "drupal/editor_advanced_link": "^1.6",
         "drupal/embed": "1.0",
         "drupal/entity": "1.0.0-rc2",
-        "drupal/entity_browser": "2.0.0",
+        "drupal/entity_browser": "~2.5",
         "drupal/entity_clone": "^1.0",
         "drupal/entity_embed": "1.0-beta2",
         "drupal/entity_reference_revisions": "~1.6",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "drupal/editor_advanced_link": "^1.6",
         "drupal/embed": "1.0",
         "drupal/entity": "1.0.0-rc2",
-        "drupal/entity_browser": "~2.5",
+        "drupal/entity_browser": "^2.5",
         "drupal/entity_clone": "^1.0",
         "drupal/entity_embed": "1.0-beta2",
         "drupal/entity_reference_revisions": "~1.6",


### PR DESCRIPTION
Original Issue, this PR is going to fix: 
![image](https://user-images.githubusercontent.com/563412/98670862-043cf800-235c-11eb-870e-fcb1d60872f5.png)


see https://youtu.be/pq0yzEwWzdQ and https://www.drupal.org/project/dropzonejs/issues/3181664

Steps for review
- [ ] Check Local Video button allows you to upload videos of mp4 extension
![image](https://user-images.githubusercontent.com/563412/98670910-19198b80-235c-11eb-99c7-f280c6bd09de.png)


Thank you for your contribution!
