### PR TITLE
[MAINTAIN-102] Decouple essential demo content

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -117,6 +117,7 @@
         "open-y-subprojects/ynorth_gxp_spots_proxy": "^1.0.1",
         "open-y-subprojects/openy_hours_formatter": "^1.2.0",
         "open-y-subprojects/openy_features": "^1.4",
+        "open-y-subprojects/openy_content_core": "*",
         "ynorth-projects/openy_repeat": "^1.0.0 || ^2.0.3"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -117,7 +117,7 @@
         "open-y-subprojects/ynorth_gxp_spots_proxy": "^1.0.1",
         "open-y-subprojects/openy_hours_formatter": "^1.2.0",
         "open-y-subprojects/openy_features": "^1.4",
-        "open-y-subprojects/openy_content_core": "^1.0",
+        "open-y-subprojects/openy_content_core": "^1.1",
         "ynorth-projects/openy_repeat": "^1.0.0 || ^2.0.3"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -117,7 +117,7 @@
         "open-y-subprojects/ynorth_gxp_spots_proxy": "^1.0.1",
         "open-y-subprojects/openy_hours_formatter": "^1.2.0",
         "open-y-subprojects/openy_features": "^1.4",
-        "open-y-subprojects/openy_content_core": "*",
+        "open-y-subprojects/openy_content_core": "^1.0",
         "ynorth-projects/openy_repeat": "^1.0.0 || ^2.0.3"
     },
     "require-dev": {

--- a/openy.profile
+++ b/openy.profile
@@ -146,6 +146,10 @@ function openy_gtranslate_place_blocks(array &$install_state) {
 function openy_demo_content_configs_map($key = NULL) {
   // Maps installation presets to demo content.
   $map = [
+    'core' => [
+      'openy_demo_taxonomy',
+      'openy_demo_tcolor',
+    ],
     'complete' => [
       'openy_demo_nalert',
       'openy_demo_nbranch',
@@ -166,7 +170,6 @@ function openy_demo_content_configs_map($key = NULL) {
       'openy_demo_webform',
       'openy_demo_ahb',
       'openy_demo_nsocial_post',
-      'openy_demo_tcolor',
       'openy_demo_tarea',
       'openy_demo_tblog',
       'openy_demo_tnews',
@@ -178,7 +181,6 @@ function openy_demo_content_configs_map($key = NULL) {
       'openy_demo_bsimple',
       'openy_demo_bamenities',
       'openy_demo_tfitness',
-      'openy_demo_taxonomy',
     ],
     'standard' => [
       'openy_demo_nalert',
@@ -343,10 +345,13 @@ function openy_import_content(array &$install_state) {
     'complete' => 'openy_complete_installation',
   ];
   $migration_tag = $preset_tags[$preset];
+  // Add core demo content.
+  _openy_import_content_helper($module_operations, 'core', 'enable');
+  $migrate_operations[] = ['openy_import_migration', ['openy_core_installation']];
 
   if ($install_state['openy']['content']) {
     // If option has been selected build demo modules installation operations array.
-    _openy_import_content_helper($module_operations, $preset);
+    _openy_import_content_helper($module_operations, $preset, 'enable');
     // Add migration import by tag to migration operations array.
     $migrate_operations[] = ['openy_import_migration', (array) $migration_tag];
     if ($preset == 'complete') {
@@ -358,7 +363,7 @@ function openy_import_content(array &$install_state) {
       $migrate_operations[] = ['openy_demo_nlanding_af_pages', []];
     }
     // Build demo modules uninstall array to disable migrations with demo content.
-    _openy_remove_migrations_helper($uninstall_operations, $preset);
+    _openy_import_content_helper($uninstall_operations, $preset, 'uninstall');
     if (function_exists('drush_print')) {
       drush_print(dt('Demo content enabled'));
     }
@@ -370,6 +375,8 @@ function openy_import_content(array &$install_state) {
     $uninstall_operations[] = ['openy_uninstall_module', (array) 'openy_demo_home_alt'];
   }
 
+  // Uninstall core demo content modules.
+  _openy_import_content_helper($uninstall_operations, 'core', 'uninstall');
   // Combine operations module enable before of migrations.
   return ['operations' => array_merge($module_operations, $migrate_operations, $uninstall_operations)];
 }
@@ -535,32 +542,16 @@ function openy_install_finish(array &$install_state) {
  *   List of module operations.
  * @param string $key
  *   Key of the section in the mapping.
+ * @param string $action
+ *   Action for demo content modules: enable|uninstall.
  */
-function _openy_import_content_helper(array &$module_operations, $key) {
+function _openy_import_content_helper(array &$module_operations, string $key, string $action) {
   $modules = openy_demo_content_configs_map($key);
   if (empty($modules)) {
     return;
   }
   foreach ($modules as $module) {
-    $module_operations[] = ['openy_enable_module', (array) $module];
-  }
-}
-
-/**
- * Demo content migrations remove helper.
- *
- * @param array $module_operations
- *   List of module operations.
- * @param string $key
- *   Key of the section in the mapping.
- */
-function _openy_remove_migrations_helper(array &$module_operations, $key) {
-  $modules = openy_demo_content_configs_map($key);
-  if (empty($modules)) {
-    return;
-  }
-  foreach ($modules as $module) {
-    $module_operations[] = ['openy_uninstall_module', (array) $module];
+    $module_operations[] = ['openy_' . $action . '_module', (array) $module];
   }
 }
 


### PR DESCRIPTION
Original Issue, this PR is going to fix: https://openy.atlassian.net/browse/MAINTAIN-102

Related PR's:
- https://github.com/open-y-subprojects/openy_content_core/pull/1
- https://github.com/open-y-subprojects/openy_demo_content/pull/2

## Steps for review

- [x] Merge related PR's
- [x] Create new version for https://packagist.org/packages/open-y-subprojects/openy_content_core
- [x] Install site on the build with `Open Y Installation Wizard`
- [x] On demo content step select 'No'
- [x] Check that color taxonomy contains terms
- [ ] Test same with `Yes` option for demo content
- [x] Test that taxonomy demo content works fine
- [x] Check that color taxonomy contains content
