### PR TITLE
Fix conflict with drupal/devel in PHP8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": ">=7.4",
         "composer/installers": "^1.2 || ^1.9",
         "cweagans/composer-patches": "^1.5.0",
-        "doctrine/inflector": "1.2.* || ^2",
+        "doctrine/inflector": "^1.2 || ^2",
         "drupal/address": "^1.8",
         "drupal/advanced_help_block": "^1.0",
         "drupal/activenet": "^1.0",


### PR DESCRIPTION
Original Issue: none

[Devel requires](https://gitlab.com/drupalspoons/devel/-/blob/4.x/composer.json#L14) `doctrine/common:^2.7` which requires `doctrine/inflector:^1.0`. `inflector` didn't allow PHP 8 support until [1.4.2](https://github.com/doctrine/inflector/releases/tag/1.4.2), so we need at least that in order to still use it.

## Steps for review

- [ ] `composer require --dev drupal/devel:^4`


## General checks
- [ ] All coding styles are fulfilled and there are no any issues reported by CodeSniffer. See [Code of Conduct](https://github.com/ymcatwincities/openy/wiki/Open-Y-Code-of-Conduct-and-Best-Practices).
- [ ] Try to use Conventional commit messages accordingly to the standard https://www.conventionalcommits.org/en/v1.0.0/#specification
- [ ] [Documentation](https://github.com/ymcatwincities/openy/tree/9.x-2.x/docs) has been updated according to PR changes.
- [ ] [Steps for review](https://github.com/ymcatwincities/openy/pull/94#issue-204580200) have been provided according to PR changes. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/9.x-2.x/.github/assets/steps-for-review.png" width="200" alt="Steps for review"/>
- [ ] Make sure you've provided all necessary hook\_update\_N to [support upgrade path](https://github.com/ymcatwincities/openy/blob/9.x-2.x/docs/Development/Upgrade%20path.md).
- [ ] Make sure your git email is associated with account on drupal.org, otherwise you won't get commits there. <br/><img src="https://raw.githubusercontent.com/ymcatwincities/openy/9.x-2.x/.github/assets/drupalorg-email.png" width="200" alt="drupal.org email"/>
- [ ] If you would like to get credits on drupal.org, [check documentation](https://github.com/ymcatwincities/openy/blob/9.x-2.x/docs/Development/Contributing.md#drupalorg-credits).

Thank you for your contribution!
