### PR TITLE
[MAINTAIN-116] Fix blog listings on Carnation

### DIFF
--- a/themes/openy_themes/openy_carnation/openy_carnation.theme
+++ b/themes/openy_themes/openy_carnation/openy_carnation.theme
@@ -499,7 +499,10 @@ function openy_carnation_theme_suggestions_form_alter(array &$suggestions, array
  * Implements hook_theme_suggestions_HOOK_alter().
  */
 function openy_carnation_theme_suggestions_views_view_unformatted_alter(array &$suggestions, array $variables) {
-  if ($variables['view']->id() == 'taxonomy_term' && isset($variables['rows'][0]['#node']) && $variables['rows'][0]['#node'] instanceof NodeInterface) {
+  if ($variables['view']->id() != 'taxonomy_term') {
+    return;
+  }
+  if (isset($variables['rows'][0]['#node']) && $variables['rows'][0]['#node'] instanceof NodeInterface) {
     $suggestions[] = 'views_view_unformatted__' . $variables['view']->id() . '__' . $variables['rows'][0]['#node']->getType();
   }
 }

--- a/themes/openy_themes/openy_carnation/openy_carnation.theme
+++ b/themes/openy_themes/openy_carnation/openy_carnation.theme
@@ -496,6 +496,15 @@ function openy_carnation_theme_suggestions_form_alter(array &$suggestions, array
 }
 
 /**
+ * Implements hook_theme_suggestions_HOOK_alter().
+ */
+function openy_carnation_theme_suggestions_views_view_unformatted_alter(array &$suggestions, array $variables) {
+  if ($variables['view']->id() == 'taxonomy_term' && isset($variables['rows'][0]['#node']) && $variables['rows'][0]['#node'] instanceof NodeInterface) {
+    $suggestions[] = 'views_view_unformatted__' . $variables['view']->id() . '__' . $variables['rows'][0]['#node']->getType();
+  }
+}
+
+/**
  * Implements hook_form_system_theme_settings_alter().
  */
 function openy_carnation_form_system_theme_settings_alter(&$form, FormStateInterface $form_state, $form_id = NULL) {

--- a/themes/openy_themes/openy_carnation/templates/views/views-view-unformatted--taxonomy-term--blog.html.twig
+++ b/themes/openy_themes/openy_carnation/templates/views/views-view-unformatted--taxonomy-term--blog.html.twig
@@ -1,0 +1,32 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a view of unformatted rows.
+ *
+ * Available variables:
+ * - title: The title of this group of rows. May be empty.
+ * - rows: A list of the view's row items.
+ *   - attributes: The row's HTML attributes.
+ *   - content: The row's content.
+ * - view: The view object.
+ * - default_row_class: A flag indicating whether default classes should be
+ *   used on rows.
+ *
+ * @see template_preprocess_views_view_unformatted()
+ *
+ * @ingroup themeable
+ */
+#}
+<div class="container">
+  <div class="taxonomy-term mt-5 row">
+    {% if title %}
+      <h3>{{ title }}</h3>
+    {% endif %}
+
+    {% for row in rows %}
+      <div{{ row.attributes.addClass('col-12 col-md-6 col-lg-4') }}>
+        {{- row.content -}}
+      </div>
+    {% endfor %}
+  </div>
+</div>


### PR DESCRIPTION
Original Issue, this PR is going to fix: https://openy.atlassian.net/browse/MAINTAIN-116

## Steps for review

- [ ] Install extended or custom Open Y version with Carnation theme
- [x] Go to `/blog/category/community-outreach`
- [x] Check that blog teaser fixed and displayed in the columns

![Screenshot from 2021-07-01 17-10-44](https://user-images.githubusercontent.com/13733670/124138440-51a6da80-da8f-11eb-9046-47033b81b2e9.png)

- [ ] Compare with https://sandbox-carnation-cus.openy.org/blog/category/community-outreach
- [ ] Check that fix works only for blog taxonomy (the rest of the views should look the same)
  - [x]  Check any item from `Amenities` list `/admin/structure/taxonomy/manage/amenities/overview`
  - [x]  Check any item from `Area` list `/admin/structure/taxonomy/manage/area/overview`
  - [x]  Check any item from `News Category` list `/admin/structure/taxonomy/manage/news_category/overview`
- [x] Non Profit
