### PR TITLE
Allow 9.0.x and 9.1.x cores for Open Y

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "drupal/colorbutton": "^1",
         "drupal/confi": "^2.0@RC || ^2.0",
         "drupal/config_update": "^1.6",
-        "drupal/core": "~9.0.7",
+        "drupal/core": "^9.0.9",
         "drupal/core-composer-scaffold": "^9",
         "drupal/core-project-message": "^9",
         "drupal/core-recommended": "^9",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "drupal/colorbutton": "^1",
         "drupal/confi": "^2.0@RC || ^2.0",
         "drupal/config_update": "^1.6",
-        "drupal/core": "^9.0.9",
+        "drupal/core": "~9.0.9 || ~9.1.0",
         "drupal/core-composer-scaffold": "^9",
         "drupal/core-project-message": "^9",
         "drupal/core-recommended": "^9",


### PR DESCRIPTION
Original Issue, this PR is going to fix: Ensure we can go with 9.1 core


## Steps for review

- [x] Verify upgrade path.
- [x] Verify build from scratch.


Thank you for your contribution!

### Documentation to be included in wiki/release notes after merging this PR

February 2021 release tagged Drupal core both 9.0.x and 9.1.x as allowed to be used.
Composer by default is installing latest stable version, so a command 
```bash
composer create-project ymcatwincities/openy-project:dev-9.2.x-development OPENY --no-interaction
```

will install Open Y on latest 9.1.x Drupal core.
If there is a need to stay on Drupal 9.0.x stable core please use
```bash
composer create-project ymcatwincities/openy-project:dev-9.2.x-development OPENY --no-interaction
cd OPENY
composer require drupal/core:~9.0.7
```
where 9.0.7 - is a needed version for your Open Y instance

