### PR TITLE
Add uninstall hook. Remove dependency from profile.

### DIFF
--- a/openy.info.yml
+++ b/openy.info.yml
@@ -69,7 +69,6 @@ dependencies:
   - twig_tweak:twig_tweak
   # Open Y
   - advanced_help_block:advanced_help_block
-  - openy_autocomplete_path:openy_autocomplete_path
   - openy_block_custom_simple:openy_block_custom_simple
   - openy_datalayer:openy_datalayer
   - openy_editor:openy_editor

--- a/openy.install
+++ b/openy.install
@@ -1171,3 +1171,10 @@ function openy_update_8084() {
     \Drupal::service('module_installer')->install(['jquery_ui_tabs']);
   }
 }
+
+/**
+ * Uninstall openy_autocomplete_path module.
+ */
+function openy_update_8086() {
+    \Drupal::service('module_installer')->uninstall(['openy_autocomplete_path']);
+}


### PR DESCRIPTION
Original Issue, this PR is going to fix: #2226 
Module itself decoupled to drupal.org https://www.drupal.org/project/openy_autocomplete_path
In 2021 in Q2 openy_autocomplete_path module will be removed from Open Y codebase - see https://github.com/ymcatwincities/openy/pull/2349

## Steps for review

- [x] Verify openy_autocomplete_path is disabled on fresh installed site.
- [x] Check openy_autocomplete_path is disabled in upgraded site.


## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer. See [Code of Conduct](https://github.com/ymcatwincities/openy/wiki/Open-Y-Code-of-Conduct-and-Best-Practices).
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/9.x-2.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/9.x-2.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/9.x-2.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/9.x-2.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/9.x-2.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
