### PR TITLE
Delete forced logic that adds btn-primary class

### DIFF
--- a/themes/openy_themes/openy_carnation/openy_carnation.theme
+++ b/themes/openy_themes/openy_carnation/openy_carnation.theme
@@ -389,14 +389,12 @@ function openy_carnation_preprocess_input(&$variables) {
     ], $variables['attributes']['class']))) {
       $variables['attributes']['class'][] = 'btn-primary';
     }
+    
+    // Add default btn class if it is absent at submit button.
     if (!in_array('btn', $variables['attributes']['class'])) {
       $variables['attributes']['class'][] = 'btn';
     }
-    else {
-      $variables['attributes']['class'][] = 'btn';
-      $variables['attributes']['class'][] = 'btn-primary';
-      $variables['attributes'] = new Attribute($variables['attributes']);
-    }
+    
   }
   if ($variables['element']['#type'] == 'textfield'
     || $variables['element']['#type'] == 'email'


### PR DESCRIPTION
Hi, @podarok.
I know that this pr might produce some regression issues, but it is very weird logic when we set `btn-primary` class everywhere
FE engineers that cant work with theme file have to fight with windwheels trying to override color of the button.

## Steps for review

- [ ] Please provide steps for review here.
- [ ] Please provide steps for review here.


## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer. See [Code of Conduct](https://github.com/ymcatwincities/openy/wiki/Open-Y-Code-of-Conduct-and-Best-Practices).
- [ ] Try to use Conventional commit messages accordingly to the standard https://www.conventionalcommits.org/en/v1.0.0/#specification
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/9.x-2.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/9.x-2.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/9.x-2.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/9.x-2.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/9.x-2.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
