### PR TITLE
Fix parameters order in the implode for PHP 7.4 compatibility

### DIFF
--- a/openy.profile
+++ b/openy.profile
@@ -654,7 +654,7 @@ function openy_form_system_theme_settings_alter(&$form, FormStateInterface $form
       - .page-node-type-{node type};<br/>
       - .node-id-{node ID};<br/>
       - .path-frontpage.<br/><br/>
-      The existing node types are: ' . implode($css_node_selectors, ', ') .'.
+      The existing node types are: ' . implode(', ', $css_node_selectors) . '.
       '),
       '#suffix' => '</div>'
     ];


### PR DESCRIPTION
On one of the clients' projects we've noticed an error message about the deprecation of the order of the parameters used:

![image](https://user-images.githubusercontent.com/5138333/138253129-a2af14a2-2c28-48d3-b4cb-9182bb9cb19b.png)

The site is currently on PHP 7.4, and there was deprecated the reverse order of parameters: https://www.php.net/manual/en/migration74.deprecated.php

Make sure these boxes are checked before asking for review of your pull request - thank you!

## Steps for review

- [ ] Run the build on PHP 7.4.
- [ ] Go to some theme settings page.
- [ ] Verify there are no error messages regarding the wrong parameters order on the `implode` call.


## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer. See [Code of Conduct](https://github.com/ymcatwincities/openy/wiki/Open-Y-Code-of-Conduct-and-Best-Practices).
- [ ] Try to use Conventional commit messages accordingly to the standard https://www.conventionalcommits.org/en/v1.0.0/#specification
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/9.x-2.x/docs) has been updated according to PR changes.
- [x] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/9.x-2.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [x] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/9.x-2.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/9.x-2.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/9.x-2.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
