### PR TITLE
Add custom query options to Save button of media image edit form.

### DIFF
--- a/modules/custom/openy_focal_point/openy_focal_point.module
+++ b/modules/custom/openy_focal_point/openy_focal_point.module
@@ -1,5 +1,7 @@
 <?php
 
+use Drupal\Core\Form\FormStateInterface;
+
 /**
  * Implements hook_theme().
  */
@@ -10,5 +12,22 @@ function openy_focal_point_theme($existing, $type, $theme, $path) {
         'data' => [],
       ],
     ],
+  ];
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter() for media_image_edit_form.
+ */
+function openy_focal_point_form_media_image_edit_form_alter(&$form, FormStateInterface $form_state, $form_id) {
+  $paragraph_type = \Drupal::request()->query->get('paragraph_type');
+  $field_name = \Drupal::request()->query->get('field_name');
+
+  if (!$paragraph_type || !$field_name) {
+    return;
+  }
+
+  $form['actions']['submit']['#ajax']['options']['query'] += [
+    'paragraph_type' => $paragraph_type,
+    'field_name' => $field_name,
   ];
 }


### PR DESCRIPTION
This is a follow-up to https://github.com/ymcatwincities/openy/pull/2404 - it fixed the Focal Point for images directly attached as fields to the nodes, but have broken the Focal Point saving process for the images in paragraphs.
This PR adds the same query params used by our custom widget to the media edit form Save button so that saving this media item doesn't over-write the Focal Point set by our custom processing.

Steps to reproduce:
- login as admin
- edit any content with paragraphs, like Landing Page
- add/edit any paragraph with image reference that is using "OpenY Entity Browser", for instance, Banner
- edit the image (it should open another modal with Media edit form) - this Image edit form uses the "OpenY Image (Focal Point)" widget, which allows to set Focal Point and Manual Crop in separate forms
- set focal point and save it (it successfully saves); close the Focal Point modal
- then Save the Image edit form - (before the patch: this Save will over-write the Focal Point set above ^^)
- edit the same image again, verify the Focal Point is still there you set it
- before the patch - it will reset to the center of the image
- after the patch - it will be there where you set it

Related configuration screens:
![image](https://user-images.githubusercontent.com/2128648/113673165-370cd180-96eb-11eb-9969-ebed34df3231.png)
![image](https://user-images.githubusercontent.com/2128648/113673360-789d7c80-96eb-11eb-8c9d-dcb80059049c.png)
![image](https://user-images.githubusercontent.com/2128648/113673588-c6b28000-96eb-11eb-9d7c-5a0a18f2c3a0.png)
