### PR TITLE
[ROY-25] Fix half size image for Rose theme

### DIFF
--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -6331,6 +6331,11 @@ body .branch-popup + .ui-widget-overlay {
   }
 }
 
+.embedded-entity img {
+  height: auto;
+  max-width: 100%;
+  width: auto;
+}
 .embedded-entity .media-image.view-mode-link {
   display: inline;
 }

--- a/themes/openy_themes/openy_rose/scss/modules/_landing.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_landing.scss
@@ -28,6 +28,11 @@
 }
 
 .embedded-entity {
+  img {
+    height: auto;
+    max-width: 100%;
+    width: auto;
+  }
   .media-image.view-mode-link {
     display: inline;
   }

--- a/themes/openy_themes/openy_rose/templates/node/node--landing-page--full.html.twig
+++ b/themes/openy_themes/openy_rose/templates/node/node--landing-page--full.html.twig
@@ -99,8 +99,8 @@
 %}
 
 {% if content.field_header_content|render|trim is not empty %}
-  <div{{ header_attributes.addClass(header_classes) }}>
-    <div{{ content_attributes }}>
+  <div{{ attributes.addClass(header_classes) }}>
+    <div{{ content_attributes.addClass(header_content_classes) }}>
       <div class="main">
         {{ content.field_header_content }}
       </div>


### PR DESCRIPTION
Issue: https://github.com/ymcatwincities/openy/issues/2292

## Steps for review

- [x] Login as admin.
- [x] Create Landing Page and add 1 column paragraph.
- [x] Add image and choose `Half Without Blazy`
![image](https://user-images.githubusercontent.com/22738130/100439528-55632080-30ac-11eb-82fe-d5bf1c7060a8.png)
- [x] Save and make sure that the image, not full size.

## General checks
- [x] All coding styles are fulfilled and there are no any issues reported by CodeSniffer. See [Code of Conduct](https://github.com/ymcatwincities/openy/wiki/Open-Y-Code-of-Conduct-and-Best-Practices).
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/8.x-1.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/8.x-1.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/8.x-1.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
