### PR TITLE
Fix global SCSS paths after decoupling of openy_features and openy_node_alert

### DIFF
--- a/themes/openy_themes/scss/modules.scss
+++ b/themes/openy_themes/scss/modules.scss
@@ -1,2 +1,2 @@
-@import "../../../modules/openy_features/openy_prgf/modules/openy_prgf_faq/scss/faq";
-@import "../../../modules/openy_features/openy_node/modules/openy_node_alert/scss/openy_node_alert";
+@import "../../../modules/contrib/openy_features/openy_prgf/modules/openy_prgf_faq/scss/faq";
+@import "../../../modules/contrib/openy_node_alert/scss/openy_node_alert";


### PR DESCRIPTION
Original Issue, this PR is going to fix: Decoupled modules are located in new directories, but global SCSS uses old paths.

## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer. See [Code of Conduct](https://github.com/ymcatwincities/openy/wiki/Open-Y-Code-of-Conduct-and-Best-Practices).
- [ ] Try to use Conventional commit messages accordingly to the standard https://www.conventionalcommits.org/en/v1.0.0/#specification
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/9.x-2.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/9.x-2.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/9.x-2.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/9.x-2.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/9.x-2.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
