### PR TITLE
fix(cache): Debugging patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -169,8 +169,6 @@
                 "1236098 - Notice: Undefined index in _color_rewrite_stylesheet()": "https://www.drupal.org/files/issues/undefined-index-in-_color_rewrite_stylesheet-1236098-37.patch",
                 "2484693 - Telephone Link field formatter InvalidArgumentException with 5 digits or fewer in the number": "https://www.drupal.org/files/issues/2484693-54.patch",
                 "2862702 - PrepareModulesEntityUninstallForm::formTitle does not exist": "https://www.drupal.org/files/issues/2862702-3.patch",
-                "Revert https://www.drupal.org/i/2160091": "https://gist.githubusercontent.com/podarok/e14c3d9ef86f8b6f5cf452dab4cd8e2f/raw/8545f552397e036a599ad56898423bf4ada37824/revert-2160091-6e84b57.diff",
-                "Apply https://www.drupal.org/i/2160091 back again": "https://gist.githubusercontent.com/podarok/1c68ac88cc988f223a09e47c3933e70d/raw/476431dad084cfb509c60187aeba5cdcc7afece7/2160091-6e84b57.diff",
                 "Apply suggestion https://drupal.slack.com/archives/C1BMUQ9U6/p1626267909357300?thread_ts=1626097881.298900&cid=C1BMUQ9U6": "https://gist.githubusercontent.com/podarok/41a0df40e3db2c809b7396bda8bc1c85/raw/f986ae5aa82eb313ab8c32f255f147fe7782a669/move_extension_list_reset.diff"
             },
             "drupal/media_entity": {

--- a/composer.json
+++ b/composer.json
@@ -169,7 +169,7 @@
                 "1236098 - Notice: Undefined index in _color_rewrite_stylesheet()": "https://www.drupal.org/files/issues/undefined-index-in-_color_rewrite_stylesheet-1236098-37.patch",
                 "2484693 - Telephone Link field formatter InvalidArgumentException with 5 digits or fewer in the number": "https://www.drupal.org/files/issues/2484693-54.patch",
                 "2862702 - PrepareModulesEntityUninstallForm::formTitle does not exist": "https://www.drupal.org/files/issues/2862702-3.patch",
-                "Apply suggestion https://drupal.slack.com/archives/C1BMUQ9U6/p1626267909357300?thread_ts=1626097881.298900&cid=C1BMUQ9U6": "https://gist.githubusercontent.com/podarok/41a0df40e3db2c809b7396bda8bc1c85/raw/f986ae5aa82eb313ab8c32f255f147fe7782a669/move_extension_list_reset.diff"
+                "Apply suggestion https://drupal.slack.com/archives/C1BMUQ9U6/p1626267909357300?thread_ts=1626097881.298900&cid=C1BMUQ9U6": "https://gist.githubusercontent.com/podarok/41a0df40e3db2c809b7396bda8bc1c85/raw/eb2741da648790e8f87b9544d86b8f2e86c0d555/move_extension_list_reset.diff"
             },
             "drupal/media_entity": {
                 "2918172 - Media Entity upgrade -> add revision fields": "https://www.drupal.org/files/issues/2918172-5.patch",

--- a/composer.json
+++ b/composer.json
@@ -169,7 +169,9 @@
                 "1236098 - Notice: Undefined index in _color_rewrite_stylesheet()": "https://www.drupal.org/files/issues/undefined-index-in-_color_rewrite_stylesheet-1236098-37.patch",
                 "2484693 - Telephone Link field formatter InvalidArgumentException with 5 digits or fewer in the number": "https://www.drupal.org/files/issues/2484693-54.patch",
                 "2862702 - PrepareModulesEntityUninstallForm::formTitle does not exist": "https://www.drupal.org/files/issues/2862702-3.patch",
-                "Revert https://www.drupal.org/i/2160091": "https://gist.githubusercontent.com/podarok/e14c3d9ef86f8b6f5cf452dab4cd8e2f/raw/8545f552397e036a599ad56898423bf4ada37824/revert-2160091-6e84b57.diff"
+                "Revert https://www.drupal.org/i/2160091": "https://gist.githubusercontent.com/podarok/e14c3d9ef86f8b6f5cf452dab4cd8e2f/raw/8545f552397e036a599ad56898423bf4ada37824/revert-2160091-6e84b57.diff",
+                "Apply https://www.drupal.org/i/2160091 back again": "https://gist.githubusercontent.com/podarok/1c68ac88cc988f223a09e47c3933e70d/raw/476431dad084cfb509c60187aeba5cdcc7afece7/2160091-6e84b57.diff",
+                "Apply suggestion https://drupal.slack.com/archives/C1BMUQ9U6/p1626267909357300?thread_ts=1626097881.298900&cid=C1BMUQ9U6": "https://gist.githubusercontent.com/podarok/41a0df40e3db2c809b7396bda8bc1c85/raw/f986ae5aa82eb313ab8c32f255f147fe7782a669/move_extension_list_reset.diff"
             },
             "drupal/media_entity": {
                 "2918172 - Media Entity upgrade -> add revision fields": "https://www.drupal.org/files/issues/2918172-5.patch",

--- a/composer.json
+++ b/composer.json
@@ -196,6 +196,9 @@
             },
             "drupal/search_api": {
                 "2898334 - Add a Role-based access processor": "https://www.drupal.org/files/issues/2021-01-31/2898334-30--role_based_access_check.patch"
+            },
+            "drupal/features": {
+                "Fix hook install https://gist.github.com/podarok/3c14521da12ad73fa08fe3ec0a237a28": "https://gist.githubusercontent.com/podarok/3c14521da12ad73fa08fe3ec0a237a28/raw/205ec76647bd9c5a0bec310c3666c95c901539d7/features_hook.diff"
             }
         }
     },


### PR DESCRIPTION
Suggested-by: @alexpott
Chat: https://drupal.slack.com/archives/C1BMUQ9U6/p1626267909357300?thread_ts=1626097881.298900&cid=C1BMUQ9U6


How to test this branch
```sh
composer create-project ymcatwincities/openy-project:dev-9.x-2.x-drupal_core9.2patch buildnew --no-interaction --prefer-dist
cd buildnew/docroot
APP_ENV=dev drush -y si openy openy_configure_profile.preset=complete openy_theme_select.theme=openy_lily -d -vvv openy_terms_of_use.agree_openy_terms=1 install_configure_form.enable_update_status_emails=NULL --db-url=mysql://root:root@127.0.0.1:/dev_sandbox_lily_custom --account-name=admin --account-pass=open9622 --uri=http://sandbox-lily-cus-dev.openy.org
```

These commands should be executed from Jenkins shell

Fail is below

```jenkins
Started by user anonymous
Building remotely on 142.93.115.102 (OpenY Sandboxes) in workspace /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM
[XXX_DEV_SANDBOX_LILY_CUSTOM] $ /bin/sh -xe /tmp/hudson6980831033200453212.sh
+ sudo rm -rf buildnew
+ composer create-project ymcatwincities/openy-project:dev-9.x-2.x-drupal_core9.2patch buildnew --no-interaction --prefer-dist
Do not run Composer as root/super user! See https://getcomposer.org/root for details
Creating a "ymcatwincities/openy-project:dev-9.x-2.x-drupal_core9.2patch" project at "./buildnew"
Installing ymcatwincities/openy-project (dev-9.x-2.x-drupal_core9.2patch 718d4a1a2a70330090d8a6157f06860b92bd070a)
  - Installing ymcatwincities/openy-project (dev-9.x-2.x-drupal_core9.2patch 718d4a1): Extracting archive
Created project in /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/buildnew
Loading composer repositories with package information
Updating dependencies
Lock file operations: 221 installs, 0 updates, 0 removals
  - Locking abraham/twitteroauth (0.7.4)
  - Locking asm89/stack-cors (1.3.0)
  - Locking chi-teck/drupal-code-generator (1.33.1)
  - Locking commerceguys/addressing (v1.2.1)
  - Locking composer/installers (v1.11.0)
  - Locking composer/semver (3.2.5)
  - Locking consolidation/annotated-command (4.2.4)
  - Locking consolidation/config (1.2.1)
  - Locking consolidation/filter-via-dot-access-data (1.0.0)
  - Locking consolidation/log (2.0.2)
  - Locking consolidation/output-formatters (4.1.2)
  - Locking consolidation/robo (1.4.13)
  - Locking consolidation/self-update (1.2.0)
  - Locking consolidation/site-alias (3.1.0)
  - Locking consolidation/site-process (4.1.0)
  - Locking container-interop/container-interop (1.2.0)
  - Locking cweagans/composer-patches (1.7.1)
  - Locking dflydev/dot-access-data (v1.1.0)
  - Locking doctrine/annotations (1.13.1)
  - Locking doctrine/collections (1.6.7)
  - Locking doctrine/inflector (v1.2.0)
  - Locking doctrine/lexer (1.2.1)
  - Locking doctrine/reflection (1.2.2)
  - Locking drupal-ckeditor-libraries-group/font (4.16.1)
  - Locking drupal/address (1.9.0)
  - Locking drupal/admin_toolbar (3.0.1)
  - Locking drupal/better_exposed_filters (5.0.0-beta3)
  - Locking drupal/blazy (2.4.0)
  - Locking drupal/captcha (1.2.0)
  - Locking drupal/ckeditor_bootstrap_buttons (2.0.0)
  - Locking drupal/ckeditor_font (1.2.0)
  - Locking drupal/colorapi (1.1.0)
  - Locking drupal/colorbutton (1.2.0)
  - Locking drupal/confi (2.0.0-rc1)
  - Locking drupal/config_update (1.7.0)
  - Locking drupal/core (9.2.1)
  - Locking drupal/core-composer-scaffold (9.2.1)
  - Locking drupal/core-project-message (9.2.1)
  - Locking drupal/core-recommended (9.2.1)
  - Locking drupal/crop (2.1.0)
  - Locking drupal/css_editor (1.3.0)
  - Locking drupal/csv_serialization (2.0.0)
  - Locking drupal/ctools (3.7.0)
  - Locking drupal/custom_formatters (3.0.0-beta1)
  - Locking drupal/datalayer (1.0.0-beta2)
  - Locking drupal/domain (1.0.0-beta6)
  - Locking drupal/domain_theme_switch (1.5.0)
  - Locking drupal/draggableviews (dev-1.x c0292a4)
  - Locking drupal/dropzonejs (2.5.0)
  - Locking drupal/easy_breadcrumb (1.15.0)
  - Locking drupal/editor_advanced_link (1.9.0)
  - Locking drupal/embed (1.4.0)
  - Locking drupal/entity (1.2.0)
  - Locking drupal/entity_browser (2.6.0)
  - Locking drupal/entity_clone (1.0.0-beta6)
  - Locking drupal/entity_embed (1.1.0)
  - Locking drupal/entity_reference_revisions (1.9.0)
  - Locking drupal/features (3.12.0)
  - Locking drupal/field_group (3.1.0)
  - Locking drupal/focal_point (1.5.0)
  - Locking drupal/fontyourface (3.6.0)
  - Locking drupal/geolocation (3.7.0)
  - Locking drupal/geysir (1.3.0)
  - Locking drupal/google_analytics (3.1.0)
  - Locking drupal/google_optimize (1.7.0)
  - Locking drupal/google_tag (1.4.0)
  - Locking drupal/image_widget_crop (2.3.0)
  - Locking drupal/inline_entity_form (1.0.0-rc9)
  - Locking drupal/jquery_ui (1.4.0)
  - Locking drupal/jquery_ui_datepicker (1.1.0)
  - Locking drupal/jquery_ui_slider (1.1.0)
  - Locking drupal/jquery_ui_tabs (1.1.0)
  - Locking drupal/jquery_ui_tooltip (1.1.0)
  - Locking drupal/jquery_ui_touch_punch (1.0.0)
  - Locking drupal/libraries (3.0.0-beta1)
  - Locking drupal/link_attributes (1.11.0)
  - Locking drupal/media_directories (2.0.1)
  - Locking drupal/media_entity_image (1.4.0-rc1)
  - Locking drupal/media_entity_video (2.0.0-rc2)
  - Locking drupal/metatag (1.16.0)
  - Locking drupal/migrate_plus (5.1.0)
  - Locking drupal/migrate_source_csv (3.4.0)
  - Locking drupal/migrate_tools (dev-5.x 56d82b4)
  - Locking drupal/panelbutton (1.3.0)
  - Locking drupal/paragraphs (1.12.0)
  - Locking drupal/pathauto (1.8.0)
  - Locking drupal/plugin (2.8.0)
  - Locking drupal/rabbit_hole (1.0.0-beta10)
  - Locking drupal/recaptcha (3.0.0)
  - Locking drupal/redirect (1.6.0)
  - Locking drupal/scheduler (1.3.0)
  - Locking drupal/search_api (1.19.0)
  - Locking drupal/search_api_solr (4.2.0)
  - Locking drupal/simple_menu_icons (2.2.0)
  - Locking drupal/simple_sitemap (3.10.0)
  - Locking drupal/slick (2.3.0)
  - Locking drupal/slick_views (2.4.0)
  - Locking drupal/social_feed_fetcher (2.0.0-alpha3)
  - Locking drupal/token (1.9.0)
  - Locking drupal/token_filter (1.2.0)
  - Locking drupal/twig_tweak (3.1.2)
  - Locking drupal/tzfield (1.3.0)
  - Locking drupal/vendor_stream_wrapper (1.6.0)
  - Locking drupal/verf (1.0.0)
  - Locking drupal/video (1.5.0-alpha1)
  - Locking drupal/video_embed_field (2.4.0)
  - Locking drupal/views_block_filter_block (1.0.0)
  - Locking drupal/views_data_export (1.0.0)
  - Locking drupal/views_field_formatter (1.13.0)
  - Locking drupal/views_infinite_scroll (1.8.0)
  - Locking drupal/webform (6.0.4)
  - Locking drush/drush (10.5.0)
  - Locking egulias/email-validator (2.1.25)
  - Locking enlightn/security-checker (v1.9.0)
  - Locking espresso-dev/instagram-basic-display-php (v1.1.6)
  - Locking facebook/graph-sdk (5.7.0)
  - Locking google/recaptcha (1.2.4)
  - Locking grasmash/expander (1.0.0)
  - Locking grasmash/yaml-expander (1.4.0)
  - Locking grt107/grt-youtube-popup (1.0.0)
  - Locking guzzlehttp/guzzle (6.5.5)
  - Locking guzzlehttp/promises (1.4.1)
  - Locking guzzlehttp/psr7 (1.8.2)
  - Locking laminas/laminas-diactoros (2.6.0)
  - Locking laminas/laminas-escaper (2.7.0)
  - Locking laminas/laminas-feed (2.14.1)
  - Locking laminas/laminas-stdlib (3.3.1)
  - Locking laminas/laminas-zendframework-bridge (1.2.0)
  - Locking league/container (2.5.0)
  - Locking league/csv (9.7.1)
  - Locking library-ckeditor/colorbutton (4.10.1)
  - Locking library-ckeditor/font (4.12.1)
  - Locking library-ckeditor/panelbutton (4.10.1)
  - Locking library-davekoelle/alphanum (1.0.0)
  - Locking library-jaypan/jquery_colorpicker (1.0.1)
  - Locking library-smonetti/btbutton (1.0.2)
  - Locking library-vakata/jstree (3.3.8)
  - Locking maennchen/zipstream-php (2.1.0)
  - Locking masterminds/html5 (2.7.4)
  - Locking mpdf/mpdf (v8.0.11)
  - Locking myclabs/deep-copy (1.10.2)
  - Locking myclabs/php-enum (1.8.3)
  - Locking nikic/php-parser (v4.11.0)
  - Locking npm-asset/blazy (1.8.2)
  - Locking npm-asset/dropzone (5.9.2)
  - Locking npm-asset/jquery-ui-touch-punch (0.2.3)
  - Locking npm-asset/jquery.easing (1.4.2)
  - Locking npm-asset/slick-carousel (1.8.1)
  - Locking oomphinc/composer-installers-extender (2.0.0)
  - Locking open-y-subprojects/openy_content_core (1.2)
  - Locking open-y-subprojects/openy_daxko_gxp_syncer (1.1.0)
  - Locking open-y-subprojects/openy_demo_content (1.2)
  - Locking open-y-subprojects/openy_features (1.4)
  - Locking open-y-subprojects/openy_hours_formatter (1.2.0)
  - Locking open-y-subprojects/openy_node_alert (1.0.1)
  - Locking open-y-subprojects/ynorth_gxp_spots_proxy (1.0.1)
  - Locking paragonie/random_compat (v9.99.100)
  - Locking pear/archive_tar (1.4.13)
  - Locking pear/console_getopt (v1.4.3)
  - Locking pear/pear-core-minimal (v1.10.10)
  - Locking pear/pear_exception (v1.0.2)
  - Locking psr/cache (1.0.1)
  - Locking psr/container (1.1.1)
  - Locking psr/event-dispatcher (1.0.0)
  - Locking psr/http-client (1.0.1)
  - Locking psr/http-factory (1.0.1)
  - Locking psr/http-message (1.0.1)
  - Locking psr/log (1.1.4)
  - Locking psy/psysh (v0.10.8)
  - Locking ralouphie/getallheaders (3.0.3)
  - Locking setasign/fpdi (v2.3.6)
  - Locking solarium/solarium (6.1.4)
  - Locking stack/builder (v1.0.6)
  - Locking symfony-cmf/routing (2.3.3)
  - Locking symfony/console (v4.4.25)
  - Locking symfony/debug (v4.4.25)
  - Locking symfony/dependency-injection (v4.4.25)
  - Locking symfony/deprecation-contracts (v2.4.0)
  - Locking symfony/dom-crawler (v4.4.25)
  - Locking symfony/error-handler (v4.4.25)
  - Locking symfony/event-dispatcher (v4.4.25)
  - Locking symfony/event-dispatcher-contracts (v1.1.9)
  - Locking symfony/filesystem (v4.4.26)
  - Locking symfony/finder (v5.3.0)
  - Locking symfony/http-client-contracts (v2.4.0)
  - Locking symfony/http-foundation (v4.4.25)
  - Locking symfony/http-kernel (v4.4.25)
  - Locking symfony/mime (v5.3.0)
  - Locking symfony/polyfill-ctype (v1.23.0)
  - Locking symfony/polyfill-iconv (v1.23.0)
  - Locking symfony/polyfill-intl-idn (v1.23.0)
  - Locking symfony/polyfill-intl-normalizer (v1.23.0)
  - Locking symfony/polyfill-mbstring (v1.23.0)
  - Locking symfony/polyfill-php72 (v1.23.0)
  - Locking symfony/polyfill-php73 (v1.23.0)
  - Locking symfony/polyfill-php80 (v1.23.0)
  - Locking symfony/process (v4.4.25)
  - Locking symfony/psr-http-message-bridge (v2.1.0)
  - Locking symfony/routing (v4.4.25)
  - Locking symfony/serializer (v4.4.25)
  - Locking symfony/service-contracts (v2.4.0)
  - Locking symfony/translation (v4.4.25)
  - Locking symfony/translation-contracts (v2.4.0)
  - Locking symfony/validator (v4.4.25)
  - Locking symfony/var-dumper (v5.3.0)
  - Locking symfony/yaml (v4.4.25)
  - Locking twig/twig (v2.14.6)
  - Locking typo3/phar-stream-wrapper (v3.1.6)
  - Locking webflo/drupal-finder (1.2.2)
  - Locking webmozart/assert (1.10.0)
  - Locking webmozart/path-util (2.3.0)
  - Locking ymcatwincities/media_entity_document (dev-8.x-1.x 7ad687a)
  - Locking ymcatwincities/openy (dev-9.x-2.x-drupal_core9.2patch fc9fd39)
  - Locking ymcatwincities/openy-cibox-build (dev-solr6 da15227)
  - Locking ymcatwincities/openy-cibox-vm (dev-master e1821c1)
  - Locking ymcatwincities/openy-docksal (dev-master b4158bf)
  - Locking ymcatwincities/openy_activity_finder (4.0.1)
  - Locking ymcatwincities/ymca_sync (10.0.2)
  - Locking ynorth-projects/openy_node_session (1.1.0)
  - Locking ynorth-projects/openy_pef_gxp_sync (1.1.2)
  - Locking ynorth-projects/openy_repeat (2.0.4)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 221 installs, 0 updates, 0 removals
  - Syncing drupal/draggableviews (dev-1.x c0292a4) into cache
  - Syncing drupal/migrate_tools (dev-5.x 56d82b4) into cache
  - Syncing grt107/grt-youtube-popup (1.0.0) into cache
  - Syncing library-jaypan/jquery_colorpicker (1.0.1) into cache
  - Syncing library-smonetti/btbutton (1.0.2) into cache
  - Downloading ymcatwincities/openy (dev-9.x-2.x-drupal_core9.2patch fc9fd39)
 0/1 [>---------------------------]   0%
 1/1 [============================] 100%
  - Installing composer/installers (v1.11.0): Extracting archive
  - Installing cweagans/composer-patches (1.7.1): Extracting archive
No patches supplied.
Gathering patches for dependencies. This might take a minute.
  - Installing drupal/core-composer-scaffold (9.2.1): Extracting archive
  - Installing drupal/core-project-message (9.2.1): Extracting archive
  - Installing oomphinc/composer-installers-extender (2.0.0): Extracting archive
  - Installing psr/container (1.1.1): Extracting archive
  - Installing symfony/service-contracts (v2.4.0): Extracting archive
  - Installing symfony/polyfill-php80 (v1.23.0): Extracting archive
  - Installing symfony/polyfill-php73 (v1.23.0): Extracting archive
  - Installing symfony/polyfill-mbstring (v1.23.0): Extracting archive
  - Installing symfony/console (v4.4.25): Extracting archive
  - Installing psr/log (1.1.4): Extracting archive
  - Installing consolidation/log (2.0.2): Extracting archive
  - Installing symfony/finder (v5.3.0): Extracting archive
  - Installing dflydev/dot-access-data (v1.1.0): Extracting archive
  - Installing consolidation/output-formatters (4.1.2): Extracting archive
  - Installing symfony/polyfill-ctype (v1.23.0): Extracting archive
  - Installing symfony/filesystem (v4.4.26): Extracting archive
  - Installing consolidation/self-update (1.2.0): Extracting archive
  - Installing doctrine/collections (1.6.7): Extracting archive
  - Installing doctrine/inflector (v1.2.0): Extracting archive
  - Installing typo3/phar-stream-wrapper (v3.1.6): Extracting archive
  - Installing twig/twig (v2.14.6): Extracting archive
  - Installing symfony/yaml (v4.4.25): Extracting archive
  - Installing symfony/translation-contracts (v2.4.0): Extracting archive
  - Installing symfony/validator (v4.4.25): Extracting archive
  - Installing symfony/translation (v4.4.25): Extracting archive
  - Installing symfony/serializer (v4.4.25): Extracting archive
  - Installing symfony/routing (v4.4.25): Extracting archive
  - Installing symfony/polyfill-php72 (v1.23.0): Extracting archive
  - Installing symfony/polyfill-intl-normalizer (v1.23.0): Extracting archive
  - Installing symfony/polyfill-intl-idn (v1.23.0): Extracting archive
  - Installing symfony/deprecation-contracts (v2.4.0): Extracting archive
  - Installing symfony/mime (v5.3.0): Extracting archive
  - Installing symfony/http-foundation (v4.4.25): Extracting archive
  - Installing psr/http-message (1.0.1): Extracting archive
  - Installing symfony/psr-http-message-bridge (v2.1.0): Extracting archive
  - Installing symfony/process (v4.4.25): Extracting archive
  - Installing symfony/polyfill-iconv (v1.23.0): Extracting archive
  - Installing symfony/http-client-contracts (v2.4.0): Extracting archive
  - Installing symfony/event-dispatcher-contracts (v1.1.9): Extracting archive
  - Installing symfony/event-dispatcher (v4.4.25): Extracting archive
  - Installing symfony/var-dumper (v5.3.0): Extracting archive
  - Installing symfony/debug (v4.4.25): Extracting archive
  - Installing symfony/error-handler (v4.4.25): Extracting archive
  - Installing symfony/http-kernel (v4.4.25): Extracting archive
  - Installing symfony/dependency-injection (v4.4.25): Extracting archive
  - Installing symfony-cmf/routing (2.3.3): Extracting archive
  - Installing stack/builder (v1.0.6): Extracting archive
  - Installing pear/pear_exception (v1.0.2): Extracting archive
  - Installing pear/console_getopt (v1.4.3): Extracting archive
  - Installing pear/pear-core-minimal (v1.10.10): Extracting archive
  - Installing pear/archive_tar (1.4.13): Extracting archive
  - Installing masterminds/html5 (2.7.4): Extracting archive
  - Installing laminas/laminas-zendframework-bridge (1.2.0): Extracting archive
  - Installing laminas/laminas-stdlib (3.3.1): Extracting archive
  - Installing laminas/laminas-escaper (2.7.0): Extracting archive
  - Installing laminas/laminas-feed (2.14.1): Extracting archive
  - Installing psr/http-factory (1.0.1): Extracting archive
  - Installing laminas/laminas-diactoros (2.6.0): Extracting archive
  - Installing ralouphie/getallheaders (3.0.3): Extracting archive
  - Installing guzzlehttp/psr7 (1.8.2): Extracting archive
  - Installing guzzlehttp/promises (1.4.1): Extracting archive
  - Installing guzzlehttp/guzzle (6.5.5): Extracting archive
  - Installing doctrine/lexer (1.2.1): Extracting archive
  - Installing egulias/email-validator (2.1.25): Extracting archive
  - Installing psr/cache (1.0.1): Extracting archive
  - Installing doctrine/annotations (1.13.1): Extracting archive
  - Installing doctrine/reflection (1.2.2): Extracting archive
  - Installing composer/semver (3.2.5): Extracting archive
  - Installing asm89/stack-cors (1.3.0): Extracting archive
  - Installing drupal/core (9.2.1): Extracting archive
  - Installing commerceguys/addressing (v1.2.1): Extracting archive
  - Installing drupal/address (1.9.0): Extracting archive
  - Installing drupal/admin_toolbar (3.0.1): Extracting archive
  - Installing drupal/jquery_ui (1.4.0): Extracting archive
  - Installing drupal/jquery_ui_touch_punch (1.0.0): Extracting archive
  - Installing drupal/jquery_ui_slider (1.1.0): Extracting archive
  - Installing drupal/jquery_ui_datepicker (1.1.0): Extracting archive
  - Installing drupal/better_exposed_filters (5.0.0-beta3): Extracting archive
  - Installing drupal/blazy (2.4.0): Extracting archive
  - Installing drupal/ckeditor_bootstrap_buttons (2.0.0): Extracting archive
  - Installing drupal-ckeditor-libraries-group/font (4.16.1): Extracting archive
  - Installing drupal/ckeditor_font (1.2.0): Extracting archive
  - Installing drupal/colorapi (1.1.0): Extracting archive
  - Installing drupal/panelbutton (1.3.0): Extracting archive
  - Installing drupal/colorbutton (1.2.0): Extracting archive
  - Installing drupal/confi (2.0.0-rc1): Extracting archive
  - Installing drupal/core-recommended (9.2.1)
  - Installing drupal/css_editor (1.3.0): Extracting archive
  - Installing drupal/custom_formatters (3.0.0-beta1): Extracting archive
  - Installing drupal/datalayer (1.0.0-beta2): Extracting archive
  - Installing drupal/domain (1.0.0-beta6): Extracting archive
  - Installing drupal/domain_theme_switch (1.5.0): Extracting archive
  - Installing drupal/draggableviews (dev-1.x c0292a4): Cloning c0292a46c5 from cache
  - Installing drupal/dropzonejs (2.5.0): Extracting archive
  - Installing drupal/easy_breadcrumb (1.15.0): Extracting archive
  - Installing drupal/editor_advanced_link (1.9.0): Extracting archive
  - Installing drupal/entity (1.2.0): Extracting archive
  - Installing drupal/entity_clone (1.0.0-beta6): Extracting archive
  - Installing drupal/config_update (1.7.0): Extracting archive
  - Installing drupal/features (3.12.0): Extracting archive
  - Installing drupal/field_group (3.1.0): Extracting archive
  - Installing drupal/crop (2.1.0): Extracting archive
  - Installing drupal/focal_point (1.5.0): Extracting archive
  - Installing drupal/fontyourface (3.6.0): Extracting archive
  - Installing drupal/geolocation (3.7.0): Extracting archive
  - Installing drupal/entity_reference_revisions (1.9.0): Extracting archive
  - Installing drupal/paragraphs (1.12.0): Extracting archive
  - Installing drupal/geysir (1.3.0): Extracting archive
  - Installing drupal/google_analytics (3.1.0): Extracting archive
  - Installing drupal/google_optimize (1.7.0): Extracting archive
  - Installing drupal/google_tag (1.4.0): Extracting archive
  - Installing drupal/image_widget_crop (2.3.0): Extracting archive
  - Installing drupal/inline_entity_form (1.0.0-rc9): Extracting archive
  - Installing drupal/jquery_ui_tabs (1.1.0): Extracting archive
  - Installing drupal/jquery_ui_tooltip (1.1.0): Extracting archive
  - Installing drupal/libraries (3.0.0-beta1): Extracting archive
  - Installing drupal/link_attributes (1.11.0): Extracting archive
  - Installing drupal/embed (1.4.0): Extracting archive
  - Installing drupal/entity_embed (1.1.0): Extracting archive
  - Installing drupal/entity_browser (2.6.0): Extracting archive
  - Installing drupal/media_directories (2.0.1): Extracting archive
  - Installing drupal/media_entity_image (1.4.0-rc1): Extracting archive
  - Installing drupal/media_entity_video (2.0.0-rc2): Extracting archive
  - Installing drupal/token (1.9.0): Extracting archive
  - Installing drupal/metatag (1.16.0): Extracting archive
  - Installing league/csv (9.7.1): Extracting archive
  - Installing drupal/migrate_source_csv (3.4.0): Extracting archive
  - Installing drupal/migrate_plus (5.1.0): Extracting archive
  - Installing drupal/migrate_tools (dev-5.x 56d82b4): Cloning 56d82b4fc1 from cache
  - Installing drupal/ctools (3.7.0): Extracting archive
  - Installing drupal/pathauto (1.8.0): Extracting archive
  - Installing drupal/plugin (2.8.0): Extracting archive
  - Installing drupal/rabbit_hole (1.0.0-beta10): Extracting archive
  - Installing google/recaptcha (1.2.4): Extracting archive
  - Installing drupal/captcha (1.2.0): Extracting archive
  - Installing drupal/recaptcha (3.0.0): Extracting archive
  - Installing drupal/redirect (1.6.0): Extracting archive
  - Installing drupal/scheduler (1.3.0): Extracting archive
  - Installing psr/http-client (1.0.1): Extracting archive
  - Installing psr/event-dispatcher (1.0.0): Extracting archive
  - Installing solarium/solarium (6.1.4): Extracting archive
  - Installing myclabs/php-enum (1.8.3): Extracting archive
  - Installing maennchen/zipstream-php (2.1.0): Extracting archive
  - Installing drupal/search_api (1.19.0): Extracting archive
  - Installing consolidation/annotated-command (4.2.4): Extracting archive
  - Installing drupal/search_api_solr (4.2.0): Extracting archive
  - Installing drupal/simple_menu_icons (2.2.0): Extracting archive
  - Installing drupal/simple_sitemap (3.10.0): Extracting archive
  - Installing drupal/slick (2.3.0): Extracting archive
  - Installing drupal/slick_views (2.4.0): Extracting archive
  - Installing facebook/graph-sdk (5.7.0): Extracting archive
  - Installing espresso-dev/instagram-basic-display-php (v1.1.6): Extracting archive
  - Installing abraham/twitteroauth (0.7.4): Extracting archive
  - Installing drupal/social_feed_fetcher (2.0.0-alpha3): Extracting archive
  - Installing drupal/token_filter (1.2.0): Extracting archive
  - Installing drupal/twig_tweak (3.1.2): Extracting archive
  - Installing drupal/tzfield (1.3.0): Extracting archive
  - Installing drupal/vendor_stream_wrapper (1.6.0): Extracting archive
  - Installing drupal/verf (1.0.0): Extracting archive
  - Installing drupal/video (1.5.0-alpha1): Extracting archive
  - Installing drupal/video_embed_field (2.4.0): Extracting archive
  - Installing drupal/views_block_filter_block (1.0.0): Extracting archive
  - Installing drupal/csv_serialization (2.0.0): Extracting archive
  - Installing drupal/views_data_export (1.0.0): Extracting archive
  - Installing drupal/views_field_formatter (1.13.0): Extracting archive
  - Installing drupal/views_infinite_scroll (1.8.0): Extracting archive
  - Installing drupal/webform (6.0.4): Extracting archive
  - Installing webmozart/assert (1.10.0): Extracting archive
  - Installing webmozart/path-util (2.3.0): Extracting archive
  - Installing webflo/drupal-finder (1.2.2): Extracting archive
  - Installing nikic/php-parser (v4.11.0): Extracting archive
  - Installing psy/psysh (v0.10.8): Extracting archive
  - Installing container-interop/container-interop (1.2.0): Extracting archive
  - Installing league/container (2.5.0): Extracting archive
  - Installing grasmash/yaml-expander (1.4.0): Extracting archive
  - Installing enlightn/security-checker (v1.9.0): Extracting archive
  - Installing grasmash/expander (1.0.0): Extracting archive
  - Installing consolidation/config (1.2.1): Extracting archive
  - Installing consolidation/site-alias (3.1.0): Extracting archive
  - Installing consolidation/site-process (4.1.0): Extracting archive
  - Installing consolidation/robo (1.4.13): Extracting archive
  - Installing consolidation/filter-via-dot-access-data (1.0.0): Extracting archive
  - Installing chi-teck/drupal-code-generator (1.33.1): Extracting archive
  - Installing drush/drush (10.5.0): Extracting archive
  - Installing grt107/grt-youtube-popup (1.0.0): Cloning d5cb51ae5d from cache
  - Installing library-ckeditor/colorbutton (4.10.1): Extracting archive
  - Installing library-ckeditor/font (4.12.1): Extracting archive
  - Installing library-ckeditor/panelbutton (4.10.1): Extracting archive
  - Installing library-davekoelle/alphanum (1.0.0): Extracting archive
  - Installing library-jaypan/jquery_colorpicker (1.0.1): Cloning da978ae124 from cache
  - Installing library-smonetti/btbutton (1.0.2): Cloning ee1fc39623 from cache
  - Installing library-vakata/jstree (3.3.8): Extracting archive
  - Installing setasign/fpdi (v2.3.6): Extracting archive
  - Installing paragonie/random_compat (v9.99.100): Extracting archive
  - Installing myclabs/deep-copy (1.10.2): Extracting archive
  - Installing mpdf/mpdf (v8.0.11): Extracting archive
  - Installing npm-asset/blazy (1.8.2): Extracting archive
  - Installing npm-asset/dropzone (5.9.2): Extracting archive
  - Installing npm-asset/jquery-ui-touch-punch (0.2.3): Extracting archive
  - Installing npm-asset/jquery.easing (1.4.2): Extracting archive
  - Installing npm-asset/slick-carousel (1.8.1): Extracting archive
  - Installing ymcatwincities/openy (dev-9.x-2.x-drupal_core9.2patch fc9fd39): Extracting archive
  - Installing ynorth-projects/openy_repeat (2.0.4): Extracting archive
  - Installing ynorth-projects/openy_pef_gxp_sync (1.1.2): Extracting archive
  - Installing ymcatwincities/ymca_sync (10.0.2): Extracting archive
  - Installing ymcatwincities/openy_activity_finder (4.0.1): Extracting archive
  - Installing ymcatwincities/media_entity_document (dev-8.x-1.x 7ad687a): Extracting archive
  - Installing symfony/dom-crawler (v4.4.25): Extracting archive
  - Installing open-y-subprojects/ynorth_gxp_spots_proxy (1.0.1): Extracting archive
  - Installing open-y-subprojects/openy_hours_formatter (1.2.0): Extracting archive
  - Installing ynorth-projects/openy_node_session (1.1.0): Extracting archive
  - Installing open-y-subprojects/openy_node_alert (1.0.1): Extracting archive
  - Installing open-y-subprojects/openy_content_core (1.2): Extracting archive
  - Installing open-y-subprojects/openy_demo_content (1.2): Extracting archive
  - Installing open-y-subprojects/openy_features (1.4): Extracting archive
  - Installing open-y-subprojects/openy_daxko_gxp_syncer (1.1.0): Extracting archive
  - Installing ymcatwincities/openy-cibox-build (dev-solr6 da15227): Extracting archive
  - Installing ymcatwincities/openy-cibox-vm (dev-master e1821c1): Extracting archive
  - Installing ymcatwincities/openy-docksal (dev-master b4158bf): Extracting archive
   0/210 [>---------------------------]   0%
   5/210 [>---------------------------]   2%
  10/210 [=>--------------------------]   4%
  20/210 [==>-------------------------]   9%
  28/210 [===>------------------------]  13%
  30/210 [====>-----------------------]  14%
  38/210 [=====>----------------------]  18%
  40/210 [=====>----------------------]  19%
  43/210 [=====>----------------------]  20%
  50/210 [======>---------------------]  23%
  53/210 [=======>--------------------]  25%
  57/210 [=======>--------------------]  27%
  63/210 [========>-------------------]  30%
  66/210 [========>-------------------]  31%
  74/210 [=========>------------------]  35%
  75/210 [==========>-----------------]  35%
  83/210 [===========>----------------]  39%
  84/210 [===========>----------------]  40%
  92/210 [============>---------------]  43%
  93/210 [============>---------------]  44%
 101/210 [=============>--------------]  48%
 102/210 [=============>--------------]  48%
 110/210 [==============>-------------]  52%
 111/210 [==============>-------------]  52%
 112/210 [==============>-------------]  53%
 120/210 [================>-----------]  57%
 122/210 [================>-----------]  58%
 130/210 [=================>----------]  61%
 132/210 [=================>----------]  62%
 136/210 [==================>---------]  64%
 139/210 [==================>---------]  66%
 141/210 [==================>---------]  67%
 146/210 [===================>--------]  69%
 149/210 [===================>--------]  70%
 151/210 [====================>-------]  71%
 156/210 [====================>-------]  74%
 157/210 [====================>-------]  74%
 160/210 [=====================>------]  76%
 165/210 [======================>-----]  78%
 167/210 [======================>-----]  79%
 170/210 [======================>-----]  80%
 174/210 [=======================>----]  82%
 176/210 [=======================>----]  83%
 181/210 [========================>---]  86%
 184/210 [========================>---]  87%
 189/210 [=========================>--]  90%
 191/210 [=========================>--]  90%
 195/210 [==========================>-]  92%
 198/210 [==========================>-]  94%
 200/210 [==========================>-]  95%
 203/210 [===========================>]  96%
 205/210 [===========================>]  97%
 207/210 [===========================>]  98%
 208/210 [===========================>]  99%
 209/210 [===========================>]  99%
 210/210 [============================] 100%
  - Applying patches for drupal/core
    https://www.drupal.org/files/issues/undefined-index-in-_color_rewrite_stylesheet-1236098-37.patch (1236098 - Notice: Undefined index in _color_rewrite_stylesheet())
    https://www.drupal.org/files/issues/2484693-54.patch (2484693 - Telephone Link field formatter InvalidArgumentException with 5 digits or fewer in the number)
    https://www.drupal.org/files/issues/2862702-3.patch (2862702 - PrepareModulesEntityUninstallForm::formTitle does not exist)
    https://gist.githubusercontent.com/podarok/41a0df40e3db2c809b7396bda8bc1c85/raw/eb2741da648790e8f87b9544d86b8f2e86c0d555/move_extension_list_reset.diff (Apply suggestion https://drupal.slack.com/archives/C1BMUQ9U6/p1626267909357300?thread_ts=1626097881.298900&cid=C1BMUQ9U6)

  - Applying patches for drupal/colorapi
    https://www.drupal.org/files/issues/2020-09-16/3171235-2.patch (3171235 - Add Value property)
    https://gist.githubusercontent.com/manachynskyi/a24c7898a0ed051bc077fc94cc2dc2e8/raw/9524fa2d630d2ee0e0e39316156612b33c854182/colorapi_config_patch.patch (Update colorapi configs)

  - Applying patches for drupal/features
    https://gist.githubusercontent.com/podarok/3c14521da12ad73fa08fe3ec0a237a28/raw/205ec76647bd9c5a0bec310c3666c95c901539d7/features_hook.diff (Fix hook install https://gist.github.com/podarok/3c14521da12ad73fa08fe3ec0a237a28)

  - Applying patches for drupal/field_group
    https://www.drupal.org/files/issues/2020-06-15/3059614-37.patch (3059614 - Fixed Undefined property: stdClass::$region in field_group_form_process())

  - Applying patches for drupal/geysir
    https://raw.githubusercontent.com/ymcatwincities/openy/8.x-2.x/patches/geysir/add-reload-page.patch (Adds a feature for reload a page after success paragraph add or edit)

  - Applying patches for drupal/entity_embed
    https://gist.githubusercontent.com/podarok/47b9e38df6570a31d1ea87fea250d6c2/raw/d1435211dffe31cb6206d360e1d99f44c0deddee/entity_embed_1_1_bc_link_to.patch (Add BC layer for entity_embed 1.1 for https://www.drupal.org/project/entity_embed/issues/2511404#comment-12129724)

  - Applying patches for drupal/entity_browser
    https://www.drupal.org/files/issues/2845037_15.patch (2845037 - Fixed the issue of Call to a member function getConfigDependencyKey() on null on [Widget view], and [SelectionDisplay view])

  - Applying patches for drupal/media_entity_video
    https://www.drupal.org/files/issues/2020-06-11/3149789-4.patch (3149789 - Add a 3.x branch with an update path to the video source in core.)

  - Applying patches for drupal/plugin
    https://www.drupal.org/files/issues/2020-07-22/2647312-32.patch (2647312 - Use SubFormState in plugin selectors)

  - Applying patches for drupal/search_api
    https://www.drupal.org/files/issues/2021-01-31/2898334-30--role_based_access_check.patch (2898334 - Add a Role-based access processor)

  - Applying patches for drupal/video_embed_field
    https://git.drupalcode.org/project/video_embed_field/-/merge_requests/3.diff (Issue #3215817: Presentational attributes such as 'border', 'align', or 'bgcolor' are used. CSS should be used for styling instead.)

54 package suggestions were added by new dependencies, use `composer suggest` to see details.
Package container-interop/container-interop is abandoned, you should avoid using it. Use psr/container instead.
Package doctrine/reflection is abandoned, you should avoid using it. Use roave/better-reflection instead.
Generating autoload files
51 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
Scaffolding files for drupal/core:
  - Copy [project-root]/.editorconfig from assets/scaffold/files/editorconfig
  - Copy [project-root]/.gitattributes from assets/scaffold/files/gitattributes
  - Copy [web-root]/.csslintrc from assets/scaffold/files/csslintrc
  - Copy [web-root]/.eslintignore from assets/scaffold/files/eslintignore
  - Copy [web-root]/.eslintrc.json from assets/scaffold/files/eslintrc.json
  - Copy [web-root]/.ht.router.php from assets/scaffold/files/ht.router.php
  - Copy [web-root]/.htaccess from assets/scaffold/files/htaccess
  - Copy [web-root]/example.gitignore from assets/scaffold/files/example.gitignore
  - Copy [web-root]/index.php from assets/scaffold/files/index.php
  - Copy [web-root]/INSTALL.txt from assets/scaffold/files/drupal.INSTALL.txt
  - Copy [web-root]/README.md from assets/scaffold/files/drupal.README.md
  - Copy [web-root]/robots.txt from assets/scaffold/files/robots.txt
  - Copy [web-root]/update.php from assets/scaffold/files/update.php
  - Copy [web-root]/web.config from assets/scaffold/files/web.config
  - Copy [web-root]/sites/README.txt from assets/scaffold/files/sites.README.txt
  - Copy [web-root]/sites/development.services.yml from assets/scaffold/files/development.services.yml
  - Copy [web-root]/sites/example.settings.local.php from assets/scaffold/files/example.settings.local.php
  - Copy [web-root]/sites/example.sites.php from assets/scaffold/files/example.sites.php
  - Copy [web-root]/sites/default/default.services.yml from assets/scaffold/files/default.services.yml
  - Copy [web-root]/sites/default/default.settings.php from assets/scaffold/files/default.settings.php
  - Copy [web-root]/modules/README.txt from assets/scaffold/files/modules.README.txt
  - Copy [web-root]/profiles/README.txt from assets/scaffold/files/profiles.README.txt
  - Copy [web-root]/themes/README.txt from assets/scaffold/files/themes.README.txt
Class DrupalComposer\DrupalScaffold\Plugin is not autoloadable, can not call post-update-cmd script
> [ -d ./vendor/ymcatwincities/openy-cibox-build ] && (rsync -r --exclude=composer.json --exclude=.gitignore --exclude=.git ./vendor/ymcatwincities/openy-cibox-build/ ./docroot) || (rm -rf ./docroot/devops ./docroot/*.sh ./docroot/*.yml ./docroot/*.md ./docroot/ansible.cfg)
> [ -d ./vendor/ymcatwincities/openy-cibox-vm ] && (rsync -r --exclude=composer.json --exclude=README.md --exclude=.gitignore --exclude=.git --exclude=LICENSE ./vendor/ymcatwincities/openy-cibox-vm/ ./) || (rm -rf cibox provisioning Vagrantfile .vagrant backup cache)
> [ -d ./vendor/ymcatwincities/openy-docksal ] && (rsync -r --exclude=composer.json --exclude=.git --exclude=README.md ./vendor/ymcatwincities/openy-docksal/ ./) || (rm -rf .docksal build.sh)
> bash scripts/remove_vendor_git_folders.sh || :
Removing .git folders from vendor folder to avoid possible git issues.
Removing .git folders from docroot/libraries folder to avoid possible git issues.
Removing .git folders from docroot/modules/contrib folder to avoid possible git issues.
+ sudo rm -rf build
+ sudo mv buildnew build
+ sudo unlink /var/www/dev_sandbox_lily_custom
+ sudo rm -f /var/www/dev_sandbox_lily_custom
+ sudo ln -s /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/docroot/ /var/www/dev_sandbox_lily_custom
+ sudo chown -R www-data:jenkins /var/www/dev_sandbox_lily_custom
+ cd /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build
+ rm -Rf {WORKSPACE}/build/docroot/sites/default/files/*
+ cd /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/docroot/
+ sudo chown www-data:www-data sites/default
[XXX_DEV_SANDBOX_LILY_CUSTOM] $ ansible-playbook /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/cibox/jobs/build.yml -f 5 -e workspace=/home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM -e build_number=dev_sandbox_lily_custom -e server_docroot_folder=/var/www -e build_folder_prefix= -i localhost, --connection=local

PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
ok: [localhost]

TASK [Folder permissions] ******************************************************
changed: [localhost]

PLAY RECAP *********************************************************************
localhost                  : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   

[XXX_DEV_SANDBOX_LILY_CUSTOM] $ /bin/sh -xe /tmp/hudson5349271045618713908.sh
+ cd /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/docroot/
+ APP_ENV=dev drush -y si openy openy_configure_profile.preset=complete openy_theme_select.theme=openy_lily -d -vvv openy_terms_of_use.agree_openy_terms=1 install_configure_form.enable_update_status_emails=NULL --db-url=mysql://root:root@127.0.0.1:/dev_sandbox_lily_custom --account-name=admin --account-pass=open9622 --uri=http://sandbox-lily-cus-dev.openy.org
Using the Drush script found at /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/vendor/drush/drush/drush using pcntl_exec
 [preflight] Config paths: /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/vendor/drush/drush/drush.yml
 [preflight] Alias paths: /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/docroot/drush/sites,/home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/drush/sites
 [preflight] Commandfile search paths: /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/vendor/drush/drush/src
 [debug] Starting bootstrap to root [0.19 sec, 8.52 MB]
 [debug] Drush bootstrap phase 1 [0.19 sec, 8.52 MB]
 [debug] Try to validate bootstrap phase 1 [0.2 sec, 8.52 MB]
 [debug] Try to validate bootstrap phase 1 [0.2 sec, 8.52 MB]
 [debug] Try to bootstrap at phase 1 [0.2 sec, 8.52 MB]
 [debug] Drush bootstrap phase: bootstrapDrupalRoot() [0.2 sec, 8.52 MB]
 [debug] Change working directory to /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/docroot [0.2 sec, 8.52 MB]
 [debug] Initialized Drupal 9.2.1 root directory at /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/docroot [0.2 sec, 8.52 MB]
 [debug] Drush bootstrap phase: bootstrapDrupalSite() [0.2 sec, 8.87 MB]
 [debug] Initialized Drupal site sandbox-lily-cus-dev.openy.org at sites/default [0.21 sec, 9.1 MB]
 [debug] Could not find a Drupal settings.php file at sites/default/settings.php. [0.21 sec, 9.1 MB]
 [debug] Drush bootstrap phase: bootstrapDrupalConfiguration() [0.21 sec, 9.1 MB]
 [debug] Add service modifier [0.21 sec, 9.24 MB]
 [info] Executing: command -v mysql [0.22 sec, 9.69 MB]
 [info] sql:query: SELECT 1; [0.22 sec, 9.73 MB]
 [info] Executing: mysql --defaults-file=/tmp/drush_qXQpvz --database=dev_sandbox_lily_custom --host=127.0.0.1 --silent -A < /tmp/drush_tPNJMx [0.22 sec, 9.73 MB]

 You are about to:
 * Create a sites/default/settings.php file
 * DROP all tables in your 'dev_sandbox_lily_custom' database.

 // Do you want to continue?: yes.                                              

 [info] Sites directory sites/default already exists - proceeding. [0.31 sec, 9.73 MB]
 [debug] Calling copy(sites/default/default.settings.php, sites/default/settings.php) [0.31 sec, 9.73 MB]
 [info] sql:query: SELECT 1; [0.31 sec, 9.73 MB]
 [info] Executing: mysql --defaults-file=/tmp/drush_0TbwTw --database=dev_sandbox_lily_custom --host=127.0.0.1 --silent -A < /tmp/drush_kplvEy [0.31 sec, 9.73 MB]
 [info] sql:query: SHOW TABLES; [0.34 sec, 9.73 MB]
 [info] Executing: mysql --defaults-file=/tmp/drush_yAzgnw --database=dev_sandbox_lily_custom --host=127.0.0.1 --silent -A < /tmp/drush_Alp53v [0.34 sec, 9.74 MB]
 [info] sql:query: DROP TABLE `advanced_help_block`, `advanced_help_block__field_ahb_description`, `advanced_help_block__field_ahb_video`, `block_content`, `block_content__body`, `block_content__field_block_content`, `block_content__field_icon`, `block_content__field_icon_class`, `block_content__field_sb_body`, `block_content__field_sb_link`, `block_content__field_sb_title`, `block_content_field_data`, `block_content_field_revision`, `block_content_revision`, `block_content_revision__body`, `block_content_revision__field_block_content`, `block_content_revision__field_icon`, `block_content_revision__field_icon_class`, `block_content_revision__field_sb_body`, `block_content_revision__field_sb_link`, `block_content_revision__field_sb_title`, `cache_container`, `captcha_sessions`, `config`, `config_snapshot`, `crop`, `crop_field_data`, `crop_field_revision`, `crop_revision`, `file_managed`, `file_usage`, `history`, `key_value`, `media`, `media__field_media_caption`, `media__field_media_document`, `media__field_media_image`, `media__field_media_in_library`, `media__field_media_local_video`, `media__field_media_mime`, `media__field_media_size`, `media__field_media_source`, `media__field_media_tags`, `media__field_media_video_embed_field`, `media__field_media_video_id`, `media_field_data`, `media_field_revision`, `media_revision`, `media_revision__field_media_caption`, `media_revision__field_media_document`, `media_revision__field_media_image`, `media_revision__field_media_in_library`, `media_revision__field_media_local_video`, `media_revision__field_media_mime`, `media_revision__field_media_size`, `media_revision__field_media_source`, `media_revision__field_media_tags`, `media_revision__field_media_video_embed_field`, `media_revision__field_media_video_id`, `menu_link_content`, `menu_link_content_data`, `menu_link_content_field_revision`, `menu_link_content_revision`, `menu_tree`, `node`, `node__body`, `node__field_bottom_content`, `node__field_content`, `node__field_header_content`, `node__field_lp_layout`, `node__field_lp_location`, `node__field_meta_tags`, `node__field_sidebar_content`, `node_access`, `node_field_data`, `node_field_revision`, `node_revision`, `node_revision__body`, `node_revision__field_bottom_content`, `node_revision__field_content`, `node_revision__field_header_content`, `node_revision__field_lp_layout`, `node_revision__field_lp_location`, `node_revision__field_meta_tags`, `node_revision__field_sidebar_content`, `openy_upgrade_log`, `openy_upgrade_log_revision`, `paragraphs_item`, `paragraphs_item_field_data`, `paragraphs_item_revision`, `paragraphs_item_revision_field_data`, `path_alias`, `path_alias_revision`, `redirect`, `router`, `sequences`, `sessions`, `shortcut`, `shortcut_field_data`, `shortcut_set_users`, `simple_sitemap`, `simple_sitemap_entity_overrides`, `taxonomy_index`, `taxonomy_term__field_color`, `taxonomy_term__field_taxonomy_content`, `taxonomy_term__parent`, `taxonomy_term_data`, `taxonomy_term_field_data`, `taxonomy_term_field_revision`, `taxonomy_term_revision`, `taxonomy_term_revision__field_color`, `taxonomy_term_revision__field_taxonomy_content`, `taxonomy_term_revision__parent`, `user__roles`, `users`, `users_data`, `users_field_data` [0.38 sec, 9.76 MB]
 [info] Executing: mysql --defaults-file=/tmp/drush_yGWcky --database=dev_sandbox_lily_custom --host=127.0.0.1 --silent -A < /tmp/drush_mj592x [0.38 sec, 9.76 MB]
 [notice] Starting Drupal installation. This takes a while. [1.21 sec, 9.75 MB]
 [debug] Calling install_drupal(Composer\Autoload\ClassLoader, array, array) [1.21 sec, 10.04 MB]
 [notice] Performed install task: openy_terms_of_use [2.4 sec, 24.06 MB]
 [notice] Performed install task: install_select_language [2.4 sec, 24.06 MB]
 [notice] Performed install task: install_select_profile [2.4 sec, 24.06 MB]
 [notice] Performed install task: install_load_profile [2.4 sec, 24.06 MB]
 [notice] Performed install task: install_verify_requirements [2.44 sec, 24.63 MB]
 [notice] Performed install task: install_settings_form [2.68 sec, 28.83 MB]
 [notice] Performed install task: install_verify_database_ready [2.68 sec, 28.98 MB]
 [info] system module installed. [3.39 sec, 44.72 MB]
 [info] user module installed. [3.94 sec, 48.71 MB]
 [notice] Performed install task: install_base_system [3.95 sec, 48.74 MB]
 [notice] Performed install task: install_bootstrap_full [3.95 sec, 48.75 MB]
 [info] path_alias module installed. [4.37 sec, 51.96 MB]
 [info] action module installed. [4.57 sec, 48.8 MB]
 [info] field module installed. [4.78 sec, 49.79 MB]
 [info] file module installed. [5.07 sec, 53.95 MB]
 [info] filter module installed. [5.3 sec, 51.87 MB]
 [info] text module installed. [5.5 sec, 51.73 MB]
 [info] options module installed. [5.75 sec, 55.24 MB]
 [info] block module installed. [6 sec, 52.03 MB]
 [info] block_content module installed. [6.62 sec, 53.52 MB]
 [info] node module installed. [7.45 sec, 53.34 MB]
 [info] breakpoint module installed. [7.63 sec, 54.16 MB]
 [info] editor module installed. [7.88 sec, 55.17 MB]
 [info] ckeditor module installed. [8.06 sec, 59.69 MB]
 [info] color module installed. [8.28 sec, 54.97 MB]
 [info] config module installed. [8.48 sec, 59.49 MB]
 [info] language module installed. [8.97 sec, 56.17 MB]
 [info] contact module installed. [9.25 sec, 55.37 MB]
 [info] contextual module installed. [9.47 sec, 56.15 MB]
 [info] datetime module installed. [9.71 sec, 56.69 MB]
 [info] datetime_range module installed. [9.98 sec, 56.31 MB]
 [info] history module installed. [10.21 sec, 56.77 MB]
 [info] taxonomy module installed. [10.79 sec, 58.13 MB]
 [info] help module installed. [11.06 sec, 57.03 MB]
 [info] image module installed. [11.39 sec, 59.04 MB]
 [info] link module installed. [11.61 sec, 58.31 MB]
 [info] media module installed. [12.18 sec, 60.08 MB]
 [info] views module installed. [12.49 sec, 58.73 MB]
 [info] media_library module installed. [13.14 sec, 67.81 MB]
 [info] menu_link_content module installed. [13.75 sec, 67.56 MB]
 [info] menu_ui module installed. [14.07 sec, 65.82 MB]
 [info] migrate module installed. [14.42 sec, 66.68 MB]
 [info] page_cache module installed. [14.78 sec, 66.81 MB]
 [info] path module installed. [15.08 sec, 66.93 MB]
 [info] quickedit module installed. [15.38 sec, 67.02 MB]
 [info] rdf module installed. [15.79 sec, 67.04 MB]
 [info] toolbar module installed. [16.14 sec, 66.37 MB]
 [info] shortcut module installed. [16.78 sec, 67.57 MB]
 [info] telephone module installed. [17.1 sec, 66.71 MB]
 [info] tour module installed. [17.48 sec, 68.94 MB]
 [info] update module installed. [17.85 sec, 67.22 MB]
 [info] field_group module installed. [18.2 sec, 68.62 MB]
 [info] libraries module installed. [18.52 sec, 68.89 MB]
 [info] datalayer module installed. [18.84 sec, 69.04 MB]
 [info] advanced_help_block module installed. [19.69 sec, 72.82 MB]
 [info] migrate_plus module installed. [20.07 sec, 73.71 MB]
 [info] migrate_tools module installed. [20.5 sec, 70.92 MB]
 [info] entity_reference_revisions module installed. [20.83 sec, 71.06 MB]
 [info] token module installed. [21.48 sec, 73.09 MB]
 [info] metatag module installed. [21.93 sec, 74.54 MB]
 [info] link_attributes module installed. [22.23 sec, 73.58 MB]
 [info] openy_system module installed. [22.54 sec, 73.43 MB]
 [info] ctools module installed. [22.86 sec, 74.55 MB]
 [info] pathauto module installed. [23.26 sec, 75.52 MB]
 [info] plugin module installed. [23.64 sec, 74.3 MB]
 [info] openy_er module installed. [24.08 sec, 76.34 MB]
 [info] paragraphs module installed. [24.86 sec, 85.35 MB]
 [info] config_update module installed. [25.24 sec, 91.03 MB]
 [info] features module installed. [25.73 sec, 100.24 MB]
 [info] config_import module installed. [26.13 sec, 107.26 MB]
 [info] openy_upgrade_tool module installed. [26.87 sec, 122.02 MB]
 [info] simple_sitemap module installed. [27.35 sec, 127.34 MB]
 [info] openy_node module installed. [29.34 sec, 136.05 MB]
 [info] entity_browser module installed. [30.07 sec, 145.34 MB]
 [info] blazy module installed. [30.71 sec, 152.55 MB]
 [info] dropzonejs module installed. [31.34 sec, 152.95 MB]
 [info] dropzonejs_eb_widget module installed. [31.95 sec, 152.96 MB]
 [info] embed module installed. [32.77 sec, 154.17 MB]
 [info] entity_embed module installed. [33.46 sec, 154.12 MB]
 [info] crop module installed. [34.53 sec, 155 MB]
 [info] focal_point module installed. [35.18 sec, 153.55 MB]
 [info] media_directories module installed. [36.41 sec, 159.15 MB]
 [info] media_directories_ui module installed. [37.24 sec, 163.8 MB]
 [info] image_widget_crop module installed. [38 sec, 173.53 MB]
 [info] openy_focal_point module installed. [38.72 sec, 173.05 MB]
 [info] rabbit_hole module installed. [39.56 sec, 174.48 MB]
 [info] openy_media module installed. [41.46 sec, 171.78 MB]
 [warning] You have manual updated embed.button.embed_image config from Open Y profile. [43.13 sec, 181.35 MB]
 [warning] You have manual updated embed.button.embed_image config from Open Y profile. [43.16 sec, 181.46 MB]
 [info] openy_media_image module installed. [44.15 sec, 182.45 MB]
 [info] scheduler module installed. [45.54 sec, 188.91 MB]
 [info] openy_migrate module installed. [46.42 sec, 181.01 MB]
 [info] redirect module installed. [47.74 sec, 178.63 MB]
 [info] openy_redirect module installed. [48.61 sec, 179.85 MB]
 [info] colorapi module installed. [49.52 sec, 177.24 MB]
 [info] openy_txnm_color module installed. [50.78 sec, 176.18 MB]
 [info] openy_tour module installed. [51.58 sec, 179.45 MB]
 [info] openy_update module installed. [52.42 sec, 179.64 MB]
 [info] admin_toolbar module installed. [53.19 sec, 179.69 MB]
 [info] jquery_ui module installed. [53.99 sec, 179.75 MB]
 [info] captcha module installed. [54.96 sec, 179.23 MB]
 [info] image_captcha module installed. [55.74 sec, 175.98 MB]
 [info] ckeditor_bootstrap_buttons module installed. [56.49 sec, 178.11 MB]
 [info] ckeditor_font module installed. [57.36 sec, 178.16 MB]
 [info] panelbutton module installed. [58.39 sec, 178.23 MB]
 [info] colorbutton module installed. [59.2 sec, 180.33 MB]
 [info] editor_advanced_link module installed. [60.1 sec, 180.4 MB]
 [info] inline_entity_form module installed. [60.98 sec, 178.52 MB]
 [info] entity_browser_entity_form module installed. [61.79 sec, 176.57 MB]
 [info] jquery_ui_tabs module installed. [62.57 sec, 178.69 MB]
 [info] jquery_ui_tooltip module installed. [63.37 sec, 180.81 MB]
 [info] metatag_open_graph module installed. [64.12 sec, 178.81 MB]
 [info] openy_node_landing module installed. [65.82 sec, 179.09 MB]
 [info] openy_block module installed. [66.71 sec, 182.13 MB]
 [info] openy_block_custom_simple module installed. [68.42 sec, 183.21 MB]
 [info] openy_taxonomy module installed. [71.54 sec, 184.01 MB]
 [info] openy_datalayer module installed. [72.44 sec, 183.43 MB]
 [info] token_filter module installed. [73.43 sec, 180.9 MB]
 [info] openy_editor module installed. [74.31 sec, 181.72 MB]
 [warning] You have manual updated embed.button.embed_document config from Open Y profile. [76.18 sec, 189.44 MB]
 [warning] You have manual updated embed.button.embed_document config from Open Y profile. [76.2 sec, 189.55 MB]
 [info] openy_media_document module installed. [76.21 sec, 189.53 MB]
 [info] video module installed. [76.97 sec, 188.28 MB]
 [warning] You have manual updated embed.button.embed_local_video config from Open Y profile. [78.45 sec, 188 MB]
 [warning] You have manual updated embed.button.embed_local_video config from Open Y profile. [78.48 sec, 188.1 MB]
 [info] openy_media_local_video module installed. [78.48 sec, 188.08 MB]
 [info] video_embed_field module installed. [79.3 sec, 188.94 MB]
 [info] video_embed_media module installed. [80.19 sec, 180.51 MB]
 [warning] You have manual updated embed.button.embed_video config from Open Y profile. [82.09 sec, 188.54 MB]
 [warning] You have manual updated embed.button.embed_video config from Open Y profile. [82.12 sec, 188.64 MB]
 [info] openy_media_video module installed. [82.12 sec, 188.61 MB]
 [info] openy_menu module installed. [82.86 sec, 191.66 MB]
 [info] openy_menu_footer module installed. [83.65 sec, 185.49 MB]
 [info] openy_menu_main module installed. [86.68 sec, 186.93 MB]
 [info] recaptcha module installed. [87.44 sec, 184.73 MB]
 [info] simple_menu_icons module installed. [88.31 sec, 183.51 MB]
 [info] twig_tweak module installed. [89.08 sec, 185.9 MB]
 [notice] Performed install task: install_profile_modules [89.15 sec, 184.76 MB]
 [info] claro theme installed. [89.23 sec, 183.86 MB]
 [info] seven theme installed. [89.24 sec, 183.86 MB]
 [info] bartik theme installed. [89.25 sec, 183.87 MB]
 [info] openy_admin theme installed. [89.27 sec, 183.87 MB]
 [notice] Performed install task: install_profile_themes [89.29 sec, 183.94 MB]
 [info] openy_user module installed. [92.95 sec, 208.19 MB]
 [info] openy module installed. [92.98 sec, 208.2 MB]
 [notice] Performed install task: install_install_profile [93.02 sec, 208.38 MB]
 [notice] Performed install task: install_configure_form [94.6 sec, 190.97 MB]
 [notice] Performed install task: openy_select_search [94.61 sec, 190.88 MB]
 [notice] Performed install task: openy_google_search [94.62 sec, 190.88 MB]
 [notice] Performed install task: openy_select_features [94.81 sec, 191.12 MB]
 [info] activenet module installed. [95.74 sec, 204.7 MB]
 [info] openy_hf module installed. [96.77 sec, 200.1 MB]
 [info] google_tag module installed. [97.89 sec, 200.6 MB]
 [info] google_analytics module installed. [99.03 sec, 198.09 MB]
 [info] openy_addthis module installed. [100.05 sec, 201.94 MB]
 [info] openy_gtranslate module installed. [101.03 sec, 199.19 MB]
 [info] easy_breadcrumb module installed. [102.19 sec, 198.43 MB]

In ContainerBuilder.php line 1032:
                                                                              
  [Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException]  
  You have requested a non-existent service "language_negotiator".            
                                                                              

Exception trace:
  at /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/vendor/symfony/dependency-injection/ContainerBuilder.php:1032
 Symfony\Component\DependencyInjection\ContainerBuilder->getDefinition() at /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/vendor/symfony/dependency-injection/ContainerBuilder.php:600
 Symfony\Component\DependencyInjection\ContainerBuilder->doGet() at /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/vendor/symfony/dependency-injection/ContainerBuilder.php:558
 Symfony\Component\DependencyInjection\ContainerBuilder->get() at /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/docroot/core/lib/Drupal.php:198
 Drupal::service() at /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/docroot/core/modules/language/language.module:298
 language_modules_installed() at n/a:n/a
 call_user_func_array() at /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/docroot/core/lib/Drupal/Core/Extension/ModuleHandler.php:403
 Drupal\Core\Extension\ModuleHandler->invokeAll() at /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/docroot/core/lib/Drupal/Core/Extension/ModuleInstaller.php:367
 Drupal\Core\Extension\ModuleInstaller->install() at /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/docroot/core/lib/Drupal/Core/ProxyClass/Extension/ModuleInstaller.php:83
 Drupal\Core\ProxyClass\Extension\ModuleInstaller->install() at /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/docroot/profiles/contrib/openy/openy.profile:569
 openy_enable_module() at /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/docroot/core/includes/batch.inc:295
 _batch_process() at /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/docroot/core/includes/form.inc:950
 batch_process() at /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/docroot/core/includes/install.core.inc:647
 install_run_task() at /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/docroot/core/includes/install.core.inc:565
 install_run_tasks() at /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/docroot/core/includes/install.core.inc:118
 install_drupal() at /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/vendor/drush/drush/includes/drush.inc:213
 drush_call_user_func_array() at /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/vendor/drush/drush/includes/drush.inc:197
 drush_op() at /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/vendor/drush/drush/src/Commands/core/SiteInstallCommands.php:149
 Drush\Commands\core\SiteInstallCommands->install() at n/a:n/a
 call_user_func_array() at /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/vendor/consolidation/annotated-command/src/CommandProcessor.php:257
 Consolidation\AnnotatedCommand\CommandProcessor->runCommandCallback() at /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/vendor/consolidation/annotated-command/src/CommandProcessor.php:212
 Consolidation\AnnotatedCommand\CommandProcessor->validateRunAndAlter() at /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/vendor/consolidation/annotated-command/src/CommandProcessor.php:176
 Consolidation\AnnotatedCommand\CommandProcessor->process() at /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/vendor/consolidation/annotated-command/src/AnnotatedCommand.php:311
 Consolidation\AnnotatedCommand\AnnotatedCommand->execute() at /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/vendor/symfony/console/Command/Command.php:255
 Symfony\Component\Console\Command\Command->run() at /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/vendor/symfony/console/Application.php:1027
 Symfony\Component\Console\Application->doRunCommand() at /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/vendor/symfony/console/Application.php:273
 Symfony\Component\Console\Application->doRun() at /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/vendor/symfony/console/Application.php:149
 Symfony\Component\Console\Application->run() at /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/vendor/drush/drush/src/Runtime/Runtime.php:118
 Drush\Runtime\Runtime->doRun() at /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/vendor/drush/drush/src/Runtime/Runtime.php:48
 Drush\Runtime\Runtime->run() at /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/vendor/drush/drush/drush.php:72
 require() at /home/jenkins/workspace/XXX_DEV_SANDBOX_LILY_CUSTOM/build/vendor/drush/drush/drush:4

Build step 'Execute shell' marked build as failure
Finished: FAILURE
```