### PR TITLE
Enable colorapi enable before jquery_colorpicker_update_8200

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "drupal/captcha": "^1.0",
         "drupal/ckeditor_bootstrap_buttons": "^1.2 || ^2.0",
         "drupal/ckeditor_font": "^1.1",
+        "drupal/colorapi": "^1.1",
         "drupal/colorbutton": "1.1",
         "drupal/confi": "^1.4 || ^2.0",
         "drupal/config_update": "^1.6",

--- a/openy.install
+++ b/openy.install
@@ -77,6 +77,14 @@ function openy_update_dependencies() {
       'system' => 8805,
     ],
   ];
+  
+  // Run jquery_colorpicker_update_8200 after colorapi enabled.
+  $dependencies['jquery_colorpicker'] = [
+    8200 => [
+      'openy_txnm_color' => 8005,
+    ],
+  ];
+  
   return $dependencies;
 }
 


### PR DESCRIPTION
Original Issue, this PR is going to fix: https://openy.slack.com/archives/C6G4ZTLVC/p1605824088012700


## Steps for review

- [ ] Verify upgrade path for colorapi is working.


Thank you for your contribution!
