### PR TITLE
Fix visibility checks for global alerts.

### DIFF
--- a/modules/openy_features/openy_node/modules/openy_node_alert/src/Plugin/rest/resource/AlertsRestResource.php
+++ b/modules/openy_features/openy_node/modules/openy_node_alert/src/Plugin/rest/resource/AlertsRestResource.php
@@ -319,7 +319,7 @@ class AlertsRestResource extends ResourceBase {
     }
 
     $visibility_paths = mb_strtolower($visibility_paths);
-    $pages = preg_split("(\r\n?|\n)", $visibility_paths);
+    $pages = array_filter(preg_split("(\r\n?|\n)", $visibility_paths));
 
     if (empty($pages)) {
       // Global alert.


### PR DESCRIPTION
If alert is global then the $pages array ends up as [0 => ""] and can't be empty after the preg_split function.

Steps to review:
- [ ] create new alert with no visibility limitations
- [ ] verify it is visible on frontpage and several other pages

Conversation about this in Slack https://openy.slack.com/archives/C6G4ZTLVC/p1611132731028300