### PR TITLE
Make Coordinates required field

### DIFF
--- a/modules/openy_features/openy_location/modules/openy_loc_branch/config/install/field.field.node.branch.field_location_coordinates.yml
+++ b/modules/openy_features/openy_location/modules/openy_loc_branch/config/install/field.field.node.branch.field_location_coordinates.yml
@@ -17,7 +17,7 @@ entity_type: node
 bundle: branch
 label: 'Branch Coordinates'
 description: ''
-required: false
+required: true
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/modules/openy_features/openy_location/modules/openy_loc_branch/openy_loc_branch.install
+++ b/modules/openy_features/openy_location/modules/openy_loc_branch/openy_loc_branch.install
@@ -452,3 +452,24 @@ function openy_loc_branch_update_8021() {
     'core.entity_view_display.node.branch.teaser',
   ]);
 }
+
+/**
+ * Update Open Y Branch feature to set coordinates as required field.
+ */
+function openy_loc_branch_update_8023() {
+  $config_dir = drupal_get_path('module', 'openy_loc_branch') . '/config/install/';
+  // Update multiple configurations.
+  $configs = [
+    'field.field.node.branch.field_location_coordinates' =>[
+      'required',
+    ],
+  ];
+
+  $config_updater = \Drupal::service('openy_upgrade_tool.param_updater');
+  foreach ($configs as $config_name => $params) {
+    $config = $config_dir . $config_name . '.yml';
+    foreach ($params as $param) {
+      $config_updater->update($config, $config_name, $param);
+    }
+  }
+}

--- a/modules/openy_features/openy_location/modules/openy_loc_camp/config/install/field.field.node.camp.field_location_coordinates.yml
+++ b/modules/openy_features/openy_location/modules/openy_loc_camp/config/install/field.field.node.camp.field_location_coordinates.yml
@@ -16,7 +16,7 @@ entity_type: node
 bundle: camp
 label: 'Camp Coordinates'
 description: ''
-required: false
+required: true
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/modules/openy_features/openy_location/modules/openy_loc_camp/openy_loc_camp.install
+++ b/modules/openy_features/openy_location/modules/openy_loc_camp/openy_loc_camp.install
@@ -309,3 +309,24 @@ function openy_loc_camp_update_8012() {
     'core.entity_view_display.node.camp.teaser',
   ]);
 }
+
+/**
+ * Update Open Y Camp feature to set coordinates as required field.
+ */
+function openy_loc_camp_update_8014() {
+  $config_dir = drupal_get_path('module', 'openy_loc_camp') . '/config/install/';
+  // Update multiple configurations.
+  $configs = [
+    'field.field.node.camp.field_location_coordinates' =>[
+      'required',
+    ],
+  ];
+
+  $config_updater = \Drupal::service('openy_upgrade_tool.param_updater');
+  foreach ($configs as $config_name => $params) {
+    $config = $config_dir . $config_name . '.yml';
+    foreach ($params as $param) {
+      $config_updater->update($config, $config_name, $param);
+    }
+  }
+}

--- a/modules/openy_features/openy_location/modules/openy_loc_facility/config/install/field.field.node.facility.field_location_coordinates.yml
+++ b/modules/openy_features/openy_location/modules/openy_loc_facility/config/install/field.field.node.facility.field_location_coordinates.yml
@@ -16,7 +16,7 @@ entity_type: node
 bundle: facility
 label: 'Facility Coordinates'
 description: ''
-required: false
+required: true
 translatable: true
 default_value: {  }
 default_value_callback: ''

--- a/modules/openy_features/openy_location/modules/openy_loc_facility/openy_loc_facility.install
+++ b/modules/openy_features/openy_location/modules/openy_loc_facility/openy_loc_facility.install
@@ -288,3 +288,24 @@ function openy_loc_facility_update_8013() {
     'core.entity_view_display.node.facility.teaser',
   ]);
 }
+
+/**
+ * Update Open Y Facility feature to set coordinates as required field.
+ */
+function openy_loc_facility_update_8015() {
+  $config_dir = drupal_get_path('module', 'openy_loc_facility') . '/config/install/';
+  // Update multiple configurations.
+  $configs = [
+    'field.field.node.facility.field_location_coordinates' =>[
+      'required',
+    ],
+  ];
+
+  $config_updater = \Drupal::service('openy_upgrade_tool.param_updater');
+  foreach ($configs as $config_name => $params) {
+    $config = $config_dir . $config_name . '.yml';
+    foreach ($params as $param) {
+      $config_updater->update($config, $config_name, $param);
+    }
+  }
+}


### PR DESCRIPTION
Original Issue, this PR is going to fix: #2327 


Make sure these boxes are checked before asking for review of your pull request - thank you!

If there is a new feature or this is a bug fix - use 9.x-2.x branch. We'll tag for release if the bug is critical asap or tag for release next bug fix release until critical issue arrived.

## Steps for review

- [x] Check branch/camp/facility Coordinates are now required field.
- [x] Check upgrade path Coordinates now required field.
![image](https://user-images.githubusercontent.com/563412/103526877-32394700-4e8a-11eb-8c16-ee6410404d45.png)



## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer. See [Code of Conduct](https://github.com/ymcatwincities/openy/wiki/Open-Y-Code-of-Conduct-and-Best-Practices).
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/9.x-2.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/9.x-2.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/9.x-2.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/9.x-2.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/9.x-2.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
