### PR TITLE
Disable online availability for having more FULL classes

### DIFF
--- a/modules/openy_features/openy_demo_content/modules/openy_demo_nsessions/config/install/migrate_plus.migration.openy_demo_node_session_05.yml
+++ b/modules/openy_features/openy_demo_content/modules/openy_demo_nsessions/config/install/migrate_plus.migration.openy_demo_node_session_05.yml
@@ -22,7 +22,7 @@ source:
           time: sports_classes_and_workshops_youth_fitness_challenge_2
       location: 2
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -42,7 +42,7 @@ source:
           time: sports_classes_and_workshops_youth_homezone_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -62,7 +62,7 @@ source:
           time: health_n_wellness_wrkshops_aoa_senior_health_and_fitness_day_2
       location: 2
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 144
@@ -82,7 +82,7 @@ source:
           time: health_and_wellness_workshops_aoa_brain_agility_fee_spr_2017_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 600
@@ -101,7 +101,7 @@ source:
           time: health_n_wellness_wrkshps_aoa_brain_agility_mat_fee_spr_2017_2
       location: 2
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 600
@@ -120,7 +120,7 @@ source:
           time: group_exercise_classes_hiit_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 216
@@ -136,7 +136,7 @@ source:
           time: group_exercise_classes_hiit_metabolic_conditioning_2
       location: 2
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 216
@@ -152,7 +152,7 @@ source:
           time: group_exercise_classes_moving_for_balance_spr_2017_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 216
@@ -168,7 +168,7 @@ source:
           time: smll_grp_training_youth_small_group_training_tween_girl_power_2
       location: 2
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 120
@@ -206,7 +206,7 @@ source:
           time: pilates_reformer_10_private_1hr_sessions_2
       location: 2
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 216
@@ -226,7 +226,7 @@ source:
           time: private_yoga_10_1hour_sessions_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 216
@@ -246,7 +246,7 @@ source:
           time: pilates_reformer_duet_10_1hour_sessions_2
       location: 2
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 192
@@ -266,7 +266,7 @@ source:
           time: partner_personal_training_1_session_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 216
@@ -286,7 +286,7 @@ source:
           time: health_improvement_livestrong_at_the_y_2
       location: 2
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 156
@@ -306,7 +306,7 @@ source:
           time: health_improvement_nutrition_consultation_initial_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 216
@@ -325,7 +325,7 @@ source:
           time: health_improvement_activly_changing_together_2
       location: 2
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 216
@@ -344,7 +344,7 @@ source:
           time: climbing_adult_rock_climbing_sept_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 216
@@ -363,7 +363,7 @@ source:
           time: climbing_adult_rock_climbing_oct_2
       location: 2
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 216
@@ -382,7 +382,7 @@ source:
           time: climbing_adult_parent_child_sept_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -400,7 +400,7 @@ source:
           time: climbing_adult_parent_child_oct_2
       location: 2
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -419,7 +419,7 @@ source:
           time: small_group_and_specialty_training_adaptive_yoga_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 216
@@ -438,7 +438,7 @@ source:
           time: smll_grp_and_specialty_training_pilates_reformer_level_1_2
       location: 2
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 216
@@ -476,7 +476,7 @@ source:
           time: small_group_and_specialty_training_pilates_reformer_level_1_2_2
       location: 2
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: true
       in_membership: true
       age_min: 216
@@ -495,7 +495,7 @@ source:
           time: weight_loss_lose_to_win_men_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: true
       in_membership: true
       age_min: 216
@@ -514,7 +514,7 @@ source:
           time: weight_loss_lose_to_win_2
       location: 2
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: true
       in_membership: true
       age_min: 216
@@ -533,7 +533,7 @@ source:
           time: b4_after_school_child_care_2016_17_woodmoor_non_school_days_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -553,7 +553,7 @@ source:
           time: before_after_school_child_care_2016_17_woodmoor_after_plus_2
       location: 2
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -573,7 +573,7 @@ source:
           time: before_after_school_child_care_2016_17_woodmoor_after_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -593,7 +593,7 @@ source:
           time: before_after_school_child_care_2016_17_sunrise_before_after_2
       location: 2
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -613,7 +613,7 @@ source:
           time: preschool_child_care_2016_17_northshore_pre_k_4_5yrs_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -633,7 +633,7 @@ source:
           time: preschool_child_care_2016_17_northshore_preschool_30m_4yr_2
       location: 2
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -653,7 +653,7 @@ source:
           time: discovery_day_camp_drop_off_carol_edwards_ctr_2017_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -673,7 +673,7 @@ source:
           time: discovery_day_camp_drop_off_kenmore_elementary_2017_2
       location: 2
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -693,7 +693,7 @@ source:
           time: discovery_day_camp_drop_off_Northshore_ymca_2017_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -713,7 +713,7 @@ source:
           time: bold_one_wk_expeditions_cascade_challenge_2
       location: 2
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 144
@@ -751,7 +751,7 @@ source:
           time: bold_one_wk_expeditions_river_and_rocks_2
       location: 2
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -771,7 +771,7 @@ source:
           time: bold_one_wk_expeditions_fishing_and_backpacking_north_cascades_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -791,7 +791,7 @@ source:
           time: earth_service_corps_about_yesc_2
       location: 2
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 156
@@ -811,7 +811,7 @@ source:
           time: academic_success_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -831,7 +831,7 @@ source:
           time: academic_success_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -851,7 +851,7 @@ source:
           time: academic_success_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -871,7 +871,7 @@ source:
           time: academic_success_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -891,7 +891,7 @@ source:
           time: academic_success_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -911,7 +911,7 @@ source:
           time: academic_success_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -931,7 +931,7 @@ source:
           time: academic_success_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -951,7 +951,7 @@ source:
           time: academic_success_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -971,7 +971,7 @@ source:
           time: academic_success_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -991,7 +991,7 @@ source:
           time: academic_success_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -1011,7 +1011,7 @@ source:
          time: academic_success_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -1031,7 +1031,7 @@ source:
          time: academic_success_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -1051,7 +1051,7 @@ source:
           time: academic_success_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -1071,7 +1071,7 @@ source:
           time: academic_success_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -1091,7 +1091,7 @@ source:
           time: academic_success_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -1111,7 +1111,7 @@ source:
           time: academic_success_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -1131,7 +1131,7 @@ source:
           time: academic_success_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -1151,7 +1151,7 @@ source:
           time: academic_success_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -1171,7 +1171,7 @@ source:
           time: academic_success_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -1191,7 +1191,7 @@ source:
           time: academic_success_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -1211,7 +1211,7 @@ source:
           time: academic_success_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -1231,7 +1231,7 @@ source:
           time: academic_success_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -1251,7 +1251,7 @@ source:
           time: academic_success_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -1271,7 +1271,7 @@ source:
           time: academic_success_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -1291,7 +1291,7 @@ source:
           time: academic_success_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -1311,7 +1311,7 @@ source:
           time: academic_success_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -1331,7 +1331,7 @@ source:
           time: academic_success_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -1351,7 +1351,7 @@ source:
           time: academic_success_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -1371,7 +1371,7 @@ source:
           time: academic_success_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -1391,7 +1391,7 @@ source:
           time: academic_success_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -1411,7 +1411,7 @@ source:
           time: academic_success_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60
@@ -1431,7 +1431,7 @@ source:
           time: academic_success_2
       location: 1
       facility: 92
-      online_registration: true
+      online_registration: false
       ticket_required: false
       in_membership: false
       age_min: 60


### PR DESCRIPTION
Original Issue, this PR is going to fix: https://openy.atlassian.net/browse/PRODDEV-148


Make sure these boxes are checked before asking for review of your pull request - thank you!

If there is a new feature or this is a bug fix - use 9.x-2.x branch. We'll tag for release if the bug is critical asap or tag for release next bug fix release until critical issue arrived.

## Steps for review

- [ ] Just code review.
- [ ] On full install there will be more FULL availability sessions.
- [ ] Condition: initial availability = 0, online registration = false => Should be FULL in Activity FInder


## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer. See [Code of Conduct](https://github.com/ymcatwincities/openy/wiki/Open-Y-Code-of-Conduct-and-Best-Practices).
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/9.x-2.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/9.x-2.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/9.x-2.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/9.x-2.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/9.x-2.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
