### PR TITLE
Get  supported ckeditor_bootstrap_buttons module version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "drupal/better_exposed_filters": "^5",
         "drupal/blazy": "2.1",
         "drupal/captcha": "^1.0",
-        "drupal/ckeditor_bootstrap_buttons": "^1.2",
+        "drupal/ckeditor_bootstrap_buttons": "^1.2 || ^2.0",
         "drupal/ckeditor_font": "^1.1",
         "drupal/colorbutton": "1.1",
         "drupal/confi": "~1.4 || ~2.0",


### PR DESCRIPTION
Original Issue, this PR is going to fix: ckeditor_bootstrap_buttons 1.x unsupported

## Steps for review

- [ ] Verify buttons button does work.
![image](https://user-images.githubusercontent.com/563412/98704183-05364f80-2385-11eb-9805-447e058aee1e.png)


Thank you for your contribution!
