### PR TITLE
Move Blazy ratio CSS fix to theme level

### DIFF
--- a/modules/openy_features/openy_media/openy_media.libraries.yml
+++ b/modules/openy_features/openy_media/openy_media.libraries.yml
@@ -13,5 +13,5 @@ browser:
 blazy_ratio:
   version: 0.1
   css:
-    component:
+    theme:
       css/blazy.ratio.css: {}


### PR DESCRIPTION
Followup to #2143 

There might be CSS aggregation issue when the CSS with fix is included earlier than the CSS it is going to fix...
Suggested change - move CSS with the fix to the "theme" level CSS - https://www.drupal.org/docs/creating-custom-modules/adding-stylesheets-css-and-javascript-js-to-a-drupal-module#library

Good case:
![image](https://user-images.githubusercontent.com/2128648/121315827-4a325c80-c93b-11eb-91ce-3890e6575b79.png)

Bad case:
![image](https://user-images.githubusercontent.com/2128648/121315873-561e1e80-c93b-11eb-87f8-6fd2b4dc2214.png)
