### PR TITLE
Resolved quick edit issue for main navigation.

### DIFF
--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -8798,7 +8798,3 @@ input[type="checkbox"]:focus {
 .footer-alerts-list .slick__arrow {
   margin-top: -25px;
 }
-.page-head__main-menu .contextual-region {
-  float: left;
-  width: 100%;
-}

--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -8798,3 +8798,7 @@ input[type="checkbox"]:focus {
 .footer-alerts-list .slick__arrow {
   margin-top: -25px;
 }
+.page-head__main-menu .contextual-region {
+  float: left;
+  width: 100%;
+}

--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -1212,6 +1212,10 @@ body {
 .page-head__main-menu .nav-level-2.open .fa-caret-down {
   display: none;
 }
+.page-head__main-menu .contextual-region {
+  float: left;
+  width: 100%;
+}
 
 .nav > li > a:hover {
   text-decoration: underline;

--- a/themes/openy_themes/openy_rose/scss/modules/_menu.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_menu.scss
@@ -384,6 +384,10 @@
       }
     }
   }
+  .contextual-region {
+    float: left;
+    width: 100%;
+  }
 }
 
 // Overriding Bootstrap text decoration.


### PR DESCRIPTION
https://github.com/ymcatwincities/openy/pull/2442

Testing steps: 

- Visit https://sandbox-rose-cus.openy.org/
- Disable one of the main nav items
- Go back to any page
- While hovering over the main navigation, the pencil icon should display. Moving your cursor to the pencil icon should keep it accessible. Clicking the pencil icon reveals a small menu, with "Quick Edit" among the choices.

