### PR TITLE
[MAINTAIN-154] fixed styles for alert's slider in header and footer for mobile screen

### DIFF
--- a/themes/openy_themes/openy_lily/css/style.css
+++ b/themes/openy_themes/openy_lily/css/style.css
@@ -188,6 +188,7 @@ h6, .h6 {
 
 body {
   padding-top: 70px !important;
+  top: 0 !important;
 }
 @media (min-width: 62em) {
   body {
@@ -2286,6 +2287,8 @@ body {
 }
 .site-alert__cta .field-alert-link a:hover {
   text-decoration: underline;
+  background-color: #fff;
+  color: #000 !important;
 }
 .site-alert__dismiss {
   color: #fff;
@@ -2365,6 +2368,10 @@ body {
 .footer-alerts-list .slick-track .slick-slide {
   display: flex;
   height: auto;
+}
+.header-alerts-list .slick-track .slick-slide .site-alert,
+.footer-alerts-list .slick-track .slick-slide .site-alert {
+  height: 100% !important;
 }
 .header-alerts-list .slick__arrow,
 .footer-alerts-list .slick__arrow {
@@ -14347,7 +14354,6 @@ textarea:focus,
 .btn.active.focus,
 .active.focus.button,
 .form-control:focus,
-.slick-arrow:focus:before,
 .navbar-toggle:focus {
   outline: none;
   box-shadow: inset 0 0 0 2px #69ff00;

--- a/themes/openy_themes/openy_lily/css/style.css
+++ b/themes/openy_themes/openy_lily/css/style.css
@@ -2287,8 +2287,7 @@ body {
 }
 .site-alert__cta .field-alert-link a:hover {
   text-decoration: underline;
-  background-color: #fff;
-  color: #000 !important;
+  opacity: 0.6;
 }
 .site-alert__dismiss {
   color: #fff;

--- a/themes/openy_themes/openy_lily/sass/modules/_alerts.scss
+++ b/themes/openy_themes/openy_lily/sass/modules/_alerts.scss
@@ -46,6 +46,8 @@ $module: 'site-alert';
       text-align: center;
       &:hover {
         text-decoration: underline;
+        background-color: $white;
+        color: $black !important;
       }
     }
   }
@@ -142,6 +144,9 @@ $module: 'site-alert';
     .slick-slide {
       display: flex;
       height: auto;
+      .site-alert {
+        height: 100% !important;
+      }
     }
   }
 

--- a/themes/openy_themes/openy_lily/sass/modules/_alerts.scss
+++ b/themes/openy_themes/openy_lily/sass/modules/_alerts.scss
@@ -46,8 +46,7 @@ $module: 'site-alert';
       text-align: center;
       &:hover {
         text-decoration: underline;
-        background-color: $white;
-        color: $black !important;
+        opacity: 0.6;
       }
     }
   }

--- a/themes/openy_themes/openy_lily/sass/modules/_page.scss
+++ b/themes/openy_themes/openy_lily/sass/modules/_page.scss
@@ -1,5 +1,6 @@
 body {
   padding-top: 70px !important;
+  top: 0 !important;
 
   @include breakpoint($screen-desktop) {
     padding-top: $top-nav-height !important;

--- a/themes/openy_themes/openy_lily/sass/state/_state.scss
+++ b/themes/openy_themes/openy_lily/sass/state/_state.scss
@@ -11,7 +11,6 @@ textarea:focus,
 .btn.active:focus,
 .btn.active.focus,
 .form-control:focus,
-.slick-arrow:focus:before,
 .navbar-toggle:focus {
   outline: none;
   box-shadow: inset 0 0 0 2px $bright-green;

--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -2488,8 +2488,7 @@ body {
 }
 .site-alert__cta .field-alert-link a:hover {
   text-decoration: underline;
-  background-color: #fff;
-  color: #000 !important;
+  opacity: 0.6;
 }
 .site-alert__dismiss {
   color: #fff;

--- a/themes/openy_themes/openy_rose/css/styles.css
+++ b/themes/openy_themes/openy_rose/css/styles.css
@@ -164,6 +164,7 @@ figcaption {
 
 body {
   padding-top: 70px !important;
+  top: 0 !important;
 }
 @media (min-width: 62em) {
   body {
@@ -2487,6 +2488,8 @@ body {
 }
 .site-alert__cta .field-alert-link a:hover {
   text-decoration: underline;
+  background-color: #fff;
+  color: #000 !important;
 }
 .site-alert__dismiss {
   color: #fff;
@@ -2562,6 +2565,10 @@ body {
 .footer-alerts-list .slick-track .slick-slide {
   display: flex;
   height: auto;
+}
+.header-alerts-list .slick-track .slick-slide .site-alert,
+.footer-alerts-list .slick-track .slick-slide .site-alert {
+  height: 100% !important;
 }
 .header-alerts-list .slick__arrow,
 .footer-alerts-list .slick__arrow {
@@ -8743,7 +8750,6 @@ textarea:focus,
 .btn.active.focus,
 .active.focus.button,
 .form-control:focus,
-.slick-arrow:focus:before,
 .navbar-toggle:focus {
   outline: none;
   box-shadow: inset 0 0 0 2px #69ff00;

--- a/themes/openy_themes/openy_rose/scss/modules/_alerts.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_alerts.scss
@@ -48,8 +48,7 @@ $module: 'site-alert';
       text-align: center;
       &:hover {
         text-decoration: underline;
-        background-color: $white;
-        color: $black !important;
+        opacity: 0.6;
       }
     }
   }

--- a/themes/openy_themes/openy_rose/scss/modules/_alerts.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_alerts.scss
@@ -48,6 +48,8 @@ $module: 'site-alert';
       text-align: center;
       &:hover {
         text-decoration: underline;
+        background-color: $white;
+        color: $black !important;
       }
     }
   }
@@ -140,6 +142,9 @@ $module: 'site-alert';
     .slick-slide {
       display: flex;
       height: auto;
+      .site-alert {
+        height: 100% !important;
+      }
     }
   }
 

--- a/themes/openy_themes/openy_rose/scss/modules/_page.scss
+++ b/themes/openy_themes/openy_rose/scss/modules/_page.scss
@@ -1,5 +1,6 @@
 body {
   padding-top: 70px !important;
+  top: 0 !important;
 
   @include breakpoint($screen-desktop) {
     padding-top: $top-nav-height !important;

--- a/themes/openy_themes/openy_rose/scss/state/_state.scss
+++ b/themes/openy_themes/openy_rose/scss/state/_state.scss
@@ -11,7 +11,6 @@ textarea:focus,
 .btn.active:focus,
 .btn.active.focus,
 .form-control:focus,
-.slick-arrow:focus:before,
 .navbar-toggle:focus {
   outline: none;
   box-shadow: inset 0 0 0 2px $bright-green;


### PR DESCRIPTION
Original Issue, this PR is going to fix: [MAINTAIN-154](https://openy.atlassian.net/browse/MAINTAIN-154)

This should fix issues for Rose and Lily themes:

-  a white line under header and before alerts
- a different height of alert's slider in mobile view
- added hover style for alert button
![MAINTAIN-154LillyHover](https://user-images.githubusercontent.com/744406/128000626-013c6eb7-fa0e-44de-90e4-8b134eaf5a35.png)
![154RoseAlerts](https://user-images.githubusercontent.com/744406/128000633-459573f9-12e5-496f-a278-8414dfc15327.gif)

## Steps for review
- [ ] got to front page with Rose theme 
- [ ] verify that you have hover effects for alert button
- [ ] switch mobile screen
- [ ] verify that you can't see the white line before alerts
- [ ] verify that you can;t see white line before alert slider
- [ ] verify the same for Lily theme


## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer. See [Code of Conduct](https://github.com/ymcatwincities/openy/wiki/Open-Y-Code-of-Conduct-and-Best-Practices).
- [ ] Try to use Conventional commit messages accordingly to the standard https://www.conventionalcommits.org/en/v1.0.0/#specification
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/9.x-2.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/9.x-2.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/9.x-2.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/9.x-2.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/9.x-2.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
