### PR TITLE
Use video from Drupal.org. Get rid of last fork dependency in 9.x branch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,6 +84,7 @@
         "drupal/tzfield": "^1.3",
         "drupal/vendor_stream_wrapper": "^1.6",
         "drupal/verf": "1.0-beta7 || ^1.0",
+        "drupal/video": "^1.5@alpha || ^1.5beta || ^1.5",
         "drupal/video_embed_field": "^2.0",
         "drupal/views_block_filter_block": "^1.0",
         "drupal/views_data_export": "1.0-rc1 || ^1.0",
@@ -108,8 +109,7 @@
         "symfony/dom-crawler": "~2.8 || ~3.0 || ~4.2",
         "symfony/process": "^4",
         "ymcatwincities/media_entity_document": "*",
-        "ymcatwincities/openy_activity_finder": "^3.1 || ^4.0",
-        "ymcatwincities/video": "*"
+        "ymcatwincities/openy_activity_finder": "^3.1 || ^4.0"
     },
     "require-dev": {
         "consolidation/robo": "^1.1.5"


### PR DESCRIPTION
See https://www.drupal.org/project/video/releases/8.x-1.5-alpha1

Original Issue, this PR is going to fix: get rid of custom forks and patched releases

Make sure these boxes are checked before asking for review of your pull request - thank you!

If there is a new feature or this is a bug fix - use 9.x-2.x branch. We'll tag for release if the bug is critical asap or tag for release next bug fix release until critical issue arrived.

## Steps for review

- [x] Check video module has a 1.5-alpha1 version string from drupal.org.


## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer. See [Code of Conduct](https://github.com/ymcatwincities/openy/wiki/Open-Y-Code-of-Conduct-and-Best-Practices).
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/9.x-2.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/9.x-2.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/9.x-2.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/9.x-2.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/9.x-2.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
