### PR TITLE
[MAINTAIN-8] added aria-hidden attribute to 'Add to calendar' link for GroupEx schedule table for all three themes

### DIFF
--- a/themes/openy_themes/openy_carnation/templates/openy_group_schedules/groupex-table-class-individual.html.twig
+++ b/themes/openy_themes/openy_carnation/templates/openy_group_schedules/groupex-table-class-individual.html.twig
@@ -26,7 +26,7 @@
       <span class="fa fa-link" aria-hidden=true></span><span class="fa fa-user"></span><a class="use-ajax" href="{{ class.instructor_link }}">{{ class.instructor|raw }}</a>
     </div>
     <div class="ical">
-      <span class="addtocalendar atc-style-blue">
+      <span class="addtocalendar atc-style-blue" aria-hidden="true">
         <var class="atc_event">
           <var class="atc_date_start">{{ class.calendar.atc_date_start }}</var>
           <var class="atc_date_end">{{ class.calendar.atc_date_end }}</var>

--- a/themes/openy_themes/openy_carnation/templates/openy_group_schedules/groupex-table-class.html.twig
+++ b/themes/openy_themes/openy_carnation/templates/openy_group_schedules/groupex-table-class.html.twig
@@ -21,7 +21,7 @@
     </div>
   </div>
   <div class="ical">
-  <span class="addtocalendar atc-style-blue">
+  <span class="addtocalendar atc-style-blue" aria-hidden="true">
    <var class="atc_event">
    <var class="atc_date_start">{{ class.calendar.atc_date_start }}</var>
    <var class="atc_date_end">{{ class.calendar.atc_date_end }}</var>

--- a/themes/openy_themes/openy_carnation/templates/openy_group_schedules/groupex-table-instructor-individual.html.twig
+++ b/themes/openy_themes/openy_carnation/templates/openy_group_schedules/groupex-table-instructor-individual.html.twig
@@ -23,7 +23,7 @@
     </div>
   </div>
   <div class="ical">
-    <span class="addtocalendar atc-style-blue">
+    <span class="addtocalendar atc-style-blue" aria-hidden="true">
       <var class="atc_event">
         <var class="atc_date_start">{{ class.calendar.atc_date_start }}</var>
         <var class="atc_date_end">{{ class.calendar.atc_date_end }}</var>

--- a/themes/openy_themes/openy_lily/templates/openy_group_schedules/groupex-table-class-individual.html.twig
+++ b/themes/openy_themes/openy_lily/templates/openy_group_schedules/groupex-table-class-individual.html.twig
@@ -26,7 +26,7 @@
       <span class="fa fa-link" aria-hidden=true></span><span class="fa fa-user"></span><a class="use-ajax" href="{{ class.instructor_link }}">{{ class.instructor|raw }}</a>
     </div>
     <div class="ical">
-      <span class="addtocalendar atc-style-blue">
+      <span class="addtocalendar atc-style-blue" aria-hidden="true">
         <var class="atc_event">
           <var class="atc_date_start">{{ class.calendar.atc_date_start }}</var>
           <var class="atc_date_end">{{ class.calendar.atc_date_end }}</var>

--- a/themes/openy_themes/openy_lily/templates/openy_group_schedules/groupex-table-class.html.twig
+++ b/themes/openy_themes/openy_lily/templates/openy_group_schedules/groupex-table-class.html.twig
@@ -21,7 +21,7 @@
     </div>
   </div>
   <div class="ical">
-  <span class="addtocalendar atc-style-blue">
+  <span class="addtocalendar atc-style-blue" aria-hidden="true">
    <var class="atc_event">
    <var class="atc_date_start">{{ class.calendar.atc_date_start }}</var>
    <var class="atc_date_end">{{ class.calendar.atc_date_end }}</var>

--- a/themes/openy_themes/openy_lily/templates/openy_group_schedules/groupex-table-instructor-individual.html.twig
+++ b/themes/openy_themes/openy_lily/templates/openy_group_schedules/groupex-table-instructor-individual.html.twig
@@ -23,7 +23,7 @@
     </div>
   </div>
   <div class="ical">
-    <span class="addtocalendar atc-style-blue">
+    <span class="addtocalendar atc-style-blue" aria-hidden="true">
       <var class="atc_event">
         <var class="atc_date_start">{{ class.calendar.atc_date_start }}</var>
         <var class="atc_date_end">{{ class.calendar.atc_date_end }}</var>

--- a/themes/openy_themes/openy_rose/templates/custom/groupex-table-class-individual.html.twig
+++ b/themes/openy_themes/openy_rose/templates/custom/groupex-table-class-individual.html.twig
@@ -31,7 +31,7 @@
     </div>
   </div>
   <div class="ical">
-      <span class="addtocalendar atc-style-blue">
+      <span class="addtocalendar atc-style-blue" aria-hidden="true">
         <var class="atc_event">
           <var class="atc_date_start">{{ class.calendar.atc_date_start }}</var>
           <var class="atc_date_end">{{ class.calendar.atc_date_end }}</var>

--- a/themes/openy_themes/openy_rose/templates/custom/groupex-table-class.html.twig
+++ b/themes/openy_themes/openy_rose/templates/custom/groupex-table-class.html.twig
@@ -25,7 +25,7 @@
     </div>
   </div>
   <div class="ical">
-    <span class="addtocalendar atc-style-blue">
+    <span class="addtocalendar atc-style-blue" aria-hidden="true">
       <var class="atc_event">
       <var class="atc_date_start">{{ class.calendar.atc_date_start }}</var>
       <var class="atc_date_end">{{ class.calendar.atc_date_end }}</var>

--- a/themes/openy_themes/openy_rose/templates/custom/groupex-table-instructor-individual.html.twig
+++ b/themes/openy_themes/openy_rose/templates/custom/groupex-table-instructor-individual.html.twig
@@ -25,7 +25,7 @@
     </div>
   </div>
   <div class="ical">
-    <span class="addtocalendar atc-style-blue">
+    <span class="addtocalendar atc-style-blue" aria-hidden="true">
       <var class="atc_event">
         <var class="atc_date_start">{{ class.calendar.atc_date_start }}</var>
         <var class="atc_date_end">{{ class.calendar.atc_date_end }}</var>


### PR DESCRIPTION
Original Issue, this PR is going to fix: [MAINTAIN-8](https://openy.atlassian.net/browse/MAINTAIN-8) and https://github.com/ymcatwincities/openy/issues/898

As was suggested in Jirra issue description i added the **aria-hidden** attribute for 'Add to caelendar' link in GroupEx schedule page for all three themes

## Steps for review

- [ ] go to /schedules/group-schedules?location=4435
- [ ] Given I have VoiceOver enabled
- [ ] When I follow to the icon
![33821368-3b77f0b0-de5c-11e7-98fd-37d1fca351dc](https://user-images.githubusercontent.com/744406/119660889-69f45b80-be38-11eb-8ee6-0ac2cef68d79.png)

- [ ] screen reader should skip this link


## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer. See [Code of Conduct](https://github.com/ymcatwincities/openy/wiki/Open-Y-Code-of-Conduct-and-Best-Practices).
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/9.x-2.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/9.x-2.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/9.x-2.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/9.x-2.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/9.x-2.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
