### PR TITLE
Remove hidden H1 tag from the google translate widget

### DIFF
--- a/modules/custom/openy_gtranslate/js/openy_gtranslate.js
+++ b/modules/custom/openy_gtranslate/js/openy_gtranslate.js
@@ -15,6 +15,8 @@
         },
         elem
       );
+      var removePopup = document.getElementById('goog-gt-tt');
+      removePopup.parentNode.removeChild(removePopup);
     }
   };
 }(jQuery, Drupal, drupalSettings));


### PR DESCRIPTION
Problem:
Google Translate widget adds a hidden block with the h1 tag to all pages.
![ksnip_20210622-113936](https://user-images.githubusercontent.com/58946680/122893033-9c697980-d34e-11eb-958b-77ca887a6e2d.png)


## Steps for review

- [ ] Verify the Google translate widget works fine
- [ ] Make sure the hidden block is removed


## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer. See [Code of Conduct](https://github.com/ymcatwincities/openy/wiki/Open-Y-Code-of-Conduct-and-Best-Practices).
- [ ] Try to use Conventional commit messages accordingly to the standard https://www.conventionalcommits.org/en/v1.0.0/#specification
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/9.x-2.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/9.x-2.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/9.x-2.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/9.x-2.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/9.x-2.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
