### PR TITLE
Add timeout for http request in openy_update module

### DIFF
--- a/modules/custom/openy_update/openy_update.module
+++ b/modules/custom/openy_update/openy_update.module
@@ -22,6 +22,9 @@ function openy_update_get_projects(&$projects) {
   try {
     $response = $client->post(OPENY_UPDATE_PACKAGES_ENDPOINT, [
       'body' => json_encode($projects),
+      'connect_timeout' => 10,
+      'read_timeout' => 20,
+      'timeout' => 30
     ]);
     if ($response->getStatusCode() == 200) {
       $body = $response->getBody();


### PR DESCRIPTION
In the openy_update module, there are HTTP requests issued to http://openy.org:1880/packages, but if this URL is not available, and Guzzle may wait for the connection for too long, that Web Server returns a Gateway Timeout error.

## Steps for review

- [ ] Open /admin/reports/status page
- [ ] Check that it does not take too long to render when http://openy.org:1880/packages is not available
