### PR TITLE
[MAINTAIN-30] fixed layout for a taxonomy term pages

### DIFF
--- a/themes/openy_themes/openy_carnation/openy_carnation.theme
+++ b/themes/openy_themes/openy_carnation/openy_carnation.theme
@@ -71,7 +71,11 @@ function openy_carnation_preprocess_html(array &$variables) {
         $variables['body_classes'][] = 'without-banner';
       }
     }
-  } else {
+  }
+  elseif (\Drupal::service('current_route_match')->getRouteName() == 'entity.taxonomy_term.canonical') {
+    $variables['body_classes'][] = 'with-banner';
+  }
+ else {
     $variables['body_classes'][] = 'without-banner';
   }
 }
@@ -267,7 +271,8 @@ function openy_carnation_preprocess_page(array &$variables) {
     // Fix hb_menu_selector plugin for Open Y Carnation theme.
     $variables['#attached']['library'][] = 'openy_carnation/hb_menu_selector_override';
   }
-
+  // Set title value for page.
+  $variables['title'] = $variables['page']['#title'];
   openy_carnation_preprocess_page_logo($variables);
 }
 

--- a/themes/openy_themes/openy_carnation/templates/page/page--taxonomy--term.html.twig
+++ b/themes/openy_themes/openy_carnation/templates/page/page--taxonomy--term.html.twig
@@ -1,0 +1,6 @@
+{% extends "page.html.twig" %}
+
+{% block pagecontent %}
+  {% include '@openy_carnation/node/include/header-default.html.twig' with {'label': title }  %}
+  {{ page.content }}
+{% endblock %}

--- a/themes/openy_themes/openy_carnation/templates/views/views-view-unformatted--taxonomy_term.html.twig
+++ b/themes/openy_themes/openy_carnation/templates/views/views-view-unformatted--taxonomy_term.html.twig
@@ -17,10 +17,8 @@
  * @ingroup themeable
  */
 #}
-{# default header #}
-{% include '@openy_carnation/node/include/header-default.html.twig' %}
 
-<div class="taxonomy-term">
+<div class="taxonomy-term container mt-5">
   {% if title %}
     <h3>{{ title }}</h3>
   {% endif %}

--- a/themes/openy_themes/openy_carnation/templates/views/views-view.html.twig
+++ b/themes/openy_themes/openy_carnation/templates/views/views-view.html.twig
@@ -35,8 +35,7 @@
 {%
   set classes = [
     dom_id ? 'js-view-dom-id-' ~ dom_id,
-    css_name,
-    css_name == 'taxonomy-term' ? 'container',
+    css_name
   ]|merge(classes|default([]))
 %}
 <div{{ attributes.addClass(classes) }}>


### PR DESCRIPTION
Original Issue, this PR is going to fix: [MAINTAIN-30](https://openy.atlassian.net/browse/MAINTAIN-30)

This one should fix broken layout for news category page when you add the alert banner on the category page page for Carnation theme. 
Now it should looks like this:
![MAINTAIN-30CarnationNewsCategoryPage](https://user-images.githubusercontent.com/744406/109628079-01ecec80-7b4b-11eb-90d6-2412e9df9571.png)


## Steps for review

- [ ] Make sure that you use Carnation theme.
- [ ] Go to the news page (/news)
- [ ] Click by one of the news
- [ ] On the news page in right sidebar click by category tag (for ex. Summer Day Camp)
- [x] Verify that page looks good
- [x] Create a new one or just edit esixting one of Alert node
- [x] Please set in the Visibility pages field: news/* (to show alert on the news pages)
- [x] Repeat step 1-3
- [ ] Verify that page looks good on all type of screens (desktop, tablet, mobile)


## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer. See [Code of Conduct](https://github.com/ymcatwincities/openy/wiki/Open-Y-Code-of-Conduct-and-Best-Practices).
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/9.x-2.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/9.x-2.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/9.x-2.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/9.x-2.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/9.x-2.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
