### PR TITLE
fix(cleanup)!: Remove jQuery Colorpicker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,6 @@
         "drupal/google_tag": "^1.4",
         "drupal/image_widget_crop": "^2",
         "drupal/inline_entity_form": "1.0-rc1 || ^1.0",
-        "drupal/jquery_colorpicker": "^2 || ^2.0@RC",
         "drupal/jquery_ui_touch_punch": "^1.0",
         "drupal/jquery_ui_tabs": "^1.1",
         "drupal/jquery_ui_tooltip": "^1.1",


### PR DESCRIPTION
Original Issue, this PR is going to fix: https://openy.atlassian.net/browse/MAINTAIN-67


Make sure these boxes are checked before asking for review of your pull request - thank you!

If there is a new feature or this is a bug fix - use 9.x-2.x branch. We'll tag for release if the bug is critical asap or tag for release next bug fix release until critical issue arrived.

## Steps for review

- [ ] We replaced jQuery Colorpicker with colorapi in February release. No need to keep it in distro.
![image](https://user-images.githubusercontent.com/563412/123790746-5d579d00-d8e7-11eb-9429-1b5eddc54b9f.png)



## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer. See [Code of Conduct](https://github.com/ymcatwincities/openy/wiki/Open-Y-Code-of-Conduct-and-Best-Practices).
- [ ] Try to use Conventional commit messages accordingly to the standard https://www.conventionalcommits.org/en/v1.0.0/#specification
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/9.x-2.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/9.x-2.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/9.x-2.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/9.x-2.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/9.x-2.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
